### PR TITLE
feat(spec-sync): notify Slack on drift PRs and failures

### DIFF
--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -1,0 +1,70 @@
+name: Slack notify
+description: >
+  Post a spec-sync status message to Slack via an incoming webhook. A silent
+  no-op when `webhook` is empty, so the workflow runs unchanged in forks and
+  before the secret is configured. Never fails the job: a Slack outage must not
+  turn a spec-sync run red.
+
+  Renders a single mrkdwn section — put any links inline in `text` with Slack's
+  `<url|label>` syntax. Deliberately no buttons: an `actions`/`button` block is
+  an interactive component that requires the app to configure an Interactivity
+  Request URL, which a webhook-only app has not — Slack would warn "not
+  configured to handle interactive responses" on click. Inline links don't.
+inputs:
+  webhook:
+    description: Slack incoming webhook URL. Empty -> silent no-op.
+    required: false
+    default: ''
+  status:
+    description: success | warning | failure | info (drives the emoji only).
+    required: true
+  title:
+    description: Bold first line of the message.
+    required: true
+  text:
+    description: Message body (Slack mrkdwn; use <url|label> for links).
+    required: true
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        WEBHOOK: ${{ inputs.webhook }}
+        STATUS: ${{ inputs.status }}
+        TITLE: ${{ inputs.title }}
+        TEXT: ${{ inputs.text }}
+      run: |
+        set -euo pipefail
+        if [ -z "${WEBHOOK}" ]; then
+          echo "slack-notify: no webhook configured; skipping."
+          exit 0
+        fi
+        case "${STATUS}" in
+          success) emoji="✅" ;;
+          warning) emoji="⚠️" ;;
+          failure) emoji="🔴" ;;
+          *)       emoji="ℹ️" ;;
+        esac
+        # jq builds (and escapes) the Block Kit payload. jq is preinstalled on GitHub-hosted runners.
+        # GITHUB_REPOSITORY is a default env var the runner sets in every step (incl. composite
+        # actions), so the context footer names the source repo — ade-typescript vs ade-python — with
+        # no input to thread through and no per-repo config.
+        payload="$(jq -n \
+          --arg header "${emoji} ${TITLE}" \
+          --arg text "${TEXT}" \
+          --arg repo "${GITHUB_REPOSITORY}" '
+          {
+            blocks: [
+              { type: "section",
+                text: { type: "mrkdwn", text: ("*" + $header + "*\n" + $text) } },
+              { type: "context",
+                elements: [ { type: "mrkdwn", text: ("📦 `" + $repo + "` · spec-sync") } ] }
+            ]
+          }')"
+        # Non-fatal by design: capture the HTTP status, never propagate a send failure.
+        code="$(curl -sS -o /dev/null -w '%{http_code}' \
+          -X POST -H 'Content-type: application/json' \
+          --data "${payload}" "${WEBHOOK}" || echo "000")"
+        if [ "${code}" != "200" ]; then
+          echo "slack-notify: webhook returned HTTP ${code} (non-fatal; continuing)."
+        fi

--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -1,20 +1,29 @@
 name: Slack notify
 description: >
-  Post a spec-sync status message to Slack via an incoming webhook. A silent
-  no-op when `webhook` is empty, so the workflow runs unchanged in forks and
-  before the secret is configured. Never fails the job: a Slack outage must not
-  turn a spec-sync run red.
+  Post a spec-sync status message to Slack. Prefers the Web API (chat.postMessage
+  with a bot token): that path can thread (via `thread_ts`) and returns the posted
+  message `ts` as an output. Falls back to an incoming webhook (flat, no ts) when
+  only `webhook` is set, and is a silent no-op when neither is configured. Never
+  fails the job: a Slack outage must not turn a spec-sync run red.
 
-  Renders a single mrkdwn section — put any links inline in `text` with Slack's
-  `<url|label>` syntax. Deliberately no buttons: an `actions`/`button` block is
-  an interactive component that requires the app to configure an Interactivity
-  Request URL, which a webhook-only app has not — Slack would warn "not
-  configured to handle interactive responses" on click. Inline links don't.
+  Renders a single mrkdwn section + a repo-context footer — put any links inline
+  in `text` with Slack's `<url|label>` syntax. Deliberately no buttons: a button
+  is an interactive component that needs an app Interactivity Request URL, which a
+  bot-token/webhook app has not (Slack warns "not configured to handle interactive
+  responses" on click). Inline links don't.
 inputs:
-  webhook:
-    description: Slack incoming webhook URL. Empty -> silent no-op.
+  bot_token:
+    description: Slack bot token (xoxb-...). When set, posts via chat.postMessage and can thread.
     required: false
     default: ''
+  webhook:
+    description: Incoming webhook URL. Used only when bot_token is empty (flat, no threading, no ts).
+    required: false
+    default: ''
+  channel:
+    description: Channel (name or ID) for chat.postMessage. Ignored in webhook mode.
+    required: false
+    default: '#ade-sdk-pipeline'
   status:
     description: success | warning | failure | info (drives the emoji only).
     required: true
@@ -24,47 +33,85 @@ inputs:
   text:
     description: Message body (Slack mrkdwn; use <url|label> for links).
     required: true
+  thread_ts:
+    description: When set (bot_token mode), post as a reply under this thread root.
+    required: false
+    default: ''
+  reply_broadcast:
+    description: "'true' to also surface a threaded reply back in the channel. Only with thread_ts."
+    required: false
+    default: 'false'
+outputs:
+  ts:
+    description: The posted message ts (empty in webhook mode, on no-op, or on failure).
+    value: ${{ steps.post.outputs.ts }}
 runs:
   using: composite
   steps:
-    - shell: bash
+    - id: post
+      shell: bash
       env:
+        BOT_TOKEN: ${{ inputs.bot_token }}
         WEBHOOK: ${{ inputs.webhook }}
+        CHANNEL: ${{ inputs.channel }}
         STATUS: ${{ inputs.status }}
         TITLE: ${{ inputs.title }}
         TEXT: ${{ inputs.text }}
+        THREAD_TS: ${{ inputs.thread_ts }}
+        REPLY_BROADCAST: ${{ inputs.reply_broadcast }}
       run: |
         set -euo pipefail
-        if [ -z "${WEBHOOK}" ]; then
-          echo "slack-notify: no webhook configured; skipping."
-          exit 0
-        fi
         case "${STATUS}" in
           success) emoji="✅" ;;
           warning) emoji="⚠️" ;;
           failure) emoji="🔴" ;;
           *)       emoji="ℹ️" ;;
         esac
-        # jq builds (and escapes) the Block Kit payload. jq is preinstalled on GitHub-hosted runners.
-        # GITHUB_REPOSITORY is a default env var the runner sets in every step (incl. composite
-        # actions), so the context footer names the source repo — ade-typescript vs ade-python — with
-        # no input to thread through and no per-repo config.
-        payload="$(jq -n \
+        # Shared blocks: a mrkdwn section + a repo-context footer. GITHUB_REPOSITORY is a default env
+        # var the runner sets in every step, so the footer names the source repo (ade-typescript vs
+        # ade-python) with no input to thread through. jq is preinstalled on GitHub-hosted runners.
+        blocks="$(jq -n \
           --arg header "${emoji} ${TITLE}" \
           --arg text "${TEXT}" \
           --arg repo "${GITHUB_REPOSITORY}" '
-          {
-            blocks: [
-              { type: "section",
-                text: { type: "mrkdwn", text: ("*" + $header + "*\n" + $text) } },
-              { type: "context",
-                elements: [ { type: "mrkdwn", text: ("📦 `" + $repo + "` · spec-sync") } ] }
-            ]
-          }')"
-        # Non-fatal by design: capture the HTTP status, never propagate a send failure.
-        code="$(curl -sS -o /dev/null -w '%{http_code}' \
-          -X POST -H 'Content-type: application/json' \
-          --data "${payload}" "${WEBHOOK}" || echo "000")"
-        if [ "${code}" != "200" ]; then
-          echo "slack-notify: webhook returned HTTP ${code} (non-fatal; continuing)."
+          [ { type: "section", text: { type: "mrkdwn", text: ("*" + $header + "*\n" + $text) } },
+            { type: "context", elements: [ { type: "mrkdwn", text: ("📦 `" + $repo + "` · spec-sync") } ] } ]')"
+
+        # Preferred: Web API. Returns the message ts (needed to thread later events) and accepts
+        # thread_ts to reply under an existing root.
+        if [ -n "${BOT_TOKEN}" ]; then
+          payload="$(jq -n \
+            --arg channel "${CHANNEL}" \
+            --arg fallback "${emoji} ${TITLE}" \
+            --argjson blocks "${blocks}" \
+            --arg thread "${THREAD_TS}" \
+            --arg broadcast "${REPLY_BROADCAST}" '
+            { channel: $channel, text: $fallback, blocks: $blocks }
+            + (if $thread != "" then { thread_ts: $thread } else {} end)
+            + (if $thread != "" and $broadcast == "true" then { reply_broadcast: true } else {} end)')"
+          resp="$(curl -sS -X POST \
+            -H "Authorization: Bearer ${BOT_TOKEN}" \
+            -H 'Content-type: application/json; charset=utf-8' \
+            --data "${payload}" https://slack.com/api/chat.postMessage \
+            || echo '{"ok":false,"error":"curl_failed"}')"
+          if [ "$(printf '%s' "${resp}" | jq -r '.ok')" = "true" ]; then
+            printf 'ts=%s\n' "$(printf '%s' "${resp}" | jq -r '.ts')" >> "$GITHUB_OUTPUT"
+          else
+            echo "slack-notify: chat.postMessage failed: $(printf '%s' "${resp}" | jq -r '.error // "unknown"') (non-fatal; continuing)."
+          fi
+          exit 0
         fi
+
+        # Fallback: incoming webhook. Flat only — returns no ts, so threading silently degrades.
+        if [ -n "${WEBHOOK}" ]; then
+          payload="$(jq -n --argjson blocks "${blocks}" '{ blocks: $blocks }')"
+          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+            -X POST -H 'Content-type: application/json' \
+            --data "${payload}" "${WEBHOOK}" || echo "000")"
+          if [ "${code}" != "200" ]; then
+            echo "slack-notify: webhook returned HTTP ${code} (non-fatal; continuing)."
+          fi
+          exit 0
+        fi
+
+        echo "slack-notify: neither bot_token nor webhook configured; skipping."

--- a/.github/workflows/spec-sync.yml
+++ b/.github/workflows/spec-sync.yml
@@ -88,10 +88,12 @@ jobs:
         if: steps.drift.outputs.code == '10' && steps.existing.outputs.open == 'true' && steps.behind.outputs.notify == 'true'
         uses: ./.github/actions/slack-notify
         with:
+          bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           webhook: ${{ secrets.SLACK_SPEC_SYNC_WEBHOOK }}
           status: warning
           title: 'spec-sync ${{ env.SPEC_LABEL }}: new drift behind the open PR'
           text: 'New ${{ env.SPEC_LABEL }} spec drift appeared beyond the <${{ steps.behind.outputs.pr_url }}|open sync PR> (live-spec `${{ steps.behind.outputs.hash }}`). Merge or close it and the next run opens a fresh one covering the rest.'
+          thread_ts: ${{ steps.behind.outputs.thread_ts }}
 
       # ---- Phase 1: mechanical (deterministic) ----
       - name: Mechanical commit + push
@@ -117,6 +119,27 @@ jobs:
             --title "spec-sync: track V1 spec drift" \
             --body $'Automated spec-sync PR.\n\n- **Commit 1 (mechanical):** normalized spec snapshot + regenerated reference models.\n- **Commit 2 (AI):** resources/methods/tests/docs wired from the spec diff (added after this PR opened).\n\nGates (surface-lock, contract tests, lint/test/typecheck) must pass. **Human review required before merge.**')"
           echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      # Post the Slack thread ROOT now — right after the PR exists, before AI wiring — so every later
+      # event (AI outcome, new drift, gates, merge) replies under it. Persist its ts on the PR body
+      # so other runs/workflows can find the thread. (Editing the body doesn't re-trigger pr-gates,
+      # which only fires on opened/synchronize/reopened.)
+      - name: Slack — PR opened (thread root)
+        id: root
+        if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true'
+        uses: ./.github/actions/slack-notify
+        with:
+          bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          webhook: ${{ secrets.SLACK_SPEC_SYNC_WEBHOOK }}
+          status: info
+          title: 'spec-sync ${{ env.SPEC_LABEL }}: new spec drift → PR opened'
+          text: '<${{ steps.open_pr.outputs.url }}|Open the PR> — mechanical spec snapshot committed; wiring the SDK next. Human review required before merge.'
+
+      - name: Save thread root on the PR
+        if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true' && steps.root.outputs.ts != ''
+        env:
+          GH_TOKEN: ${{ secrets.SPEC_SYNC_TOKEN }}
+        run: ./scripts/spec-sync/thread-ts.sh set "${{ steps.open_pr.outputs.url }}" "${{ steps.root.outputs.ts }}"
 
       # ---- Phase 2: AI wiring — edits ONLY. The agent holds no git/push capability, so a
       # prompt-injected spec description cannot route around review to push to a branch. ----
@@ -164,16 +187,17 @@ jobs:
             echo "summary=Mechanical snapshot + AI wiring committed. Gates must pass; human review required before merge." >> "$GITHUB_OUTPUT"
           fi
 
-      # Case 1: fresh drift -> a new PR was opened above. Announce it once, noting whether AI wiring
-      # landed a second commit or the PR is mechanical-only.
-      - name: Slack — new drift, PR opened
+      # The AI-wiring outcome, as a reply under the PR-opened thread root (steps.root).
+      - name: Slack — AI wiring result
         if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true'
         uses: ./.github/actions/slack-notify
         with:
+          bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           webhook: ${{ secrets.SLACK_SPEC_SYNC_WEBHOOK }}
           status: info
-          title: 'spec-sync ${{ env.SPEC_LABEL }}: new spec drift → PR opened'
-          text: '<${{ steps.open_pr.outputs.url }}|Open the PR> — ${{ steps.ai_push.outputs.summary }}'
+          title: 'spec-sync ${{ env.SPEC_LABEL }}: AI wiring'
+          text: ${{ steps.ai_push.outputs.summary }}
+          thread_ts: ${{ steps.root.outputs.ts }}
 
       # Catch-all failure alert for this job. Tailors the message to the two failure modes worth
       # calling out — a spec fetch/normalize error (often the staging cluster being unbooked) and an
@@ -182,6 +206,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/slack-notify
         with:
+          bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           webhook: ${{ secrets.SLACK_SPEC_SYNC_WEBHOOK }}
           status: failure
           title: 'spec-sync ${{ env.SPEC_LABEL }}: run failed'
@@ -192,6 +217,7 @@ jobs:
             && 'AI wiring step failed. Any open sync PR has only the mechanical commit and needs manual wiring.'
             || 'spec-sync run failed. See the workflow run for details.') }}
             · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>
+          thread_ts: ${{ steps.root.outputs.ts }}
 
   # V2 loop. Same machinery as the V1 job above, pointed at the V2 spec on the AIDE gateway
   # and a separate sync branch, with a V2-tailored wiring prompt. Kept as a distinct job (not a
@@ -275,10 +301,12 @@ jobs:
         if: steps.drift.outputs.code == '10' && steps.existing.outputs.open == 'true' && steps.behind.outputs.notify == 'true'
         uses: ./.github/actions/slack-notify
         with:
+          bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           webhook: ${{ secrets.SLACK_SPEC_SYNC_WEBHOOK }}
           status: warning
           title: 'spec-sync ${{ env.SPEC_LABEL }}: new drift behind the open PR'
           text: 'New ${{ env.SPEC_LABEL }} spec drift appeared beyond the <${{ steps.behind.outputs.pr_url }}|open sync PR> (live-spec `${{ steps.behind.outputs.hash }}`). Merge or close it and the next run opens a fresh one covering the rest.'
+          thread_ts: ${{ steps.behind.outputs.thread_ts }}
 
       # ---- Phase 1: mechanical (deterministic) ----
       - name: Mechanical commit + push
@@ -302,6 +330,27 @@ jobs:
             --title "spec-sync: track V2 spec drift" \
             --body $'Automated V2 spec-sync PR (`client.v2`).\n\n- **Commit 1 (mechanical):** normalized V2 spec snapshot + regenerated reference models.\n- **Commit 2 (AI, only if the spec diff needs SDK changes):** client.v2 resources/methods/tests/docs wired from the diff, added after this PR opened. Workflow-only drift is excluded and an AI no-op is skipped, so some drifts produce a **mechanical-only PR with no second commit**.\n\nGates (surface-lock, V2 contract tests, lint/test/typecheck) must pass. When present, the AI commit is a **draft a human finishes** (the V2 ergonomic layer — unified Job, dual-host, schema coercion — is not in the spec). **Human review required before merge.**')"
           echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      # Post the Slack thread ROOT now — right after the PR exists, before AI wiring — so every later
+      # event (AI outcome, new drift, gates, merge) replies under it. Persist its ts on the PR body
+      # so other runs/workflows can find the thread. (Editing the body doesn't re-trigger pr-gates,
+      # which only fires on opened/synchronize/reopened.)
+      - name: Slack — PR opened (thread root)
+        id: root
+        if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true'
+        uses: ./.github/actions/slack-notify
+        with:
+          bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          webhook: ${{ secrets.SLACK_SPEC_SYNC_WEBHOOK }}
+          status: info
+          title: 'spec-sync ${{ env.SPEC_LABEL }}: new spec drift → PR opened'
+          text: '<${{ steps.open_pr.outputs.url }}|Open the PR> — mechanical spec snapshot committed; wiring the SDK next. Human review required before merge.'
+
+      - name: Save thread root on the PR
+        if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true' && steps.root.outputs.ts != ''
+        env:
+          GH_TOKEN: ${{ secrets.SPEC_SYNC_TOKEN }}
+        run: ./scripts/spec-sync/thread-ts.sh set "${{ steps.open_pr.outputs.url }}" "${{ steps.root.outputs.ts }}"
 
       # ---- Phase 2: AI wiring — edits ONLY (no git/push; a later step commits). ----
       - name: AI wiring (edits only)
@@ -403,16 +452,17 @@ jobs:
             echo "summary=Mechanical snapshot + AI wiring committed (a draft a human finishes). Gates must pass; human review required before merge." >> "$GITHUB_OUTPUT"
           fi
 
-      # Case 1: fresh drift -> a new PR was opened above. Announce it once, noting whether AI wiring
-      # landed a second commit or the PR is mechanical-only.
-      - name: Slack — new drift, PR opened
+      # The AI-wiring outcome, as a reply under the PR-opened thread root (steps.root).
+      - name: Slack — AI wiring result
         if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true'
         uses: ./.github/actions/slack-notify
         with:
+          bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           webhook: ${{ secrets.SLACK_SPEC_SYNC_WEBHOOK }}
           status: info
-          title: 'spec-sync ${{ env.SPEC_LABEL }}: new spec drift → PR opened'
-          text: '<${{ steps.open_pr.outputs.url }}|Open the PR> — ${{ steps.ai_push.outputs.summary }}'
+          title: 'spec-sync ${{ env.SPEC_LABEL }}: AI wiring'
+          text: ${{ steps.ai_push.outputs.summary }}
+          thread_ts: ${{ steps.root.outputs.ts }}
 
       # Catch-all failure alert for this job. Tailors the message to the two failure modes worth
       # calling out — a spec fetch/normalize error (often the staging cluster being unbooked) and an
@@ -421,6 +471,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/slack-notify
         with:
+          bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           webhook: ${{ secrets.SLACK_SPEC_SYNC_WEBHOOK }}
           status: failure
           title: 'spec-sync ${{ env.SPEC_LABEL }}: run failed'
@@ -431,3 +482,4 @@ jobs:
             && 'AI wiring step failed. Any open sync PR has only the mechanical commit and needs manual wiring.'
             || 'spec-sync run failed. See the workflow run for details.') }}
             · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>
+          thread_ts: ${{ steps.root.outputs.ts }}

--- a/.github/workflows/spec-sync.yml
+++ b/.github/workflows/spec-sync.yml
@@ -22,6 +22,7 @@ jobs:
     env:
       V1_SPEC_URL: https://api.va.staging.landing.ai/v1/ade/openapi.json  # staging drives the loop
       SYNC_BRANCH: spec-sync/v1   # fixed branch: reruns update one PR in place, never a pile of them
+      SPEC_LABEL: V1   # used only in Slack/PR-comment copy to disambiguate the two jobs
     steps:
       - uses: actions/checkout@v6
         with:
@@ -73,9 +74,24 @@ jobs:
             echo "open=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Sync PR already open — skip
+      # A sync PR is already open. Every hourly tick still reports drift (check-drift compares against
+      # main, not the PR branch), so instead of a bare skip: detect drift that appeared BEYOND the
+      # open PR and, if any, annotate the PR + emit one Slack ping per distinct new spec (deduped).
+      - name: New drift behind the open PR
+        id: behind
         if: steps.drift.outputs.code == '10' && steps.existing.outputs.open == 'true'
-        run: echo "A spec-sync PR is already open; skipping until it is merged or closed."
+        env:
+          GH_TOKEN: ${{ secrets.SPEC_SYNC_TOKEN }}
+        run: ./scripts/spec-sync/notify-new-drift.sh specs/v1-ade.json "$SYNC_BRANCH" "$SPEC_LABEL"
+
+      - name: Slack — new drift behind the open PR
+        if: steps.drift.outputs.code == '10' && steps.existing.outputs.open == 'true' && steps.behind.outputs.notify == 'true'
+        uses: ./.github/actions/slack-notify
+        with:
+          webhook: ${{ secrets.SLACK_SPEC_SYNC_WEBHOOK }}
+          status: warning
+          title: 'spec-sync ${{ env.SPEC_LABEL }}: new drift behind the open PR'
+          text: 'New ${{ env.SPEC_LABEL }} spec drift appeared beyond the <${{ steps.behind.outputs.pr_url }}|open sync PR> (live-spec `${{ steps.behind.outputs.hash }}`). Merge or close it and the next run opens a fresh one covering the rest.'
 
       # ---- Phase 1: mechanical (deterministic) ----
       - name: Mechanical commit + push
@@ -92,17 +108,20 @@ jobs:
       # Open the PR now — before the AI step — so a run that dies in phase 2 leaves a visible PR
       # (with just the mechanical commit) instead of an orphan branch.
       - name: Open sync PR
+        id: open_pr
         if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true'
         env:
           GH_TOKEN: ${{ secrets.SPEC_SYNC_TOKEN }}
         run: |
-          gh pr create --base main --head "$SYNC_BRANCH" \
+          url="$(gh pr create --base main --head "$SYNC_BRANCH" \
             --title "spec-sync: track V1 spec drift" \
-            --body $'Automated spec-sync PR.\n\n- **Commit 1 (mechanical):** normalized spec snapshot + regenerated reference models.\n- **Commit 2 (AI):** resources/methods/tests/docs wired from the spec diff (added after this PR opened).\n\nGates (surface-lock, contract tests, lint/test/typecheck) must pass. **Human review required before merge.**'
+            --body $'Automated spec-sync PR.\n\n- **Commit 1 (mechanical):** normalized spec snapshot + regenerated reference models.\n- **Commit 2 (AI):** resources/methods/tests/docs wired from the spec diff (added after this PR opened).\n\nGates (surface-lock, contract tests, lint/test/typecheck) must pass. **Human review required before merge.**')"
+          echo "url=$url" >> "$GITHUB_OUTPUT"
 
       # ---- Phase 2: AI wiring — edits ONLY. The agent holds no git/push capability, so a
       # prompt-injected spec description cannot route around review to push to a branch. ----
       - name: AI wiring (edits only)
+        id: ai_wiring
         if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true'
         uses: anthropics/claude-code-action@v1
         with:
@@ -132,15 +151,47 @@ jobs:
       # the AI changes actually reach the PR (the action's automation mode does not push), and it
       # is the only step with push capability.
       - name: Commit + push AI wiring
+        id: ai_push
         if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true'
         run: |
           git add -A
           if git diff --cached --quiet; then
             echo "AI step produced no changes."
+            echo "summary=Mechanical-only PR (AI wiring added no changes). Human review required before merge." >> "$GITHUB_OUTPUT"
           else
             git commit -m "feat(spec-sync): wire SDK to spec diff (AI)"
             git push origin HEAD:"$SYNC_BRANCH"
+            echo "summary=Mechanical snapshot + AI wiring committed. Gates must pass; human review required before merge." >> "$GITHUB_OUTPUT"
           fi
+
+      # Case 1: fresh drift -> a new PR was opened above. Announce it once, noting whether AI wiring
+      # landed a second commit or the PR is mechanical-only.
+      - name: Slack — new drift, PR opened
+        if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true'
+        uses: ./.github/actions/slack-notify
+        with:
+          webhook: ${{ secrets.SLACK_SPEC_SYNC_WEBHOOK }}
+          status: info
+          title: 'spec-sync ${{ env.SPEC_LABEL }}: new spec drift → PR opened'
+          text: '<${{ steps.open_pr.outputs.url }}|Open the PR> — ${{ steps.ai_push.outputs.summary }}'
+
+      # Catch-all failure alert for this job. Tailors the message to the two failure modes worth
+      # calling out — a spec fetch/normalize error (often the staging cluster being unbooked) and an
+      # AI-wiring crash (PR left mechanical-only) — and falls back to a generic run-failed otherwise.
+      - name: Slack — spec-sync failed
+        if: failure()
+        uses: ./.github/actions/slack-notify
+        with:
+          webhook: ${{ secrets.SLACK_SPEC_SYNC_WEBHOOK }}
+          status: failure
+          title: 'spec-sync ${{ env.SPEC_LABEL }}: run failed'
+          text: >-
+            ${{ (steps.drift.outputs.code != '' && steps.drift.outputs.code != '0' && steps.drift.outputs.code != '10')
+            && format('Spec fetch/normalize failed (exit {0}). This targets staging — check whether the ADE cluster is unbooked (book via <https://github.com/landing-ai/finops/actions/workflows/book-ade.yml|finops book-ade.yml>) before assuming a real outage.', steps.drift.outputs.code)
+            || (steps.ai_wiring.outcome == 'failure'
+            && 'AI wiring step failed. Any open sync PR has only the mechanical commit and needs manual wiring.'
+            || 'spec-sync run failed. See the workflow run for details.') }}
+            · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>
 
   # V2 loop. Same machinery as the V1 job above, pointed at the V2 spec on the AIDE gateway
   # and a separate sync branch, with a V2-tailored wiring prompt. Kept as a distinct job (not a
@@ -156,6 +207,7 @@ jobs:
     env:
       V2_SPEC_URL: https://aide.staging.landing.ai/openapi.json  # staging drives the loop
       SYNC_BRANCH: spec-sync/v2   # separate branch so V1 and V2 sync PRs never collide
+      SPEC_LABEL: V2   # used only in Slack/PR-comment copy to disambiguate the two jobs
     steps:
       - uses: actions/checkout@v6
         with:
@@ -209,9 +261,24 @@ jobs:
             echo "open=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Sync PR already open — skip
+      # A sync PR is already open. Every hourly tick still reports drift (check-drift compares against
+      # main, not the PR branch), so instead of a bare skip: detect drift that appeared BEYOND the
+      # open PR and, if any, annotate the PR + emit one Slack ping per distinct new spec (deduped).
+      - name: New drift behind the open PR
+        id: behind
         if: steps.drift.outputs.code == '10' && steps.existing.outputs.open == 'true'
-        run: echo "A spec-sync PR is already open; skipping until it is merged or closed."
+        env:
+          GH_TOKEN: ${{ secrets.SPEC_SYNC_TOKEN }}
+        run: ./scripts/spec-sync/notify-new-drift.sh specs/v2-aide.json "$SYNC_BRANCH" "$SPEC_LABEL"
+
+      - name: Slack — new drift behind the open PR
+        if: steps.drift.outputs.code == '10' && steps.existing.outputs.open == 'true' && steps.behind.outputs.notify == 'true'
+        uses: ./.github/actions/slack-notify
+        with:
+          webhook: ${{ secrets.SLACK_SPEC_SYNC_WEBHOOK }}
+          status: warning
+          title: 'spec-sync ${{ env.SPEC_LABEL }}: new drift behind the open PR'
+          text: 'New ${{ env.SPEC_LABEL }} spec drift appeared beyond the <${{ steps.behind.outputs.pr_url }}|open sync PR> (live-spec `${{ steps.behind.outputs.hash }}`). Merge or close it and the next run opens a fresh one covering the rest.'
 
       # ---- Phase 1: mechanical (deterministic) ----
       - name: Mechanical commit + push
@@ -226,16 +293,19 @@ jobs:
           git push --force origin "$SYNC_BRANCH"
 
       - name: Open sync PR
+        id: open_pr
         if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true'
         env:
           GH_TOKEN: ${{ secrets.SPEC_SYNC_TOKEN }}
         run: |
-          gh pr create --base main --head "$SYNC_BRANCH" \
+          url="$(gh pr create --base main --head "$SYNC_BRANCH" \
             --title "spec-sync: track V2 spec drift" \
-            --body $'Automated V2 spec-sync PR (`client.v2`).\n\n- **Commit 1 (mechanical):** normalized V2 spec snapshot + regenerated reference models.\n- **Commit 2 (AI, only if the spec diff needs SDK changes):** client.v2 resources/methods/tests/docs wired from the diff, added after this PR opened. Workflow-only drift is excluded and an AI no-op is skipped, so some drifts produce a **mechanical-only PR with no second commit**.\n\nGates (surface-lock, V2 contract tests, lint/test/typecheck) must pass. When present, the AI commit is a **draft a human finishes** (the V2 ergonomic layer — unified Job, dual-host, schema coercion — is not in the spec). **Human review required before merge.**'
+            --body $'Automated V2 spec-sync PR (`client.v2`).\n\n- **Commit 1 (mechanical):** normalized V2 spec snapshot + regenerated reference models.\n- **Commit 2 (AI, only if the spec diff needs SDK changes):** client.v2 resources/methods/tests/docs wired from the diff, added after this PR opened. Workflow-only drift is excluded and an AI no-op is skipped, so some drifts produce a **mechanical-only PR with no second commit**.\n\nGates (surface-lock, V2 contract tests, lint/test/typecheck) must pass. When present, the AI commit is a **draft a human finishes** (the V2 ergonomic layer — unified Job, dual-host, schema coercion — is not in the spec). **Human review required before merge.**')"
+          echo "url=$url" >> "$GITHUB_OUTPUT"
 
       # ---- Phase 2: AI wiring — edits ONLY (no git/push; a later step commits). ----
       - name: AI wiring (edits only)
+        id: ai_wiring
         if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true'
         uses: anthropics/claude-code-action@v1
         with:
@@ -320,12 +390,44 @@ jobs:
           ./scripts/format
 
       - name: Commit + push AI wiring
+        id: ai_push
         if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true'
         run: |
           git add -A
           if git diff --cached --quiet; then
             echo "AI step produced no changes."
+            echo "summary=Mechanical-only PR (AI wiring added no changes — e.g. workflow-only drift). Human review required before merge." >> "$GITHUB_OUTPUT"
           else
             git commit -m "feat(spec-sync): wire client.v2 to spec diff (AI)"
             git push origin HEAD:"$SYNC_BRANCH"
+            echo "summary=Mechanical snapshot + AI wiring committed (a draft a human finishes). Gates must pass; human review required before merge." >> "$GITHUB_OUTPUT"
           fi
+
+      # Case 1: fresh drift -> a new PR was opened above. Announce it once, noting whether AI wiring
+      # landed a second commit or the PR is mechanical-only.
+      - name: Slack — new drift, PR opened
+        if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true'
+        uses: ./.github/actions/slack-notify
+        with:
+          webhook: ${{ secrets.SLACK_SPEC_SYNC_WEBHOOK }}
+          status: info
+          title: 'spec-sync ${{ env.SPEC_LABEL }}: new spec drift → PR opened'
+          text: '<${{ steps.open_pr.outputs.url }}|Open the PR> — ${{ steps.ai_push.outputs.summary }}'
+
+      # Catch-all failure alert for this job. Tailors the message to the two failure modes worth
+      # calling out — a spec fetch/normalize error (often the staging cluster being unbooked) and an
+      # AI-wiring crash (PR left mechanical-only) — and falls back to a generic run-failed otherwise.
+      - name: Slack — spec-sync failed
+        if: failure()
+        uses: ./.github/actions/slack-notify
+        with:
+          webhook: ${{ secrets.SLACK_SPEC_SYNC_WEBHOOK }}
+          status: failure
+          title: 'spec-sync ${{ env.SPEC_LABEL }}: run failed'
+          text: >-
+            ${{ (steps.drift.outputs.code != '' && steps.drift.outputs.code != '0' && steps.drift.outputs.code != '10')
+            && format('Spec fetch/normalize failed (exit {0}). This targets staging — check whether the ADE cluster is unbooked (book via <https://github.com/landing-ai/finops/actions/workflows/book-ade.yml|finops book-ade.yml>) before assuming a real outage.', steps.drift.outputs.code)
+            || (steps.ai_wiring.outcome == 'failure'
+            && 'AI wiring step failed. Any open sync PR has only the mechanical commit and needs manual wiring.'
+            || 'spec-sync run failed. See the workflow run for details.') }}
+            · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>

--- a/scripts/spec-sync/notify-new-drift.sh
+++ b/scripts/spec-sync/notify-new-drift.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Case 2 of spec-sync Slack notifications: drift is detected, but a sync PR is ALREADY open.
+#
+# The open-PR path runs every hour, and because check-drift compares the live spec against `main`
+# (not the PR branch), every one of those runs looks like "drift" until the PR merges. Notifying on
+# each would spam the channel hourly. This script suppresses that noise and fires only on genuinely
+# NEW drift that appeared *beyond* what the open PR already contains:
+#
+#   1. Compare the live spec (check-drift already wrote it into the working tree) against the PR
+#      branch's committed snapshot. Equal -> the PR already covers it -> stay silent.
+#   2. Otherwise there is new drift. Dedup by content hash via a sticky comment on the PR so we ping
+#      exactly once per distinct new live-spec, not once per hourly tick.
+#
+# Usage: notify-new-drift.sh <spec-path> <sync-branch> <label>
+# Writes to $GITHUB_OUTPUT: notify=<true|false>, and when notify=true also pr_url=<url> hash=<hash>.
+# Requires GH_TOKEN, GITHUB_REPOSITORY, and GITHUB_OUTPUT in the environment.
+set -euo pipefail
+
+spec_path="$1"
+sync_branch="$2"
+label="$3"
+
+out() { echo "$1" >> "$GITHUB_OUTPUT"; }
+
+# The live spec check-drift just wrote into the working tree vs the PR branch's committed snapshot.
+git fetch --quiet origin "$sync_branch"
+branch_spec="$(git show "origin/${sync_branch}:${spec_path}" 2>/dev/null || true)"
+if [ -n "$branch_spec" ] && [ "$branch_spec" = "$(cat "$spec_path")" ]; then
+  echo "Open PR already covers the current live spec; no new drift. Staying quiet."
+  out "notify=false"
+  exit 0
+fi
+
+hash="$(sha256sum "$spec_path" | cut -c1-12)"
+pr="$(gh pr list --state open --head "$sync_branch" --json number --jq '.[0].number')"
+if [ -z "$pr" ]; then
+  # The PR closed between the open-check and here; nothing to annotate.
+  out "notify=false"
+  exit 0
+fi
+
+# The sticky comment is both the user-facing signal and the dedup store: it always holds the latest
+# new-drift hash, so "does it already mention this hash" answers "have we pinged for this drift yet".
+marker="<!-- spec-sync-new-drift -->"
+comments="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${pr}/comments" --paginate)"
+cid="$(printf '%s' "$comments" | jq -r "[.[] | select(.body | contains(\"$marker\"))][0].id // empty")"
+prev="$(printf '%s' "$comments" | jq -r "[.[] | select(.body | contains(\"$marker\"))][0].body // empty")"
+
+if printf '%s' "$prev" | grep -q "$hash"; then
+  echo "Already notified for live-spec ${hash}; staying quiet."
+  out "notify=false"
+  exit 0
+fi
+
+body="${marker}
+:warning: **New ${label} spec drift beyond this PR** (live-spec \`${hash}\`). This PR is a snapshot of earlier drift and is now stale relative to the live spec — merge or close it and the next spec-sync run will open a fresh PR covering the rest."
+
+if [ -n "$cid" ]; then
+  gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${cid}" -f body="$body" >/dev/null
+else
+  gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${pr}/comments" -f body="$body" >/dev/null
+fi
+
+out "notify=true"
+out "pr_url=$(gh pr view "$pr" --json url --jq .url)"
+out "hash=${hash}"

--- a/scripts/spec-sync/notify-new-drift.sh
+++ b/scripts/spec-sync/notify-new-drift.sh
@@ -64,3 +64,5 @@ fi
 out "notify=true"
 out "pr_url=$(gh pr view "$pr" --json url --jq .url)"
 out "hash=${hash}"
+# The Slack thread root for this PR (empty if it predates threading) so the caller can reply in-thread.
+out "thread_ts=$("$(dirname "$0")/thread-ts.sh" get "$pr")"

--- a/scripts/spec-sync/thread-ts.sh
+++ b/scripts/spec-sync/thread-ts.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Persist / retrieve the Slack thread-root `ts` for a sync PR, stored as a hidden marker in the PR
+# body. Lifecycle events in later runs and other workflows (new drift, gates red, merged) read it
+# back to reply into the same thread instead of posting a fresh top-level message.
+#
+#   thread-ts.sh get <pr>       -> print the stored ts (empty if none)
+#   thread-ts.sh set <pr> <ts>  -> upsert the marker in the PR body
+#
+# Only the run that opens the PR writes; every later event only reads, so there is no write race
+# (and spec-sync is serialized by its concurrency group anyway). Requires GH_TOKEN + gh.
+set -euo pipefail
+
+marker="spec-sync-slack-thread:"
+cmd="${1:?usage: thread-ts.sh get|set <pr> [ts]}"
+pr="${2:?pr number required}"
+body="$(gh pr view "$pr" --json body -q .body 2>/dev/null || true)"
+
+case "$cmd" in
+  get)
+    printf '%s\n' "$body" | sed -n "s/.*<!-- ${marker} \\([^ ]*\\) -->.*/\\1/p" | head -n1
+    ;;
+  set)
+    ts="${3:?ts required}"
+    # Drop any existing marker line, then append the fresh one, and replace the PR body.
+    cleaned="$(printf '%s\n' "$body" | grep -vF "<!-- ${marker}" || true)"
+    printf '%s\n<!-- %s %s -->\n' "$cleaned" "$marker" "$ts" | gh pr edit "$pr" --body-file -
+    ;;
+  *)
+    echo "thread-ts.sh: unknown command '$cmd' (want get|set)" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
Ports the ade-typescript spec-sync Slack notifications (landing-ai/ade-typescript#85) to ade-python. Shared `slack-notify` composite action + four notifications wired into both spec-sync jobs (V1 + V2), posting to `#ade-sdk-pipeline` via the `SLACK_SPEC_SYNC_WEBHOOK` org secret.

- **drift → PR opened** (once; notes whether AI wiring landed)
- **new drift behind an already-open PR** — deduped via a sticky PR comment
- **spec fetch/normalize failure** — with the staging-cluster-unbooked hint
- **AI-wiring crash** — PR left mechanical-only

The action no-ops when the secret is unset and never fails the job. Links are inline mrkdwn (no interactive buttons), and a context footer names the repo via `$GITHUB_REPOSITORY`. Validated with actionlint; shared files are byte-identical to ade-typescript.

Phase 2 (separate PR, both repos): gates-red-on-sync-PR, daily aging nudge, PR-merged confirmation.