### PR TITLE
fix(v2): utf-8 save encoding + require exactly one extract markdown source

### DIFF
--- a/src/landingai_ade/_client.py
+++ b/src/landingai_ade/_client.py
@@ -146,14 +146,14 @@ def _save_response(
         save_path = Path(save_to)
         if save_path.suffix.lower() == ".json":
             save_path.parent.mkdir(parents=True, exist_ok=True)
-            save_path.write_text(result.to_json())
+            save_path.write_text(result.to_json(), encoding="utf-8")
         else:
             save_path.mkdir(parents=True, exist_ok=True)
             if filename == "output":
                 output_path = save_path / f"{method_name}_output.json"
             else:
                 output_path = save_path / f"{filename}_{method_name}_output.json"
-            output_path.write_text(result.to_json())
+            output_path.write_text(result.to_json(), encoding="utf-8")
     except OSError as exc:
         raise LandingAiadeError(f"Failed to save {method_name} response to {save_to}: {exc}") from exc
 

--- a/src/landingai_ade/resources/v2/extract.py
+++ b/src/landingai_ade/resources/v2/extract.py
@@ -32,6 +32,22 @@ def _build_extract_body(
     idempotency_key: object,
     service_tier: object = omit,
 ) -> Dict[str, Any]:
+    provided = [
+        name
+        for name, value in (
+            ("markdown", markdown),
+            ("markdown_ref", markdown_ref),
+            ("markdown_url", markdown_url),
+        )
+        if value is not omit and value is not None
+    ]
+    if len(provided) != 1:
+        raise ValueError(
+            "extract requires exactly one markdown source: provide one of "
+            "`markdown`, `markdown_ref`, or `markdown_url`"
+            + (f" (received: {', '.join(provided)})" if provided else "")
+            + "."
+        )
     body: Dict[str, Any] = {"schema": coerce_schema_to_dict(schema)}
     for key, value in (
         ("markdown", markdown),

--- a/tests/api_resources/v2/test_extract.py
+++ b/tests/api_resources/v2/test_extract.py
@@ -52,6 +52,27 @@ def test_extract_sync_strict_option() -> None:
     assert req["markdown_url"] == "https://x/y.md"
 
 
+def test_extract_requires_a_markdown_source() -> None:
+    # api.md documents the contract: provide exactly one of markdown /
+    # markdown_ref / markdown_url. Omitting all three used to send a sourceless
+    # body and surface an opaque server 500; the SDK now fails fast client-side.
+    client = LandingAIADE(apikey=APIKEY)
+    with pytest.raises(ValueError, match="exactly one"):
+        client.v2.extract(schema={"type": "object"})
+
+
+def test_extract_rejects_multiple_markdown_sources() -> None:
+    client = LandingAIADE(apikey=APIKEY)
+    with pytest.raises(ValueError, match="exactly one"):
+        client.v2.extract(schema={"type": "object"}, markdown="x", markdown_url="https://x/y.md")
+
+
+def test_extract_job_create_requires_a_markdown_source() -> None:
+    client = LandingAIADE(apikey=APIKEY)
+    with pytest.raises(ValueError, match="exactly one"):
+        client.v2.extract_jobs.create(schema={"type": "object"})
+
+
 @respx.mock
 def test_extract_sync_504() -> None:
     client = LandingAIADE(apikey=APIKEY, max_retries=0)

--- a/tests/api_resources/v2/test_extract.py
+++ b/tests/api_resources/v2/test_extract.py
@@ -52,21 +52,26 @@ def test_extract_sync_strict_option() -> None:
     assert req["markdown_url"] == "https://x/y.md"
 
 
+@respx.mock
 def test_extract_requires_a_markdown_source() -> None:
     # api.md documents the contract: provide exactly one of markdown /
     # markdown_ref / markdown_url. Omitting all three used to send a sourceless
     # body and surface an opaque server 500; the SDK now fails fast client-side.
+    # No route is registered: @respx.mock keeps this hermetic, so a regression in
+    # the guard fails loudly on an unmocked request instead of hitting the network.
     client = LandingAIADE(apikey=APIKEY)
     with pytest.raises(ValueError, match="exactly one"):
         client.v2.extract(schema={"type": "object"})
 
 
+@respx.mock
 def test_extract_rejects_multiple_markdown_sources() -> None:
     client = LandingAIADE(apikey=APIKEY)
     with pytest.raises(ValueError, match="exactly one"):
         client.v2.extract(schema={"type": "object"}, markdown="x", markdown_url="https://x/y.md")
 
 
+@respx.mock
 def test_extract_job_create_requires_a_markdown_source() -> None:
     client = LandingAIADE(apikey=APIKEY)
     with pytest.raises(ValueError, match="exactly one"):

--- a/tests/test_save_to.py
+++ b/tests/test_save_to.py
@@ -206,6 +206,40 @@ class TestSaveResponse:
         assert Path(output_file).exists()
         assert Path(output_file).read_text() == '{"string": true}'
 
+    def test_writes_utf8_encoding_for_non_ascii(self, tmp_path: Path) -> None:
+        """Non-ASCII JSON must be written as UTF-8, not the platform default.
+
+        Without an explicit encoding, Path.write_text() uses the locale
+        encoding (cp1252 on Windows) and raises UnicodeEncodeError on CJK /
+        accented content. Assert the bytes on disk are exactly the UTF-8
+        encoding of the payload, independent of the host locale.
+        """
+        payload = '{"name": "太郎", "city": "München"}'
+        mock_result = MagicMock()
+        mock_result.to_json.return_value = payload
+
+        output_file = tmp_path / "unicode.json"
+        _save_response(output_file, "ignored", "extract", mock_result)
+
+        assert output_file.read_bytes() == payload.encode("utf-8")
+        assert output_file.read_text(encoding="utf-8") == payload
+
+    def test_write_text_called_with_utf8_encoding(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Guard the fix cross-platform: write_text must receive encoding='utf-8'."""
+        captured: dict[str, object] = {}
+        original = Path.write_text
+
+        def spy(self: Path, data: str, **kwargs: object) -> int:
+            captured["encoding"] = kwargs.get("encoding")
+            return original(self, data, encoding="utf-8")
+
+        monkeypatch.setattr(Path, "write_text", spy)
+        mock_result = MagicMock()
+        mock_result.to_json.return_value = "{}"
+
+        _save_response(tmp_path, "doc", "extract", mock_result)
+        assert captured["encoding"] == "utf-8"
+
 
 class TestAsyncSaveTo:
     """Tests that async client methods accept save_to and save correctly."""


### PR DESCRIPTION
## Summary

Fixes two QA-reported P0 issues in `client.v2` (ADE - QA - Testing project).

### 1. `save_to` writes non-UTF-8 JSON → `UnicodeEncodeError` on Windows
[Asana 1216406454855485](https://app.asana.com/1/504311096896991/project/1208747057905216/task/1216406454855485)

`_save_response()` wrote the response JSON via `Path.write_text()` with no explicit encoding, so on Windows it fell back to the cp1252 locale codec and raised `UnicodeEncodeError` on any non-Latin-1 content (CJK, accented text, …). Both write sites now pass `encoding="utf-8"`. All V1 and V2 `save_to` paths funnel through this one helper, so this fixes every surface at once.

### 2. Extract without a markdown source → opaque HTTP 500
[Asana 1216406582493052](https://app.asana.com/1/504311096896991/project/1208747057905216/task/1216406582493052)

`api.md` documents the contract as *"provide exactly one of `markdown` / `markdown_ref` / `markdown_url`"*, but nothing enforced it — a caller supplying none sent a sourceless body and got back an opaque server 500. `_build_extract_body()` now enforces that contract and raises a clear `ValueError` **before** the request is sent. Every extract path (sync `run`, async `run`, sync + async `jobs.create`) builds its body through this helper, so all are covered.

## Out of scope

The related ticket [1216406454855481](https://app.asana.com/1/504311096896991/project/1208747057905216/task/1216406454855481) ("unsupported schema field type → HTTP 502 instead of 422") is a **backend** status-code bug — the SDK only forwards the schema verbatim and faithfully maps whatever status the server returns. It needs a fix in the `/v2/extract` service, not here.

## Tests

- utf-8: a cross-platform guard asserting `write_text` receives `encoding="utf-8"` (macOS defaults to utf-8 and wouldn't otherwise catch a regression) + a non-ASCII round-trip.
- source guard: zero sources, multiple sources, and `jobs.create` with no source.
- Full suite green (585 passed / 240 skipped), ruff lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)