### PR TITLE
feat(spec-sync): Phase 2 lifecycle notifications (gates, merge, aging)

### DIFF
--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -80,24 +80,29 @@ runs:
         # Preferred: Web API. Returns the message ts (needed to thread later events) and accepts
         # thread_ts to reply under an existing root.
         if [ -n "${BOT_TOKEN}" ]; then
+          # Fallback text (notifications + screen readers) carries the body too, not just the title.
+          fallback="${emoji} ${TITLE}"
+          if [ -n "${TEXT}" ]; then fallback="${fallback}"$'\n'"${TEXT}"; fi
           payload="$(jq -n \
             --arg channel "${CHANNEL}" \
-            --arg fallback "${emoji} ${TITLE}" \
+            --arg fallback "${fallback}" \
             --argjson blocks "${blocks}" \
             --arg thread "${THREAD_TS}" \
             --arg broadcast "${REPLY_BROADCAST}" '
             { channel: $channel, text: $fallback, blocks: $blocks }
             + (if $thread != "" then { thread_ts: $thread } else {} end)
             + (if $thread != "" and $broadcast == "true" then { reply_broadcast: true } else {} end)')"
-          resp="$(curl -sS -X POST \
+          # --connect-timeout/--max-time bound a hung connection so a Slack stall can't hold the job.
+          resp="$(curl -sS --connect-timeout 10 --max-time 20 -X POST \
             -H "Authorization: Bearer ${BOT_TOKEN}" \
             -H 'Content-type: application/json; charset=utf-8' \
             --data "${payload}" https://slack.com/api/chat.postMessage \
             || echo '{"ok":false,"error":"curl_failed"}')"
-          if [ "$(printf '%s' "${resp}" | jq -r '.ok')" = "true" ]; then
-            printf 'ts=%s\n' "$(printf '%s' "${resp}" | jq -r '.ts')" >> "$GITHUB_OUTPUT"
+          # Parse defensively: an empty/non-JSON response must not fail the step (non-fatal contract).
+          if [ "$(printf '%s' "${resp}" | jq -r '.ok // false' 2>/dev/null || echo false)" = "true" ]; then
+            printf 'ts=%s\n' "$(printf '%s' "${resp}" | jq -r '.ts // empty' 2>/dev/null || true)" >> "$GITHUB_OUTPUT"
           else
-            echo "slack-notify: chat.postMessage failed: $(printf '%s' "${resp}" | jq -r '.error // "unknown"') (non-fatal; continuing)."
+            echo "slack-notify: chat.postMessage failed: $(printf '%s' "${resp}" | jq -r '.error // "unknown"' 2>/dev/null || echo 'non-JSON response') (non-fatal; continuing)."
           fi
           exit 0
         fi
@@ -105,7 +110,7 @@ runs:
         # Fallback: incoming webhook. Flat only — returns no ts, so threading silently degrades.
         if [ -n "${WEBHOOK}" ]; then
           payload="$(jq -n --argjson blocks "${blocks}" '{ blocks: $blocks }')"
-          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+          code="$(curl -sS --connect-timeout 10 --max-time 20 -o /dev/null -w '%{http_code}' \
             -X POST -H 'Content-type: application/json' \
             --data "${payload}" "${WEBHOOK}" || echo "000")"
           if [ "${code}" != "200" ]; then

--- a/.github/workflows/spec-sync-lifecycle.yml
+++ b/.github/workflows/spec-sync-lifecycle.yml
@@ -1,0 +1,109 @@
+name: Spec Sync Lifecycle
+# Phase 2 spec-sync Slack notifications: gate failures, merges, and aging — all posted as replies
+# under the PR-opened thread root (root ts persisted on the PR body by the spec-sync workflow).
+# These triggers run the DEFAULT-branch version of this file, so they only take effect once merged.
+on:
+  workflow_run:
+    workflows: ['PR Gates']
+    types: [completed]
+  pull_request:
+    types: [closed]
+    branches: [main]
+  schedule:
+    - cron: '0 16 * * *' # daily aging sweep
+
+permissions:
+  contents: read
+  pull-requests: write # aging writes a dedup marker to the PR body; the others only read
+
+jobs:
+  # ⑤ Gates failed on a sync PR — reply under its thread.
+  gate-alert:
+    if: >-
+      github.event_name == 'workflow_run'
+      && github.repository == 'landing-ai/ade-python'
+      && github.event.workflow_run.conclusion == 'failure'
+      && startsWith(github.event.workflow_run.head_branch, 'spec-sync/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Resolve sync PR + thread root
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          num="$(gh pr list --state open --head "$HEAD_BRANCH" --json number --jq '.[0].number')"
+          if [ -z "$num" ]; then echo "No open PR for $HEAD_BRANCH."; echo "found=false" >> "$GITHUB_OUTPUT"; exit 0; fi
+          {
+            echo "found=true"
+            echo "url=$(gh pr view "$num" --json url --jq .url)"
+            echo "ts=$(./scripts/spec-sync/thread-ts.sh get "$num")"
+            echo "label=$([ "$HEAD_BRANCH" = 'spec-sync/v2' ] && echo V2 || echo V1)"
+          } >> "$GITHUB_OUTPUT"
+      - name: Slack — gates failed on the sync PR
+        if: steps.pr.outputs.found == 'true'
+        uses: ./.github/actions/slack-notify
+        with:
+          bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          status: failure
+          title: 'spec-sync ${{ steps.pr.outputs.label }}: gates failed on the sync PR'
+          text: 'PR Gates failed on the <${{ steps.pr.outputs.url }}|open sync PR> — it can''t merge until they are green. See <${{ github.event.workflow_run.html_url }}|the gate run>.'
+          thread_ts: ${{ steps.pr.outputs.ts }}
+
+  # ⑦ Sync PR merged — reply under its thread and broadcast to the channel.
+  merged:
+    if: >-
+      github.event_name == 'pull_request'
+      && github.repository == 'landing-ai/ade-python'
+      && github.event.pull_request.merged == true
+      && startsWith(github.event.pull_request.head.ref, 'spec-sync/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+      - name: Read thread root
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          {
+            echo "ts=$(./scripts/spec-sync/thread-ts.sh get "$PR")"
+            echo "label=$([ "$HEAD_REF" = 'spec-sync/v2' ] && echo V2 || echo V1)"
+          } >> "$GITHUB_OUTPUT"
+      - name: Slack — sync PR merged
+        uses: ./.github/actions/slack-notify
+        with:
+          bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          status: success
+          title: 'spec-sync ${{ steps.pr.outputs.label }}: PR merged — spec back in sync'
+          text: 'The <${{ github.event.pull_request.html_url }}|sync PR> was merged. Spec is back in sync.'
+          thread_ts: ${{ steps.pr.outputs.ts }}
+          reply_broadcast: 'true'
+
+  # ⑥ Aging nudge — daily reminder for a sync PR left open too long.
+  aging:
+    if: github.event_name == 'schedule' && github.repository == 'landing-ai/ade-python'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        branch: [spec-sync/v1, spec-sync/v2]
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check aging
+        id: age
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./scripts/spec-sync/aging-nudge.sh '${{ matrix.branch }}'
+      - name: Slack — sync PR is aging
+        if: steps.age.outputs.nudge == 'true'
+        uses: ./.github/actions/slack-notify
+        with:
+          bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          status: warning
+          title: "spec-sync ${{ matrix.branch == 'spec-sync/v2' && 'V2' || 'V1' }}: sync PR open ${{ steps.age.outputs.age_days }} days"
+          text: 'The <${{ steps.age.outputs.pr_url }}|sync PR> has been open ${{ steps.age.outputs.age_days }} days. Review and merge or close it — further drift is held until it clears.'
+          thread_ts: ${{ steps.age.outputs.thread_ts }}

--- a/.github/workflows/spec-sync.yml
+++ b/.github/workflows/spec-sync.yml
@@ -137,6 +137,7 @@ jobs:
 
       - name: Save thread root on the PR
         if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true' && steps.root.outputs.ts != ''
+        continue-on-error: true # bookkeeping only; thread-ts.sh fails closed, and a hiccup must not red the run
         env:
           GH_TOKEN: ${{ secrets.SPEC_SYNC_TOKEN }}
         run: ./scripts/spec-sync/thread-ts.sh set "${{ steps.open_pr.outputs.url }}" "${{ steps.root.outputs.ts }}"
@@ -189,7 +190,7 @@ jobs:
 
       # The AI-wiring outcome, as a reply under the PR-opened thread root (steps.root).
       - name: Slack — AI wiring result
-        if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true'
+        if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true' && steps.root.outputs.ts != ''
         uses: ./.github/actions/slack-notify
         with:
           bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -348,6 +349,7 @@ jobs:
 
       - name: Save thread root on the PR
         if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true' && steps.root.outputs.ts != ''
+        continue-on-error: true # bookkeeping only; thread-ts.sh fails closed, and a hiccup must not red the run
         env:
           GH_TOKEN: ${{ secrets.SPEC_SYNC_TOKEN }}
         run: ./scripts/spec-sync/thread-ts.sh set "${{ steps.open_pr.outputs.url }}" "${{ steps.root.outputs.ts }}"
@@ -454,7 +456,7 @@ jobs:
 
       # The AI-wiring outcome, as a reply under the PR-opened thread root (steps.root).
       - name: Slack — AI wiring result
-        if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true'
+        if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true' && steps.root.outputs.ts != ''
         uses: ./.github/actions/slack-notify
         with:
           bot_token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/scripts/spec-sync/aging-nudge.sh
+++ b/scripts/spec-sync/aging-nudge.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Phase 2 ⑥ — aging nudge. For the open sync PR on <sync-branch>, decide whether to post a "still
+# open" reminder: fire only when it has been open at least MIN_AGE_DAYS and we have not nudged in the
+# last MIN_GAP_DAYS. Dedup via a hidden marker in the PR body that records the day of the last nudge,
+# so a stuck PR gets an escalating trickle (day 3, 6, 9…) rather than a daily nag.
+#
+# Usage: aging-nudge.sh <sync-branch>
+# Writes $GITHUB_OUTPUT: nudge=<true|false>; when true also pr_url, thread_ts, age_days.
+# Requires GH_TOKEN + gh, and a GNU `date` (the ubuntu runner has it).
+set -euo pipefail
+
+sync_branch="$1"
+min_age="${MIN_AGE_DAYS:-3}"
+min_gap="${MIN_GAP_DAYS:-3}"
+here="$(cd "$(dirname "$0")" && pwd)"
+out() { echo "$1" >> "$GITHUB_OUTPUT"; }
+
+pr="$(gh pr list --state open --head "$sync_branch" --json number --jq '.[0].number')"
+if [ -z "$pr" ]; then
+  echo "No open PR on $sync_branch."
+  out "nudge=false"; exit 0
+fi
+
+now_days=$(( $(date -u +%s) / 86400 ))
+created="$(gh pr view "$pr" --json createdAt --jq .createdAt)"
+created_days=$(( $(date -u -d "$created" +%s) / 86400 ))
+age=$(( now_days - created_days ))
+if [ "$age" -lt "$min_age" ]; then
+  echo "PR #$pr is $age day(s) old (< $min_age); no nudge."
+  out "nudge=false"; exit 0
+fi
+
+body="$(gh pr view "$pr" --json body -q .body)"
+marker="spec-sync-nudged:"
+last="$(printf '%s\n' "$body" | sed -n "s/.*<!-- ${marker} \\([0-9]*\\) -->.*/\\1/p" | head -n1)"
+if [ -n "$last" ] && [ "$(( now_days - last ))" -lt "$min_gap" ]; then
+  echo "PR #$pr nudged $(( now_days - last )) day(s) ago (< $min_gap); staying quiet."
+  out "nudge=false"; exit 0
+fi
+
+# Record today's nudge (preserve any other markers, e.g. the thread-ts one).
+cleaned="$(printf '%s\n' "$body" | grep -vF "<!-- ${marker}" || true)"
+printf '%s\n<!-- %s %s -->\n' "$cleaned" "$marker" "$now_days" | gh pr edit "$pr" --body-file -
+
+out "nudge=true"
+out "pr_url=$(gh pr view "$pr" --json url --jq .url)"
+out "thread_ts=$("$here/thread-ts.sh" get "$pr")"
+out "age_days=$age"

--- a/scripts/spec-sync/thread-ts.sh
+++ b/scripts/spec-sync/thread-ts.sh
@@ -13,14 +13,22 @@ set -euo pipefail
 marker="spec-sync-slack-thread:"
 cmd="${1:?usage: thread-ts.sh get|set <pr> [ts]}"
 pr="${2:?pr number required}"
-body="$(gh pr view "$pr" --json body -q .body 2>/dev/null || true)"
 
 case "$cmd" in
   get)
+    # Best-effort: a read failure just means "no thread root yet" -> caller posts top-level.
+    body="$(gh pr view "$pr" --json body -q .body 2>/dev/null || true)"
     printf '%s\n' "$body" | sed -n "s/.*<!-- ${marker} \\([^ ]*\\) -->.*/\\1/p" | head -n1
     ;;
   set)
     ts="${3:?ts required}"
+    # Fail closed: a `gh pr view` failure must NOT look like an empty body, or the `gh pr edit`
+    # below would replace the entire PR description with just the marker. Abort instead. (An
+    # actually-empty description is a success with empty output, and is handled fine.)
+    if ! body="$(gh pr view "$pr" --json body -q .body)"; then
+      echo "thread-ts.sh: could not read PR #$pr body; refusing to overwrite it." >&2
+      exit 1
+    fi
     # Drop any existing marker line, then append the fresh one, and replace the PR body.
     cleaned="$(printf '%s\n' "$body" | grep -vF "<!-- ${marker}" || true)"
     printf '%s\n<!-- %s %s -->\n' "$cleaned" "$marker" "$ts" | gh pr edit "$pr" --body-file -


### PR DESCRIPTION
Stacked on #118 (Phase 1). Ports ade-typescript#86 to ade-python. Adds a `Spec Sync Lifecycle` workflow posting three more events as **thread replies** under the PR-opened root:

- **⑤ gates red** — `workflow_run` on `PR Gates` failure for a `spec-sync/*` PR
- **⑦ merged** — `pull_request: closed` + merged, with `reply_broadcast`
- **⑥ aging** — daily `schedule`; nudges a sync PR open ≥3 days, deduped via a PR-body marker (day 3, 6, 9…)

Byte-identical to ade-typescript#86 except the repo guard; `aging-nudge.sh` is identical. Validated: actionlint clean, aging logic mock-tested. Threading/bot-token already proven from ade-python in #118's smoke, so no redundant smoke here. These triggers run the default-branch version, so they take effect once merged.

Note: base is #118's branch to keep the diff Phase-2-only — retarget to `main` after #118 merges.