### PR TITLE
fix: serialize split_class in split multipart requests

### DIFF
--- a/src/landingai_ade/_client.py
+++ b/src/landingai_ade/_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import json
 import importlib.metadata
 from typing import TYPE_CHECKING, Any, Dict, Union, Mapping, Iterable, Optional, cast
 from pathlib import Path
@@ -559,7 +560,7 @@ class LandingAIADE(SyncAPIClient):
     def split(
         self,
         *,
-        split_class: Iterable[client_split_params.SplitClass],
+        split_class: Union[str, Iterable[client_split_params.SplitClass]],
         markdown: Union[FileTypes, str, None] | Omit = omit,
         markdown_url: Optional[str] | Omit = omit,
         model: Optional[str] | Omit = omit,
@@ -606,9 +607,10 @@ class LandingAIADE(SyncAPIClient):
         # Store original inputs for filename extraction
         original_markdown = markdown
         original_markdown_url = markdown_url
+        normalized_split_class = split_class if isinstance(split_class, str) else json.dumps(list(split_class))
         body = deepcopy_minimal(
             {
-                "split_class": split_class,
+                "split_class": normalized_split_class,
                 "markdown": markdown,
                 "markdown_url": markdown_url,
                 "model": model,
@@ -1080,7 +1082,7 @@ class AsyncLandingAIADE(AsyncAPIClient):
     async def split(
         self,
         *,
-        split_class: Iterable[client_split_params.SplitClass],
+        split_class: Union[str, Iterable[client_split_params.SplitClass]],
         markdown: Union[FileTypes, str, None] | Omit = omit,
         markdown_url: Optional[str] | Omit = omit,
         model: Optional[str] | Omit = omit,
@@ -1119,9 +1121,10 @@ class AsyncLandingAIADE(AsyncAPIClient):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
+        normalized_split_class = split_class if isinstance(split_class, str) else json.dumps(list(split_class))
         body = deepcopy_minimal(
             {
-                "split_class": split_class,
+                "split_class": normalized_split_class,
                 "markdown": markdown,
                 "markdown_url": markdown_url,
                 "model": model,

--- a/src/landingai_ade/_client.py
+++ b/src/landingai_ade/_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import json
 import importlib.metadata
 from typing import TYPE_CHECKING, Any, Dict, Union, Mapping, Iterable, Optional, cast
 from pathlib import Path
@@ -731,7 +732,7 @@ class LandingAIADE(SyncAPIClient):
     def split(
         self,
         *,
-        split_class: Iterable[client_split_params.SplitClass],
+        split_class: Union[str, Iterable[client_split_params.SplitClass]],
         markdown: Union[FileTypes, str, None] | Omit = omit,
         markdown_url: Optional[str] | Omit = omit,
         model: Optional[str] | Omit = omit,
@@ -779,9 +780,10 @@ class LandingAIADE(SyncAPIClient):
         # Store original inputs for filename extraction
         original_markdown = markdown
         original_markdown_url = markdown_url
+        normalized_split_class = split_class if isinstance(split_class, str) else json.dumps(list(split_class))
         body = deepcopy_with_paths(
             {
-                "split_class": split_class,
+                "split_class": normalized_split_class,
                 "markdown": markdown,
                 "markdown_url": markdown_url,
                 "model": model,
@@ -1422,7 +1424,7 @@ class AsyncLandingAIADE(AsyncAPIClient):
     async def split(
         self,
         *,
-        split_class: Iterable[client_split_params.SplitClass],
+        split_class: Union[str, Iterable[client_split_params.SplitClass]],
         markdown: Union[FileTypes, str, None] | Omit = omit,
         markdown_url: Optional[str] | Omit = omit,
         model: Optional[str] | Omit = omit,
@@ -1470,9 +1472,10 @@ class AsyncLandingAIADE(AsyncAPIClient):
         # Store original inputs for filename extraction
         original_markdown = markdown
         original_markdown_url = markdown_url
+        normalized_split_class = split_class if isinstance(split_class, str) else json.dumps(list(split_class))
         body = deepcopy_with_paths(
             {
-                "split_class": split_class,
+                "split_class": normalized_split_class,
                 "markdown": markdown,
                 "markdown_url": markdown_url,
                 "model": model,

--- a/src/landingai_ade/types/client_split_params.py
+++ b/src/landingai_ade/types/client_split_params.py
@@ -11,7 +11,7 @@ __all__ = ["ClientSplitParams", "SplitClass"]
 
 
 class ClientSplitParams(TypedDict, total=False):
-    split_class: Required[Iterable[SplitClass]]
+    split_class: Required[Union[str, Iterable[SplitClass]]]
     """List of split classification options/configuration.
 
     Can be provided as JSON string in form data.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -579,6 +579,30 @@ class TestLandingAiade:
             b"",
         ]
 
+    def test_split_sends_split_class_as_json_string_in_multipart(self, client: LandingAIADE) -> None:
+        request = client._build_request(
+            FinalRequestOptions.construct(
+                method="post",
+                url="/v1/ade/split",
+                headers={"Content-Type": "multipart/form-data; boundary=6b7ba517decee4a450543ea6ae821c82"},
+                json_data={"split_class": json.dumps([{"name": "Bank Statement"}]), "markdown": "# doc"},
+                files=(),
+            )
+        )
+
+        assert request.read().split(b"\r\n") == [
+            b"--6b7ba517decee4a450543ea6ae821c82",
+            b'Content-Disposition: form-data; name="split_class"',
+            b"",
+            b'[{"name": "Bank Statement"}]',
+            b"--6b7ba517decee4a450543ea6ae821c82",
+            b'Content-Disposition: form-data; name="markdown"',
+            b"",
+            b"# doc",
+            b"--6b7ba517decee4a450543ea6ae821c82--",
+            b"",
+        ]
+
     @pytest.mark.respx(base_url=base_url)
     def test_binary_content_upload(self, respx_mock: MockRouter, client: LandingAIADE) -> None:
         respx_mock.post("/upload").mock(side_effect=mirror_request_content)


### PR DESCRIPTION
Closes #76

## Summary
- serialize `split_class` as a JSON string before sending multipart split requests
- accept either the documented JSON string form or the typed iterable form at the client boundary
- add a focused multipart regression test for the split payload shape

## Testing
- `uv run --with pytest --with pytest-xdist --with pytest-asyncio --with respx pytest tests/test_client.py -k 'multipart_repeating_array or split_sends_split_class_as_json_string_in_multipart'`
- `uv run --with ruff ruff check src/landingai_ade/_client.py src/landingai_ade/types/client_split_params.py tests/test_client.py`
