### PR TITLE
style: make main format-clean under ./scripts/format

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,11 @@ from pathlib import Path
 from pydantic import BaseModel, Field
 from landingai_ade import LandingAIADE
 
+
 class Invoice(BaseModel):
     invoice_number: str = Field(description="The invoice number")
     total: str = Field(description="Invoice grand total")
+
 
 client = LandingAIADE()  # reads VISION_AGENT_API_KEY
 
@@ -83,15 +85,15 @@ client = LandingAIADE()
 # Parse a local file
 parsed = client.v2.parse(
     document=Path("path/to/file.pdf"),
-    model="dpt-3-pro-latest",       # optional; defaults to the latest DPT-3 Pro model
-    save_to="./output",             # optional; saves as {input_file}_parse_output.json
+    model="dpt-3-pro-latest",  # optional; defaults to the latest DPT-3 Pro model
+    save_to="./output",  # optional; saves as {input_file}_parse_output.json
 )
 
 # Or parse a file at a URL
 parsed = client.v2.parse(document_url="https://example.com/file.pdf")
 
-print(parsed.markdown)              # full document as Markdown
-print(parsed.metadata.page_count)   # pages processed
+print(parsed.markdown)  # full document as Markdown
+print(parsed.metadata.page_count)  # pages processed
 ```
 
 The response is a `V2ParseResponse`:
@@ -114,21 +116,23 @@ from pathlib import Path
 from pydantic import BaseModel, Field
 from landingai_ade import LandingAIADE
 
+
 class Person(BaseModel):
     name: str = Field(description="Person's full name")
     age: int = Field(description="Person's age")
+
 
 client = LandingAIADE()
 parsed = client.v2.parse(document=Path("path/to/file.pdf"))
 
 result = client.v2.extract(
-    schema=Person,                       # Pydantic model, dict, or JSON string
-    markdown=parsed.markdown,            # or markdown_url="https://example.com/doc.md"
-    save_to="./output",                  # optional
+    schema=Person,  # Pydantic model, dict, or JSON string
+    markdown=parsed.markdown,  # or markdown_url="https://example.com/doc.md"
+    save_to="./output",  # optional
 )
 
-print(result.extraction)                 # {"name": "...", "age": ...}
-print(result.extraction_metadata)        # per-field source spans in the Markdown
+print(result.extraction)  # {"name": "...", "age": ...}
+print(result.extraction_metadata)  # per-field source spans in the Markdown
 ```
 
 The response is a `V2ExtractResult`:
@@ -155,7 +159,7 @@ client = LandingAIADE()
 
 job = client.v2.parse_jobs.create(
     document=Path("path/to/large_file.pdf"),
-    service_tier="standard",   # "standard" (default, lower cost) or "priority" (faster)
+    service_tier="standard",  # "standard" (default, lower cost) or "priority" (faster)
 )
 print(job.job_id, job.status)
 
@@ -194,10 +198,12 @@ import asyncio
 from pathlib import Path
 from landingai_ade import AsyncLandingAIADE
 
+
 async def main() -> None:
     async with AsyncLandingAIADE() as client:
         parsed = await client.v2.parse(document=Path("path/to/file.pdf"))
         print(parsed.markdown)
+
 
 asyncio.run(main())
 ```
@@ -212,9 +218,11 @@ pip install landingai-ade[aiohttp]
 import asyncio
 from landingai_ade import AsyncLandingAIADE, DefaultAioHttpClient
 
+
 async def main() -> None:
     async with AsyncLandingAIADE(http_client=DefaultAioHttpClient()) as client:
         ...  # same usage as the example above
+
 
 asyncio.run(main())
 ```
@@ -255,10 +263,12 @@ client = LandingAIADE()
 # Split a combined file into sub-documents
 parsed = client.parse(document=Path("statements.pdf"), model="dpt-2-latest")
 split = client.split(
-    split_class=json.dumps([
-        {"name": "Bank Statement", "description": "Summarizes account activity over a period."},
-        {"name": "Pay Stub", "description": "Details an employee's earnings for a pay period."},
-    ]),
+    split_class=json.dumps(
+        [
+            {"name": "Bank Statement", "description": "Summarizes account activity over a period."},
+            {"name": "Pay Stub", "description": "Details an employee's earnings for a pay period."},
+        ]
+    ),
     markdown=parsed.markdown,
     model="split-latest",
 )
@@ -312,8 +322,8 @@ except landingai_ade.APIStatusError as e:
 Connection errors, 408, 409, 429, and 5xx responses are retried twice by default with exponential backoff. Configure with `max_retries`:
 
 ```python
-client = LandingAIADE(max_retries=0)                 # default is 2
-client.with_options(max_retries=5).v2.parse(...)     # per-request
+client = LandingAIADE(max_retries=0)  # default is 2
+client.with_options(max_retries=5).v2.parse(...)  # per-request
 ```
 
 ### Timeouts
@@ -321,8 +331,8 @@ client.with_options(max_retries=5).v2.parse(...)     # per-request
 Requests time out after 8 minutes by default. Configure with `timeout` (a float or an [`httpx.Timeout`](https://www.python-httpx.org/advanced/timeouts/#fine-tuning-the-configuration)):
 
 ```python
-client = LandingAIADE(timeout=20.0)                  # seconds
-client.with_options(timeout=5.0).v2.parse(...)       # per-request
+client = LandingAIADE(timeout=20.0)  # seconds
+client.with_options(timeout=5.0).v2.parse(...)  # per-request
 ```
 
 On a client-side transport timeout, an `APITimeoutError` is raised, and the request is retried twice by default. The v2 synchronous endpoints also have a server-side wait window: exceeding it returns HTTP 504 and raises `V2SyncTimeoutError` instead; switch to [jobs](#process-large-documents-asynchronously-jobs) for those documents.
@@ -408,6 +418,7 @@ To check the version in use at runtime:
 
 ```python
 import landingai_ade
+
 print(landingai_ade.__version__)
 ```
 

--- a/examples/v2_smoke_test.py
+++ b/examples/v2_smoke_test.py
@@ -106,6 +106,7 @@ def _selected(only: Optional[str]) -> List[str]:
 
 # --------------------------------------------------------------------------- sync
 
+
 def run_sync(args: argparse.Namespace, checks: List[str]) -> int:
     kwargs: dict[str, Any] = {}
     environment = _resolve_environment(args)
@@ -130,6 +131,7 @@ def run_sync(args: argparse.Namespace, checks: List[str]) -> int:
             print()
 
     if "files" in checks:
+
         def _files() -> Any:
             nonlocal file_ref
             file_ref = client.v2.files.upload(file=("doc.md", SAMPLE_MARKDOWN.encode(), "text/markdown"))
@@ -138,6 +140,7 @@ def run_sync(args: argparse.Namespace, checks: List[str]) -> int:
         record("files.upload", _files)
 
     if "extract" in checks:
+
         def _extract() -> Any:
             res = client.v2.extract(
                 schema=RevenueSchema,
@@ -149,6 +152,7 @@ def run_sync(args: argparse.Namespace, checks: List[str]) -> int:
         record("v2.extract (sync)", _extract)
 
     if "extract_jobs" in checks:
+
         def _extract_jobs() -> Any:
             job = client.v2.extract_jobs.create(schema=RevenueSchema, markdown=SAMPLE_MARKDOWN)
             done = client.v2.extract_jobs.wait(job.job_id, timeout=args.timeout)
@@ -162,13 +166,17 @@ def run_sync(args: argparse.Namespace, checks: List[str]) -> int:
             print("── v2.parse (sync) ".ljust(60, "─") + "\n   SKIP  (no --document / --document-url)\n")
             results["v2.parse (sync)"] = "SKIP"
         else:
-            record("v2.parse (sync)", lambda: _short(client.v2.parse(model=args.parse_model or None, **doc_kwargs).markdown))  # type: ignore[arg-type]
+            record(
+                "v2.parse (sync)",
+                lambda: _short(client.v2.parse(model=args.parse_model or None, **doc_kwargs).markdown),
+            )  # type: ignore[arg-type]
 
     if "parse_jobs" in checks:
         if doc_kwargs is None:
             print("── v2.parse_jobs ".ljust(60, "─") + "\n   SKIP  (no --document / --document-url)\n")
             results["v2.parse_jobs"] = "SKIP"
         else:
+
             def _parse_jobs() -> Any:
                 job = client.v2.parse_jobs.create(**doc_kwargs)
                 done = client.v2.parse_jobs.wait(job.job_id, timeout=args.timeout)
@@ -188,6 +196,7 @@ def _document_kwargs(args: argparse.Namespace) -> Optional[dict[str, Any]]:
 
 
 # -------------------------------------------------------------------------- async
+
 
 def run_async(args: argparse.Namespace, checks: List[str]) -> int:
     async def _main() -> int:
@@ -237,6 +246,7 @@ def run_async(args: argparse.Namespace, checks: List[str]) -> int:
 
 
 # ------------------------------------------------------------------------- shared
+
 
 def _summarize(results: dict[str, str]) -> int:
     print("═" * 60)

--- a/src/landingai_ade/_client.py
+++ b/src/landingai_ade/_client.py
@@ -265,9 +265,7 @@ class LandingAIADE(SyncAPIClient):
             except KeyError as exc:
                 raise ValueError(f"Unknown environment: {environment}") from exc
 
-        v1_base_url_was_explicit = v1_base_url_was_explicit or (
-            base_url_env is not None and not is_given(environment)
-        )
+        v1_base_url_was_explicit = v1_base_url_was_explicit or (base_url_env is not None and not is_given(environment))
         self._v2_base_url = _resolve_v2_base_url(environment, v2_base_url, base_url, v1_base_url_was_explicit)
 
         super().__init__(
@@ -981,9 +979,7 @@ class AsyncLandingAIADE(AsyncAPIClient):
             except KeyError as exc:
                 raise ValueError(f"Unknown environment: {environment}") from exc
 
-        v1_base_url_was_explicit = v1_base_url_was_explicit or (
-            base_url_env is not None and not is_given(environment)
-        )
+        v1_base_url_was_explicit = v1_base_url_was_explicit or (base_url_env is not None and not is_given(environment))
         self._v2_base_url = _resolve_v2_base_url(environment, v2_base_url, base_url, v1_base_url_was_explicit)
 
         super().__init__(

--- a/src/landingai_ade/resources/v2/_base.py
+++ b/src/landingai_ade/resources/v2/_base.py
@@ -48,8 +48,7 @@ def _next_delay(current: float, poll_interval: Optional[float]) -> float:
 def _raise_if_failed(job: Job, *, raise_on_failure: bool) -> None:
     if raise_on_failure and job.error is not None:
         raise JobFailedError(
-            f"Job {job.job_id} ended {job.status.value}: "
-            f"{job.error.message or job.error.code or 'unknown error'}"
+            f"Job {job.job_id} ended {job.status.value}: {job.error.message or job.error.code or 'unknown error'}"
         )
 
 

--- a/src/landingai_ade/resources/v2/extract.py
+++ b/src/landingai_ade/resources/v2/extract.py
@@ -41,9 +41,7 @@ def _build_extract_body(
     if len(provided) != 1:
         raise ValueError(
             "extract requires exactly one markdown source: provide one of "
-            "`markdown` or `markdown_url`"
-            + (f" (received: {', '.join(provided)})" if provided else "")
-            + "."
+            "`markdown` or `markdown_url`" + (f" (received: {', '.join(provided)})" if provided else "") + "."
         )
     body: Dict[str, Any] = {"schema": coerce_schema_to_dict(schema)}
     for key, value in (

--- a/tests/api_resources/v2/test_async_smoke.py
+++ b/tests/api_resources/v2/test_async_smoke.py
@@ -69,8 +69,6 @@ async def test_async_extract_jobs_create_get_and_wait() -> None:
     assert fetched.status is JobStatus.PROCESSING
 
     ticks = iter([0.0, 0.0, 0.1, 0.2, 0.3])
-    waited = await client.v2.extract_jobs.wait(
-        "e1", timeout=30, poll_interval=0.01, _monotonic=lambda: next(ticks)
-    )
+    waited = await client.v2.extract_jobs.wait("e1", timeout=30, poll_interval=0.01, _monotonic=lambda: next(ticks))
     assert waited.status is JobStatus.COMPLETED
     assert isinstance(waited.result, V2ExtractResult)

--- a/tests/api_resources/v2/test_extract.py
+++ b/tests/api_resources/v2/test_extract.py
@@ -89,7 +89,9 @@ def test_extract_sync_504() -> None:
 def test_extract_job_create_and_get() -> None:
     client = LandingAIADE(apikey=APIKEY)
     respx.post("https://api.ade.landing.ai/v2/extract/jobs").mock(
-        return_value=httpx.Response(202, json={"job_id": "e1", "status": "pending", "created_at": "2026-01-01T00:00:00Z"})
+        return_value=httpx.Response(
+            202, json={"job_id": "e1", "status": "pending", "created_at": "2026-01-01T00:00:00Z"}
+        )
     )
     job = client.v2.extract_jobs.create(schema={"type": "object"}, markdown="x", service_tier="priority")
     assert job.job_id == "e1" and job.status is JobStatus.PENDING
@@ -97,8 +99,13 @@ def test_extract_job_create_and_get() -> None:
     respx.get("https://api.ade.landing.ai/v2/extract/jobs/e1").mock(
         return_value=httpx.Response(
             200,
-            json={"job_id": "e1", "status": "completed", "created_at": "2026-01-01T00:00:00Z",
-                  "completed_at": "2026-01-01T00:00:09Z", "result": EXTRACT_BODY},
+            json={
+                "job_id": "e1",
+                "status": "completed",
+                "created_at": "2026-01-01T00:00:00Z",
+                "completed_at": "2026-01-01T00:00:09Z",
+                "result": EXTRACT_BODY,
+            },
         )
     )
     done = client.v2.extract_jobs.get("e1")
@@ -156,11 +163,12 @@ def test_extract_job_wait_raise_on_failure() -> None:
 
     client = LandingAIADE(apikey=APIKEY)
     respx.get("https://api.ade.landing.ai/v2/extract/jobs/e3").mock(
-        return_value=httpx.Response(200, json={"job_id": "e3", "status": "failed", "error": {"code": "x", "message": "no"}})
+        return_value=httpx.Response(
+            200, json={"job_id": "e3", "status": "failed", "error": {"code": "x", "message": "no"}}
+        )
     )
     with pytest.raises(JobFailedError):
-        client.v2.extract_jobs.wait("e3", timeout=5, poll_interval=0.01, raise_on_failure=True,
-                                    _monotonic=lambda: 0.0)
+        client.v2.extract_jobs.wait("e3", timeout=5, poll_interval=0.01, raise_on_failure=True, _monotonic=lambda: 0.0)
 
 
 @respx.mock

--- a/tests/api_resources/v2/test_parse.py
+++ b/tests/api_resources/v2/test_parse.py
@@ -44,8 +44,15 @@ RICH_PARSE_BODY: Dict[str, Any] = {
                         "id": "e2",
                         "span": [20, 80],
                         "children": [
-                            {"type": "table_cell", "id": "e3", "span": [25, 30],
-                             "row": 0, "col": 1, "colspan": 2, "rowspan": 1},
+                            {
+                                "type": "table_cell",
+                                "id": "e3",
+                                "span": [25, 30],
+                                "row": 0,
+                                "col": 1,
+                                "colspan": 2,
+                                "rowspan": 1,
+                            },
                         ],
                     },
                 ],
@@ -60,12 +67,23 @@ RICH_PARSE_BODY: Dict[str, Any] = {
                 "page": 0,
                 "span": [0, 100],
                 "children": [
-                    {"type": "text", "id": "e1", "span": [0, 20], "box": [10, 10, 200, 30],
-                     "parts": [{"span": [0, 20], "box": [10, 10, 200, 30]}]},
-                    {"type": "table", "id": "e2", "span": [20, 80], "box": [10, 40, 400, 300], "parts": [],
-                     "children": [
-                         {"type": "table_cell", "id": "e3", "span": [25, 30], "box": [12, 42, 100, 80], "parts": []},
-                     ]},
+                    {
+                        "type": "text",
+                        "id": "e1",
+                        "span": [0, 20],
+                        "box": [10, 10, 200, 30],
+                        "parts": [{"span": [0, 20], "box": [10, 10, 200, 30]}],
+                    },
+                    {
+                        "type": "table",
+                        "id": "e2",
+                        "span": [20, 80],
+                        "box": [10, 40, 400, 300],
+                        "parts": [],
+                        "children": [
+                            {"type": "table_cell", "id": "e3", "span": [25, 30], "box": [12, 42, 100, 80], "parts": []},
+                        ],
+                    },
                 ],
             }
         ],
@@ -76,9 +94,7 @@ RICH_PARSE_BODY: Dict[str, Any] = {
 @respx.mock
 def test_parse_sync_ok_routes_to_v2_and_sends_options_json() -> None:
     client = LandingAIADE(apikey=APIKEY, environment="production")
-    route = respx.post("https://api.ade.landing.ai/v2/parse").mock(
-        return_value=httpx.Response(200, json=PARSE_BODY)
-    )
+    route = respx.post("https://api.ade.landing.ai/v2/parse").mock(return_value=httpx.Response(200, json=PARSE_BODY))
     result = client.v2.parse(document=b"pdf", model="dpt-3-latest", options={"foo": "bar"})
     assert isinstance(result, V2ParseResponse)
     assert result.markdown == "# Hello"
@@ -90,9 +106,7 @@ def test_parse_sync_ok_routes_to_v2_and_sends_options_json() -> None:
 @respx.mock
 def test_parse_sync_omits_unset_fields_from_multipart_body() -> None:
     client = LandingAIADE(apikey=APIKEY, environment="production")
-    route = respx.post("https://api.ade.landing.ai/v2/parse").mock(
-        return_value=httpx.Response(200, json=PARSE_BODY)
-    )
+    route = respx.post("https://api.ade.landing.ai/v2/parse").mock(return_value=httpx.Response(200, json=PARSE_BODY))
     client.v2.parse(document=b"pdf")
     # Unset `Omit`/`NotGiven` sentinels must never leak into the multipart
     # body as literal `"<...Omit object...>"` / `"NOT_GIVEN"` form fields.
@@ -111,9 +125,7 @@ def test_parse_sync_omits_explicit_none_fields_from_multipart_body() -> None:
     # so an explicit `None` for an optional field must be dropped by hand -- it
     # must never leak into the multipart body as a literal "None"/"null" field.
     client = LandingAIADE(apikey=APIKEY, environment="production")
-    route = respx.post("https://api.ade.landing.ai/v2/parse").mock(
-        return_value=httpx.Response(200, json=PARSE_BODY)
-    )
+    route = respx.post("https://api.ade.landing.ai/v2/parse").mock(return_value=httpx.Response(200, json=PARSE_BODY))
     client.v2.parse(document=b"x", document_url=None, model=None, options=None, password=None)
     sent = route.calls.last.request.content
     assert b"document_url" not in sent
@@ -219,9 +231,7 @@ def test_parse_sync_typed_structure_and_grounding() -> None:
     from landingai_ade.types.v2 import V2ParseGrounding, V2ParseStructure
 
     client = LandingAIADE(apikey=APIKEY)
-    respx.post("https://api.ade.landing.ai/v2/parse").mock(
-        return_value=httpx.Response(200, json=RICH_PARSE_BODY)
-    )
+    respx.post("https://api.ade.landing.ai/v2/parse").mock(return_value=httpx.Response(200, json=RICH_PARSE_BODY))
     result = client.v2.parse(document=b"pdf")
 
     assert isinstance(result.structure, V2ParseStructure)
@@ -252,9 +262,15 @@ def test_parse_sync_tolerates_unknown_element_type_and_extra_keys() -> None:
         "structure": {
             "type": "document",
             "children": [
-                {"type": "page", "page": 0, "span": [0, 5], "future_field": 7, "children": [
-                    {"type": "some_future_kind", "id": "e9", "span": [0, 5]},
-                ]},
+                {
+                    "type": "page",
+                    "page": 0,
+                    "span": [0, 5],
+                    "future_field": 7,
+                    "children": [
+                        {"type": "some_future_kind", "id": "e9", "span": [0, 5]},
+                    ],
+                },
             ],
         },
         "grounding": {"type": "document", "children": []},


### PR DESCRIPTION
Pure formatter output (`ruff format` + `ruffen-docs` + `ruff check --fix`), no behavior change.

**Why:** main is not clean under the current formatter, and the spec-sync workflow runs `./scripts/format` before committing the AI wiring — so every sync PR (e.g. #115) re-carries the same cosmetic hunks (README/examples code-block reflow, line joins in `_client.py` and the v2 resources), inflating review diffs. Formatting main once makes those hunks disappear from #115's diff and keeps future sync PRs noise-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)