### PR TITLE
chore: remove Stainless-generated file headers

### DIFF
--- a/examples/.keep
+++ b/examples/.keep
@@ -1,4 +1,1 @@
-File generated from our OpenAPI spec by Stainless.
-
-This directory can be used to store example files demonstrating usage of this SDK.
-It is ignored by Stainless code generation and its content (other than this keep file) won't be touched.
+This directory can be used to store custom files to expand the SDK.

--- a/src/landingai_ade/__init__.py
+++ b/src/landingai_ade/__init__.py
@@ -1,5 +1,3 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import typing as _t
 
 from . import types

--- a/src/landingai_ade/_client.py
+++ b/src/landingai_ade/_client.py
@@ -1,5 +1,3 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 from __future__ import annotations
 
 import os

--- a/src/landingai_ade/_constants.py
+++ b/src/landingai_ade/_constants.py
@@ -1,5 +1,3 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import httpx
 
 RAW_RESPONSE_HEADER = "X-Stainless-Raw-Response"

--- a/src/landingai_ade/_exceptions.py
+++ b/src/landingai_ade/_exceptions.py
@@ -1,5 +1,3 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 from __future__ import annotations
 
 from typing_extensions import Literal

--- a/src/landingai_ade/_resource.py
+++ b/src/landingai_ade/_resource.py
@@ -1,5 +1,3 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 from __future__ import annotations
 
 import time

--- a/src/landingai_ade/lib/.keep
+++ b/src/landingai_ade/lib/.keep
@@ -1,4 +1,1 @@
-File generated from our OpenAPI spec by Stainless.
-
 This directory can be used to store custom files to expand the SDK.
-It is ignored by Stainless code generation and its content (other than this keep file) won't be touched.

--- a/src/landingai_ade/resources/__init__.py
+++ b/src/landingai_ade/resources/__init__.py
@@ -1,5 +1,3 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 from .parse_jobs import (
     ParseJobsResource,
     AsyncParseJobsResource,

--- a/src/landingai_ade/resources/parse_jobs.py
+++ b/src/landingai_ade/resources/parse_jobs.py
@@ -1,5 +1,3 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 from __future__ import annotations
 
 from typing import Mapping, Optional, cast

--- a/src/landingai_ade/types/__init__.py
+++ b/src/landingai_ade/types/__init__.py
@@ -1,5 +1,3 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 from __future__ import annotations
 
 from .shared import ParseMetadata as ParseMetadata, ParseGroundingBox as ParseGroundingBox

--- a/src/landingai_ade/types/classify_response.py
+++ b/src/landingai_ade/types/classify_response.py
@@ -1,5 +1,3 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 from typing import List, Optional
 
 from pydantic import Field as FieldInfo

--- a/src/landingai_ade/types/client_classify_params.py
+++ b/src/landingai_ade/types/client_classify_params.py
@@ -1,5 +1,3 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 from __future__ import annotations
 
 from typing import Iterable, Optional

--- a/src/landingai_ade/types/client_extract_build_schema_params.py
+++ b/src/landingai_ade/types/client_extract_build_schema_params.py
@@ -1,5 +1,3 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 from __future__ import annotations
 
 from typing import Union, Optional

--- a/src/landingai_ade/types/client_extract_params.py
+++ b/src/landingai_ade/types/client_extract_params.py
@@ -1,5 +1,3 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 from __future__ import annotations
 
 from typing import Union, Optional

--- a/src/landingai_ade/types/client_parse_params.py
+++ b/src/landingai_ade/types/client_parse_params.py
@@ -1,5 +1,3 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 from __future__ import annotations
 
 from typing import Optional

--- a/src/landingai_ade/types/client_section_params.py
+++ b/src/landingai_ade/types/client_section_params.py
@@ -1,5 +1,3 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 from __future__ import annotations
 
 from typing import Union, Optional

--- a/src/landingai_ade/types/client_split_params.py
+++ b/src/landingai_ade/types/client_split_params.py
@@ -1,5 +1,3 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 from __future__ import annotations
 
 from typing import Union, Iterable, Optional

--- a/src/landingai_ade/types/extract_build_schema_response.py
+++ b/src/landingai_ade/types/extract_build_schema_response.py
@@ -1,5 +1,3 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 from typing import List, Optional
 from typing_extensions import Literal
 

--- a/src/landingai_ade/types/extract_response.py
+++ b/src/landingai_ade/types/extract_response.py
@@ -1,5 +1,3 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 from typing import List, Optional
 from typing_extensions import Literal
 

--- a/src/landingai_ade/types/parse_job_create_params.py
+++ b/src/landingai_ade/types/parse_job_create_params.py
@@ -1,5 +1,3 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 from __future__ import annotations
 
 from typing import Optional

--- a/src/landingai_ade/types/parse_job_create_response.py
+++ b/src/landingai_ade/types/parse_job_create_response.py
@@ -1,5 +1,3 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 from .._models import BaseModel
 
 __all__ = ["ParseJobCreateResponse"]

--- a/src/landingai_ade/types/parse_job_get_response.py
+++ b/src/landingai_ade/types/parse_job_get_response.py
@@ -1,5 +1,3 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 from typing import Dict, List, Union, Optional
 from typing_extensions import Literal, TypeAlias
 

--- a/src/landingai_ade/types/parse_job_list_params.py
+++ b/src/landingai_ade/types/parse_job_list_params.py
@@ -1,5 +1,3 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 from __future__ import annotations
 
 from typing import Optional

--- a/src/landingai_ade/types/parse_job_list_response.py
+++ b/src/landingai_ade/types/parse_job_list_response.py
@@ -1,5 +1,3 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 from typing import List, Optional
 
 from .._models import BaseModel

--- a/src/landingai_ade/types/parse_response.py
+++ b/src/landingai_ade/types/parse_response.py
@@ -1,5 +1,3 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 from typing import Dict, List, Union, Optional
 from typing_extensions import Literal, TypeAlias
 

--- a/src/landingai_ade/types/section_response.py
+++ b/src/landingai_ade/types/section_response.py
@@ -1,5 +1,3 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 from typing import List, Optional
 
 from .._models import BaseModel

--- a/src/landingai_ade/types/shared/__init__.py
+++ b/src/landingai_ade/types/shared/__init__.py
@@ -1,4 +1,2 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 from .parse_metadata import ParseMetadata as ParseMetadata
 from .parse_grounding_box import ParseGroundingBox as ParseGroundingBox

--- a/src/landingai_ade/types/shared/parse_grounding_box.py
+++ b/src/landingai_ade/types/shared/parse_grounding_box.py
@@ -1,5 +1,3 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 from ..._models import BaseModel
 
 __all__ = ["ParseGroundingBox"]

--- a/src/landingai_ade/types/shared/parse_metadata.py
+++ b/src/landingai_ade/types/shared/parse_metadata.py
@@ -1,5 +1,3 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 from typing import List, Optional
 
 from ..._models import BaseModel

--- a/src/landingai_ade/types/split_response.py
+++ b/src/landingai_ade/types/split_response.py
@@ -1,5 +1,3 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 from typing import List, Optional
 
 from .._models import BaseModel

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,0 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.

--- a/tests/api_resources/__init__.py
+++ b/tests/api_resources/__init__.py
@@ -1,1 +1,0 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.

--- a/tests/api_resources/test_client.py
+++ b/tests/api_resources/test_client.py
@@ -1,5 +1,3 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 from __future__ import annotations
 
 import os

--- a/tests/api_resources/test_parse_jobs.py
+++ b/tests/api_resources/test_parse_jobs.py
@@ -1,5 +1,3 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 from __future__ import annotations
 
 import os

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,3 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 from __future__ import annotations
 
 import os

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,3 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 from __future__ import annotations
 
 import gc


### PR DESCRIPTION
Mechanical follow-up promised in the #100 review (the `_version.py` header thread): removes the first-line `# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.` from all 34 remaining source files, and rewrites the two `.keep` placeholders whose body text also described Stainless codegen behavior.

The code is hand-maintained since the Stainless exit; these headers contradicted the new CONTRIBUTING.md.

**Verified locally on the swept tree**: `./scripts/lint` clean (ruff + pyright + mypy, 55 files) and `pytest` green (489 passed / 180 skipped). CI runs the full suite including the pydantic-v1 leg.

Stacked on #100 (`chore/stainless-exit`) — GitHub will retarget to `main` automatically when that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)