### PR TITLE
test: regenerate spec-sync v2 with request-body reference models

### DIFF
--- a/api.md
+++ b/api.md
@@ -64,7 +64,7 @@ Methods:
 
 The `client.v2` sub-client targets LandingAI's next-generation ADE gateway, which lives on its own host (`api.ade.[env].landing.ai`) rather than the V1 host (`api.va.[env].landing.ai`). It is **additive**: `client.v2.*` is a separate surface from the top-level `client.*` (V1) methods documented above, and using it does not change any V1 behavior. See the [README](README.md#environments) for environment selection and usage examples.
 
-`client.v2.parse_jobs`, `client.v2.extract_jobs`, and `client.v2.ground_jobs` all return a single, unified <a href="./src/landingai_ade/types/v2/job.py">`Job`</a> shape, even though the underlying parse/extract/ground job envelopes differ upstream -- `Job.raw` retains the full original envelope as an escape hatch for any field not surfaced on the typed model.
+`client.v2.parse_jobs`, `client.v2.extract_jobs`, `client.v2.build_schema_jobs`, and `client.v2.ground_jobs` all return a single, unified <a href="./src/landingai_ade/types/v2/job.py">`Job`</a> shape, even though the underlying parse/extract/build-schema/ground job envelopes differ upstream -- `Job.raw` retains the full original envelope as an escape hatch for any field not surfaced on the typed model.
 
 Types:
 
@@ -73,6 +73,10 @@ from landingai_ade.types.v2 import (
     Job,
     JobError,
     JobStatus,
+    V2BuildSchemaBilling,
+    V2BuildSchemaMetadata,
+    V2BuildSchemaResponse,
+    V2BuildSchemaWarning,
     V2ExtractBilling,
     V2ExtractMetadata,
     V2ExtractResult,
@@ -99,6 +103,7 @@ from landingai_ade.types.v2 import (
 - <code><a href="./src/landingai_ade/types/v2/job.py">Job</a></code> -- unified job shape: `job_id`, `status` (<code><a href="./src/landingai_ade/types/v2/job.py">JobStatus</a></code>: `pending` / `processing` / `completed` / `failed` / `cancelled`), `created_at`, `completed_at`, `progress`, `result` (a `V2ParseResponse` for parse jobs, a `V2ExtractResult` for extract jobs, or `None` until completion), `error` (<code><a href="./src/landingai_ade/types/v2/job.py">JobError</a></code>), `raw` (the full original envelope as a `dict`), and the `.is_terminal` property.
 - <code><a href="./src/landingai_ade/types/v2/parse_response.py">V2ParseResponse</a></code> -- `markdown`, `structure`, `grounding`, `metadata` (<code><a href="./src/landingai_ade/types/v2/parse_response.py">V2ParseMetadata</a></code>, which nests <code><a href="./src/landingai_ade/types/v2/parse_response.py">V2ParseBilling</a></code> and carries `output_markdown_chars`, `range_units`, and `openapi_spec`). `structure` is a typed <code><a href="./src/landingai_ade/types/v2/parse_response.py">V2ParseStructure</a></code> tree (`document` → <code><a href="./src/landingai_ade/types/v2/parse_response.py">V2ParsePage</a></code> → <code><a href="./src/landingai_ade/types/v2/parse_response.py">V2ParseElement</a></code>); each node below the root carries its spatial data inline in a <code><a href="./src/landingai_ade/types/v2/parse_response.py">V2ParseNodeGrounding</a></code> (`page`, <code><a href="./src/landingai_ade/types/v2/parse_response.py">V2ParseRange</a></code>, <code><a href="./src/landingai_ade/types/v2/parse_response.py">V2ParseBox</a></code>, normalized page coordinates), and leaf elements additionally carry an `atomic_grounding` list. With `options.inline_markdown`, each node also carries its `markdown` slice. The legacy top-level `grounding` tree (<code><a href="./src/landingai_ade/types/v2/parse_response.py">V2ParseGrounding</a></code> → `V2ParseGroundingPage` → `V2ParseGroundingElement` → `V2ParseGroundingEntry`) is retained for older gateway responses. Element `type`/page `status` are permissive strings and unknown keys are retained.
 - <code><a href="./src/landingai_ade/types/v2/extract_response.py">V2ExtractResult</a></code> -- `extraction`, `extraction_metadata`, `markdown`, `output_ref`, `schema_violation_error` (set when `strict=False` and the schema had unextractable fields), `warnings`, and `metadata` (<code><a href="./src/landingai_ade/types/v2/extract_response.py">V2ExtractMetadata</a></code>, which carries `model_version`, `input_markdown_chars`, `output_extraction_chars`, `range_units`, `openapi_spec`, and nests <code><a href="./src/landingai_ade/types/v2/extract_response.py">V2ExtractBilling</a></code>).
+- <code><a href="./src/landingai_ade/types/v2/build_schema_response.py">V2BuildSchemaResponse</a></code> -- `extraction_schema` (the generated JSON Schema serialized as a **string**, VTRA parity) and `metadata` (<code><a href="./src/landingai_ade/types/v2/build_schema_response.py">V2BuildSchemaMetadata</a></code>: `job_id`, `duration_ms`, `filename`, `org_id`, `version`, `openapi_spec`, nested <code><a href="./src/landingai_ade/types/v2/build_schema_response.py">V2BuildSchemaBilling</a></code>, and a list of <code><a href="./src/landingai_ade/types/v2/build_schema_response.py">V2BuildSchemaWarning</a></code> `{code, msg}` entries). `filename` and `version` are retained for v1 compatibility but always `None` in this version.
 - <code><a href="./src/landingai_ade/types/v2/file_upload_response.py">V2FileUploadResponse</a></code> -- `file_ref`.
 - <code><a href="./src/landingai_ade/types/v2/ground_response.py">V2GroundResult</a></code> -- `grounding` (a tree mirroring the input `extraction_metadata`, each `{value, ranges}` leaf replaced by the list of `structure` blocks its ranges overlap) and `metadata` (<code><a href="./src/landingai_ade/types/v2/ground_response.py">V2GroundMetadata</a></code>: `job_id`, `duration_ms`, `openapi_spec`, and nested <code><a href="./src/landingai_ade/types/v2/ground_response.py">V2GroundBilling</a></code>).
 
@@ -126,6 +131,17 @@ Methods:
 
   Same polling/timeout semantics as `parse_jobs.wait`. Extract jobs have no `cancelled` status, so `raise_on_failure` only ever triggers on `failed`.
 
+- <code title="post /v2/extract/build-schema">client.v2.<a href="./src/landingai_ade/resources/v2/v2.py">build_schema</a>(\*, markdowns=..., markdown_urls=..., prompt=..., schema=...) -> <a href="./src/landingai_ade/types/v2/build_schema_response.py">V2BuildSchemaResponse</a></code>
+
+  Synchronous schema generation. Generates or refines an extraction JSON Schema from one or more source markdown documents (`markdowns`, inline content or file text), markdown URLs (`markdown_urls`), a natural-language `prompt`, and/or an existing `schema` to iterate on. Provide **at least one** of the four. `schema` accepts a pydantic `BaseModel` subclass, a `dict`, or a JSON-encoded string -- all are coerced and sent as a JSON string. The result's `extraction_schema` is itself a JSON string suitable for passing to `extract`. Raises `V2SyncTimeoutError` on a 504; use `build_schema_jobs` for long-running inputs.
+
+- <code title="post /v2/extract/build-schema/jobs">client.v2.build_schema_jobs.<a href="./src/landingai_ade/resources/v2/build_schema.py">create</a>(\*, markdowns=..., markdown_urls=..., prompt=..., schema=..., service_tier=...) -> <a href="./src/landingai_ade/types/v2/job.py">Job</a></code>
+- <code title="get /v2/extract/build-schema/jobs/{job_id}">client.v2.build_schema_jobs.<a href="./src/landingai_ade/resources/v2/build_schema.py">get</a>(job_id) -> <a href="./src/landingai_ade/types/v2/job.py">Job</a></code>
+- <code title="get /v2/extract/build-schema/jobs">client.v2.build_schema_jobs.<a href="./src/landingai_ade/resources/v2/build_schema.py">list</a>(\*, page=..., page_size=..., status=...) -> JobList[<a href="./src/landingai_ade/types/v2/job.py">Job</a>]</code>
+- <code>client.v2.build_schema_jobs.<a href="./src/landingai_ade/resources/v2/build_schema.py">wait</a>(job_id, \*, timeout=600, poll_interval=None, raise_on_failure=False) -> <a href="./src/landingai_ade/types/v2/job.py">Job</a></code>
+
+  Same polling/timeout semantics as `parse_jobs.wait`. Build-schema jobs have no `cancelled` status, so `raise_on_failure` only ever triggers on `failed`. A completed job's `result` is a `V2BuildSchemaResponse`.
+
 - <code title="post /v2/ground">client.v2.<a href="./src/landingai_ade/resources/v2/v2.py">ground</a>(\*, extraction_metadata, structure) -> <a href="./src/landingai_ade/types/v2/ground_response.py">V2GroundResult</a></code>
 
   Synchronous ground. Maps each extracted field back to the `structure` blocks it was quoted from by overlapping `extraction_metadata` ranges against every block's inline `grounding.range`. Both `extraction_metadata` (e.g. `client.v2.extract(...).extraction_metadata`) and `structure` (e.g. `client.v2.parse(...).structure`) accept a `dict` or a pydantic model. Block ids resolve only against the `structure` supplied here, so pass the parse result the extraction actually came from. Raises `V2SyncTimeoutError` on a 504; use `ground_jobs` for long-running inputs.
@@ -143,5 +159,5 @@ Methods:
 
 Notes:
 
-- `parse_jobs.list` / `extract_jobs.list` / `ground_jobs.list` all return a `JobList` (a `list[Job]` subclass) carrying pagination metadata: `.has_more`, `.org_id`, `.page`, `.page_size`.
+- `parse_jobs.list` / `extract_jobs.list` / `build_schema_jobs.list` / `ground_jobs.list` all return a `JobList` (a `list[Job]` subclass) carrying pagination metadata: `.has_more`, `.org_id`, `.page`, `.page_size`.
 - All `client.v2.*` methods accept the usual `extra_headers`, `extra_query`, `extra_body`, and `timeout` overrides; sync methods additionally accept `save_to` (parse/extract only, not the job-creation methods) to write the response to disk, mirroring V1's `save_to`.

--- a/docs/v2-testing.md
+++ b/docs/v2-testing.md
@@ -9,7 +9,7 @@ what to check when the upstream spec (`specs/v2-aide.json`) changes.
 | Layer | Location | What it covers |
 | --- | --- | --- |
 | Response models | `tests/test_v2_types.py` | Deserialization of `V2ParseResponse` / `V2ExtractResult` / `V2GroundResult` and their nested models from plain dicts, including unknown-key tolerance. |
-| Job normalization | `tests/test_v2_normalize.py` | `normalize_parse_job` / `normalize_extract_job` / `normalize_ground_job`: envelope → unified `Job` (status, timestamps, `result`, `error`). |
+| Job normalization | `tests/test_v2_normalize.py` | `normalize_parse_job` / `normalize_extract_job` / `normalize_build_schema_job` / `normalize_ground_job`: envelope → unified `Job` (status, timestamps, `result`, `error`). |
 | Resource wiring | `tests/api_resources/v2/` | `respx`-mocked HTTP: host routing, multipart/JSON bodies, options serialization, job polling. No network. |
 | Live smoke | `tests/contract/test_v2_smoke.py` | End-to-end calls against staging (marked `contract`; skipped unless `LANDINGAI_ADE_STAGING_APIKEY` is set). |
 
@@ -68,6 +68,27 @@ The async `extract_jobs.create` also accepts `output_save_url` (async jobs only)
 when set, the finished result is delivered to that URL and the completed job
 reports `output_url` (on `Job.raw`) instead of an inline `result`.
 
+## Current build-schema-response shape
+
+`POST /v2/extract/build-schema` (and the completed `build_schema_jobs` result)
+returns a `V2BuildSchemaResponse` — it generates or refines an extraction JSON
+Schema from source markdown and/or a natural-language prompt:
+
+- `extraction_schema` — the generated JSON Schema serialized as a **string**
+  (VTRA parity; the field is a string, not an object). It is suitable for passing
+  straight to `client.v2.extract(schema=...)`.
+- `metadata` (`V2BuildSchemaMetadata`) — `job_id`, `duration_ms`, `filename`,
+  `org_id`, `version`, `openapi_spec`, `billing` (`V2BuildSchemaBilling`), and
+  `warnings` (a list of `V2BuildSchemaWarning` `{code, msg}` objects, e.g. code
+  `nonconformant_schema`). `filename` and `version` are retained for v1
+  compatibility but always `None` in this version.
+
+`client.v2.build_schema(...)` takes `markdowns` (inline content or file text),
+`markdown_urls`, `prompt`, and `schema` (an existing schema to iterate on;
+accepts a pydantic model, a `dict`, or a JSON string, coerced to a JSON string) —
+**at least one** must be provided or the SDK raises `ValueError` client-side.
+`build_schema_jobs.create` additionally accepts `service_tier`.
+
 ## Current ground-response shape
 
 `POST /v2/ground` (and the completed `ground_jobs` result) returns a
@@ -87,9 +108,9 @@ be passed directly). `ground_jobs.create` additionally accepts `output_save_url`
 
 ## Async job envelopes
 
-`normalize_parse_job`, `normalize_extract_job`, and `normalize_ground_job` fold
-the upstream job envelopes into the unified `Job`. All are tolerant of field-name
-drift:
+`normalize_parse_job`, `normalize_extract_job`, `normalize_build_schema_job`, and
+`normalize_ground_job` fold the upstream job envelopes into the unified `Job`. All
+are tolerant of field-name drift:
 
 - The parse response lives under `result` (older envelopes used `data`).
 - Failures arrive as a structured `error` object (`{code, message}`); older parse

--- a/specs/_generated/v2_models.py
+++ b/specs/_generated/v2_models.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Literal, Optional, Union
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, RootModel
 
@@ -13,11 +13,7 @@ class BaseElementOptions(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    markdown: Optional[bool] = Field(True, title='Markdown')
-
-
-class BodyStageFileV1FilesPost(BaseModel):
-    file: str = Field(..., title='File')
+    markdown: bool | None = Field(True, title='Markdown')
 
 
 class Box(BaseModel):
@@ -53,6 +49,25 @@ class Box(BaseModel):
     )
 
 
+class BuildSchemaWarning(BaseModel):
+    """
+    A structured warning from the schema-generation process (VTRA
+    ``ExtractWarning``). ``code`` classifies the warning (e.g.
+    ``nonconformant_schema``); ``msg`` is the human-readable description.
+    """
+
+    code: str = Field(
+        ...,
+        description='The type of warning, used to translate to a status code downstream.',
+        title='Code',
+    )
+    msg: str = Field(
+        ...,
+        description='Human-readable description of the warning with more details.',
+        title='Msg',
+    )
+
+
 class Type(Enum):
     """
     The element type. Determines which optional fields appear on this element.
@@ -81,7 +96,7 @@ class FigureOptions(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    markdown: Optional[bool] = Field(True, title='Markdown')
+    markdown: bool | None = Field(True, title='Markdown')
 
 
 class Status(Enum):
@@ -107,12 +122,12 @@ class ParseBilling(BaseModel):
     Billing summary for one parse request.
     """
 
-    service_tier: Optional[ServiceTier] = Field(
+    service_tier: ServiceTier | None = Field(
         ...,
         description='The service tier the request ran in: `standard` or `priority`. A sync request reports `priority` (same lane, same price).',
         title='Service Tier',
     )
-    total_credits: Optional[float] = Field(
+    total_credits: float | None = Field(
         ..., description='Credits charged for this request.', title='Total Credits'
     )
 
@@ -127,7 +142,7 @@ class ParseMetadata(BaseModel):
     billing: ParseBilling = Field(
         ..., description='Billing summary: the service tier and the credits charged.'
     )
-    duration_ms: Optional[int] = Field(
+    duration_ms: int | None = Field(
         ..., description='Total processing time in milliseconds.', title='Duration Ms'
     )
     failed_pages: list[int] = Field(
@@ -135,12 +150,12 @@ class ParseMetadata(BaseModel):
         description='1-indexed page numbers that failed to parse. Empty when all pages succeed; failed pages also appear in `structure.children` with `status: failed`.',
         title='Failed Pages',
     )
-    job_id: Optional[str] = Field(
+    job_id: str | None = Field(
         ...,
         description="The parse job identifier — always server-minted and unique per submit. On the async `/jobs` route this is the id the caller polls. Correlates with the job's entry in your billing dashboard. Format: ``<service>-<26-character Crockford base32 ULID>`` matching ``^(parse|extract)-[0-9a-hjkmnp-tv-z]{26}$``. Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
         title='Job Id',
     )
-    model_version: Optional[str] = Field(
+    model_version: str | None = Field(
         ...,
         description='The exact model snapshot that parsed the document, e.g. `dpt-3-pro-20260710`.',
         title='Model Version',
@@ -150,12 +165,12 @@ class ParseMetadata(BaseModel):
         description='URL of the OpenAPI spec covering this API, for inspection and client generation.',
         title='Openapi Spec',
     )
-    output_markdown_chars: Optional[int] = Field(
+    output_markdown_chars: int | None = Field(
         ...,
         description='Number of Unicode code points in the returned `markdown` string.',
         title='Output Markdown Chars',
     )
-    page_count: Optional[int] = Field(
+    page_count: int | None = Field(
         ...,
         description='Total number of pages in the source document. Includes pages filtered out by `options.pages`; the actual returned pages are in `structure.children`.',
         title='Page Count',
@@ -193,8 +208,8 @@ class TableOptions(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    format: Optional[Format] = Field('html', title='Format')
-    markdown: Optional[bool] = Field(True, title='Markdown')
+    format: Format | None = Field('html', title='Format')
+    markdown: bool | None = Field(True, title='Markdown')
 
 
 class V2Billing(BaseModel):
@@ -203,13 +218,55 @@ class V2Billing(BaseModel):
     charged.
     """
 
-    service_tier: Optional[ServiceTier] = Field(
+    service_tier: ServiceTier | None = Field(
         None,
         description='The service tier the request ran in: `standard` or `priority`. A sync request reports `priority` (same lane, same price).',
         title='Service Tier',
     )
-    total_credits: Optional[float] = Field(
+    total_credits: float | None = Field(
         None, description='Credits charged for this request.', title='Total Credits'
+    )
+
+
+class V2BuildSchemaMetadata(BaseModel):
+    """
+    Response metadata for a v2 build-schema call (VTRA
+    ``BuildSchemaMetadata``).
+    """
+
+    billing: V2Billing | None = Field(
+        None,
+        description='Billing summary: the service tier the request ran in and the credits charged.',
+    )
+    duration_ms: int | None = Field(
+        0,
+        description='End-to-end request duration in milliseconds.',
+        title='Duration Ms',
+    )
+    filename: str | None = Field(
+        None,
+        description="Name of the first source document. Retained for v1 compatibility but NOT populated in this version — always null (the source is staged as an opaque ref, so the original name isn't carried through). Do not depend on it.",
+        title='Filename',
+    )
+    job_id: str | None = Field(
+        '',
+        description='Gateway job id (workflow id). Matches the billing row id in vision-agent.',
+        title='Job Id',
+    )
+    openapi_spec: str = Field(
+        ...,
+        description='URL of the OpenAPI spec covering this API, for inspection and client generation.',
+    )
+    org_id: str | None = Field(None, description='Organization ID.', title='Org Id')
+    version: str | None = Field(
+        None,
+        description='Model version used for generation. build-schema is version-free (no ``model``/``version`` input), so this is always null. Retained for v1 response-shape compatibility.',
+        title='Version',
+    )
+    warnings: list[BuildSchemaWarning] | None = Field(
+        None,
+        description='Structured warnings from the schema-generation process. Each is a ``{code, msg}`` object (e.g. code ``nonconformant_schema``).',
+        title='Warnings',
     )
 
 
@@ -218,11 +275,11 @@ class V2ExtractMetadata(BaseModel):
     Response metadata for a v2 extract call.
     """
 
-    billing: Optional[V2Billing] = Field(
+    billing: V2Billing | None = Field(
         None,
         description='Billing summary: the service tier the request ran in and the credits charged.',
     )
-    doc_id: Optional[str] = Field(
+    doc_id: str | None = Field(
         None,
         description='Present when the input markdown contained a ``<!-- doc_id=<id> -->`` comment (embedded by ``POST /v2/parse``). Links this extract call to the originating parse job.',
         title='Doc Id',
@@ -232,7 +289,7 @@ class V2ExtractMetadata(BaseModel):
         description='End-to-end request duration in milliseconds.',
         title='Duration Ms',
     )
-    input_markdown_chars: Optional[int] = Field(
+    input_markdown_chars: int | None = Field(
         None,
         description='Characters (Unicode code points) in the input markdown as submitted — the input basis of the credit charge.',
         title='Input Markdown Chars',
@@ -249,7 +306,7 @@ class V2ExtractMetadata(BaseModel):
         ...,
         description='URL of the OpenAPI spec covering this API, for inspection and client generation.',
     )
-    output_extraction_chars: Optional[int] = Field(
+    output_extraction_chars: int | None = Field(
         None,
         description='Characters in the serialized extraction output — the output basis of the credit charge.',
         title='Output Extraction Chars',
@@ -269,7 +326,7 @@ class V2ExtractOptions(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    strict: Optional[bool] = Field(
+    strict: bool | None = Field(
         False,
         description='When ``true``, a schema containing fields the model cannot extract fails with a validation error — HTTP 422 on the sync route, or a failed job (``status: "failed"``) on the async ``/jobs`` route. When ``false`` (default), unsupported fields are skipped and extraction continues.',
         title='Strict',
@@ -281,7 +338,7 @@ class V2GroundMetadata(BaseModel):
     Response metadata for a v2 ground call.
     """
 
-    billing: Optional[V2Billing] = Field(
+    billing: V2Billing | None = Field(
         None,
         description='Billing summary: the service tier the request ran in and the credits charged.',
     )
@@ -307,7 +364,7 @@ class V2WorkflowMetadata(BaseModel):
     (``docs/pipeline-v2-proposal.md`` → Top-level metadata).
     """
 
-    billing: Optional[V2Billing] = Field(
+    billing: V2Billing | None = Field(
         None,
         description='Billing summary: the service tier the request ran in and the credits charged.',
     )
@@ -325,14 +382,6 @@ class V2WorkflowMetadata(BaseModel):
     )
 
 
-class ValidationError(BaseModel):
-    ctx: Optional[dict[str, Any]] = Field(None, title='Context')
-    input: Optional[Any] = Field(None, title='Input')
-    loc: list[Union[str, int]] = Field(..., title='Location')
-    msg: str = Field(..., title='Message')
-    type: str = Field(..., title='Error Type')
-
-
 class WorkflowDocumentInput(BaseModel):
     """
     One declared document input in the ``inputs`` map.
@@ -345,13 +394,13 @@ class WorkflowDocumentInput(BaseModel):
       by the gateway before the workflow starts).
     """
 
-    document: Optional[str] = Field(
+    document: str | None = Field(
         None,
         description='Name of the multipart form part carrying the document bytes. The gateway resolves this to an internal ref before validation; it is not stored in the final request object.',
         examples=['report_pdf'],
         title='Document',
     )
-    document_url: Optional[str] = Field(
+    document_url: str | None = Field(
         None,
         description='URL to fetch the document from. Must be a public http(s) URL; private/loopback IPs are rejected at submit time.',
         title='Document Url',
@@ -370,30 +419,963 @@ class WorkflowStepOptions(BaseModel):
     stage. Omit entirely to use each stage's defaults.
     """
 
-    pages: Optional[list[Page1]] = Field(
+    pages: list[Page1] | None = Field(
         None,
         description='1-indexed page numbers to process. ``null`` = all pages. Values < 1 are rejected; numbers > page_count are silently ignored.',
         title='Pages',
     )
-    strict: Optional[bool] = Field(
+    strict: bool | None = Field(
         False,
         description='When ``true``, a schema containing fields the model cannot extract fails with a validation error — HTTP 422 on the sync route, or a failed job on the async ``/jobs`` route. When ``false``, unsupported fields are skipped.',
         title='Strict',
     )
 
 
+class V2ExtractPostRequest(BaseModel):
+    """
+    Input to V2ExtractOperationWorkflow.
+
+    Provide the markdown as an inline ``markdown`` string, as a multipart file
+    part named ``markdown`` (for large inputs — the gateway stages the upload
+    internally), or via a public ``markdown_url``. Exactly one source must be
+    supplied.
+    """
+
+    markdown: str | None = Field(
+        None,
+        description='Markdown string to extract from, or a multipart FILE part carrying the markdown (large inputs — uploads are staged by the gateway). Can come from any source — LandingAI parse output, a third-party parser, or hand-authored text. When the markdown was produced by ``POST /v2/parse``, it ends with a ``<!-- doc_id=<id> -->`` comment that the service reads automatically and echoes as ``metadata.doc_id``.',
+        title='Markdown',
+    )
+    markdown_url: str | None = Field(
+        None,
+        description='URL to fetch the markdown from. Must be a public http(s) URL; private/loopback IPs are rejected at submit time.',
+        title='Markdown Url',
+    )
+    model: str | None = Field(
+        None,
+        description='The version of the model to use for extraction. Use ``extract-latest`` to use the latest version.',
+        title='Model',
+    )
+    options: V2ExtractOptions | None = Field(
+        None, description='Extraction options (``strict``). Omit for defaults.'
+    )
+    schema_: dict[str, Any] = Field(
+        ...,
+        alias='schema',
+        description='JSON Schema describing the fields to extract. The schema must be an object type with a ``properties`` map of field names to their types and descriptions.',
+        examples=[
+            {
+                'properties': {
+                    'revenue': {'description': 'Q1 revenue figure', 'type': 'string'},
+                    'summary': {'description': 'Executive summary', 'type': 'string'},
+                },
+                'type': 'object',
+            }
+        ],
+        title='Schema',
+    )
+
+
+class V2ExtractPostRequest1(BaseModel):
+    markdown: str | bytes | None = None
+    markdown_url: str | None = Field(
+        None,
+        description='URL to fetch the markdown from. Must be a public http(s) URL; private/loopback IPs are rejected at submit time. JSON-serialized string in form data.',
+        title='Markdown Url',
+    )
+    model: str | None = Field(
+        None,
+        description='The version of the model to use for extraction. Use ``extract-latest`` to use the latest version. JSON-serialized string in form data.',
+        title='Model',
+    )
+    options: V2ExtractOptions | None = Field(
+        None,
+        description='Extraction options (``strict``). Omit for defaults. JSON-serialized string in form data.',
+    )
+    schema_: dict[str, Any] = Field(
+        ...,
+        alias='schema',
+        description='JSON Schema describing the fields to extract. The schema must be an object type with a ``properties`` map of field names to their types and descriptions. JSON-serialized string in form data.',
+        examples=[
+            {
+                'properties': {
+                    'revenue': {'description': 'Q1 revenue figure', 'type': 'string'},
+                    'summary': {'description': 'Executive summary', 'type': 'string'},
+                },
+                'type': 'object',
+            }
+        ],
+        title='Schema',
+    )
+
+
+class V2ExtractPostResponse(BaseModel):
+    """
+    Result returned by V2ExtractOperationWorkflow — the ``/v2/extract``
+    response body (``docs/extract-v2-proposal.md`` → Response).
+
+    ``extraction`` and ``extraction_metadata`` mirror each other structurally:
+    leaf values in ``extraction`` are replaced by ``ExtractionFieldMetadata``
+    objects in ``extraction_metadata``.
+    """
+
+    extraction: dict[str, Any] = Field(
+        ...,
+        description='Extracted values conforming to the request ``schema``.',
+        title='Extraction',
+    )
+    extraction_metadata: dict[str, Any] = Field(
+        ...,
+        description='Per-field metadata, mirroring ``extraction`` with leaf values replaced by ``{value, ranges}`` objects.',
+        title='Extraction Metadata',
+    )
+    markdown: str = Field(..., description='Echoed input markdown.', title='Markdown')
+    metadata: V2ExtractMetadata = Field(
+        ...,
+        description='Request metadata (job_id, model_version, duration_ms, doc_id, billing).',
+    )
+    schema_violation_error: str | None = Field(
+        None,
+        description='Set when ``options.strict`` is false and the schema contained fields the model could not extract — the extraction is partial.',
+        title='Schema Violation Error',
+    )
+    warnings: list[dict[str, Any]] | None = Field(
+        None,
+        description='Non-fatal warnings emitted during extraction.',
+        title='Warnings',
+    )
+
+
+class V2ExtractBuildSchemaPostRequest(BaseModel):
+    """
+    Input to V2BuildSchemaOperationWorkflow — the ``/v2/extract/build-schema``
+    request body.
+
+    Mirrors VTRA's ``BuildSchemaRequest``: generate a JSON Schema from one or
+    more source markdown documents and/or a natural-language ``prompt``, and/or
+    iterate on an existing ``schema``. At least one of ``markdowns`` /
+    ``markdown_urls`` / ``prompt`` / ``schema`` must be provided.
+    """
+
+    markdown_urls: list[str] | None = Field(
+        None,
+        description='URLs to Markdown files to analyze for schema generation.',
+        title='Markdown Urls',
+    )
+    markdowns: list[str] | None = Field(
+        None,
+        description='Markdown files or inline content strings to analyze for schema generation. Multiple documents can be provided for better schema coverage.',
+        title='Markdowns',
+    )
+    prompt: str | None = Field(
+        None,
+        description='Instructions for how to generate or modify the schema.',
+        title='Prompt',
+    )
+    schema_: str | None = Field(
+        None,
+        alias='schema',
+        description='Existing JSON schema to iterate on or refine.',
+        title='Schema',
+    )
+
+
+class V2ExtractBuildSchemaPostRequest1(BaseModel):
+    markdown_urls: list[str] | None = Field(
+        None,
+        description='URLs to Markdown files to analyze for schema generation. JSON-serialized string in form data.',
+        title='Markdown Urls',
+    )
+    markdowns: list[str | bytes] | None = Field(
+        None, description='Repeat the field for each file upload.'
+    )
+    prompt: str | None = Field(
+        None,
+        description='Instructions for how to generate or modify the schema. JSON-serialized string in form data.',
+        title='Prompt',
+    )
+    schema_: str | None = Field(
+        None,
+        alias='schema',
+        description='Existing JSON schema to iterate on or refine. JSON-serialized string in form data.',
+        title='Schema',
+    )
+
+
+class V2ExtractBuildSchemaPostResponse(BaseModel):
+    """
+    Result returned by V2BuildSchemaOperationWorkflow — the
+    ``/v2/extract/build-schema`` response body (VTRA ``BuildSchemaResponse``).
+
+    ``extraction_schema`` is the generated JSON Schema serialized as a STRING
+    (VTRA parity — the v1 field is a string, not an object).
+    """
+
+    extraction_schema: str = Field(
+        ...,
+        description='The generated JSON schema as a string.',
+        title='Extraction Schema',
+    )
+    metadata: V2BuildSchemaMetadata = Field(
+        ..., description='The metadata for the schema generation process.'
+    )
+
+
+class V2ExtractBuildSchemaJobsGetParametersQuery(BaseModel):
+    page: int | None = Field(
+        0, description='Page number (0-indexed).', ge=0, title='Page'
+    )
+    page_size: int | None = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    )
+    status: str | None = Field(
+        None, description='Filter by job status.', title='Status'
+    )
+
+
+class Status1(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+
+
+class Job(BaseModel):
+    completed_at: str | None = None
+    created_at: str | None = None
+    failure_reason: str | None = None
+    job_id: str | None = Field(
+        None,
+        description='The unique identifier for this v2-build-schema job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    model_version: str | None = None
+    status: Status1 | None = None
+
+
+class V2ExtractBuildSchemaJobsGetResponse(BaseModel):
+    has_more: bool | None = None
+    jobs: list[Job] | None = None
+    page: int | None = None
+    page_size: int | None = None
+
+
+class ServiceTier2(Enum):
+    """
+    Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.
+    """
+
+    standard = 'standard'
+    priority = 'priority'
+
+
+class V2ExtractBuildSchemaJobsPostRequest(BaseModel):
+    """
+    Input to V2BuildSchemaOperationWorkflow — the ``/v2/extract/build-schema``
+    request body.
+
+    Mirrors VTRA's ``BuildSchemaRequest``: generate a JSON Schema from one or
+    more source markdown documents and/or a natural-language ``prompt``, and/or
+    iterate on an existing ``schema``. At least one of ``markdowns`` /
+    ``markdown_urls`` / ``prompt`` / ``schema`` must be provided.
+    """
+
+    markdown_urls: list[str] | None = Field(
+        None,
+        description='URLs to Markdown files to analyze for schema generation.',
+        title='Markdown Urls',
+    )
+    markdowns: list[str] | None = Field(
+        None,
+        description='Markdown files or inline content strings to analyze for schema generation. Multiple documents can be provided for better schema coverage.',
+        title='Markdowns',
+    )
+    prompt: str | None = Field(
+        None,
+        description='Instructions for how to generate or modify the schema.',
+        title='Prompt',
+    )
+    schema_: str | None = Field(
+        None,
+        alias='schema',
+        description='Existing JSON schema to iterate on or refine.',
+        title='Schema',
+    )
+    service_tier: ServiceTier2 | None = Field(
+        None,
+        description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
+    )
+
+
+class V2ExtractBuildSchemaJobsPostRequest1(BaseModel):
+    markdown_urls: list[str] | None = Field(
+        None,
+        description='URLs to Markdown files to analyze for schema generation. JSON-serialized string in form data.',
+        title='Markdown Urls',
+    )
+    markdowns: list[str | bytes] | None = Field(
+        None, description='Repeat the field for each file upload.'
+    )
+    prompt: str | None = Field(
+        None,
+        description='Instructions for how to generate or modify the schema. JSON-serialized string in form data.',
+        title='Prompt',
+    )
+    schema_: str | None = Field(
+        None,
+        alias='schema',
+        description='Existing JSON schema to iterate on or refine. JSON-serialized string in form data.',
+        title='Schema',
+    )
+    service_tier: ServiceTier2 | None = Field(
+        None,
+        description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
+    )
+
+
+class V2ExtractBuildSchemaJobsPostResponse(BaseModel):
+    created_at: str | None = None
+    job_id: str | None = Field(
+        None,
+        description='The unique identifier for this v2-build-schema job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    status: Status1 | None = None
+
+
+class Error(BaseModel):
+    """
+    Present once status is ``failed``.
+    """
+
+    code: str | None = Field(
+        None, description='Stable error code (``internal_error`` when unmapped).'
+    )
+    message: str | None = None
+
+
+class Result(BaseModel):
+    """
+    Result returned by V2BuildSchemaOperationWorkflow — the
+    ``/v2/extract/build-schema`` response body (VTRA ``BuildSchemaResponse``).
+
+    ``extraction_schema`` is the generated JSON Schema serialized as a STRING
+    (VTRA parity — the v1 field is a string, not an object).
+    """
+
+    extraction_schema: str = Field(
+        ...,
+        description='The generated JSON schema as a string.',
+        title='Extraction Schema',
+    )
+    metadata: V2BuildSchemaMetadata = Field(
+        ..., description='The metadata for the schema generation process.'
+    )
+
+
+class V2ExtractBuildSchemaJobsJobIdGetResponse(BaseModel):
+    completed_at: str | None = Field(
+        None, description='Present once the job is terminal.'
+    )
+    created_at: str | None = None
+    error: Error | None = Field(None, description='Present once status is ``failed``.')
+    job_id: str | None = Field(
+        None,
+        description='The unique identifier for this v2-build-schema job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    progress: float | None = Field(
+        None,
+        description='Job completion as a decimal from 0 (not started) to 1 (complete). Present while ``processing``.',
+        ge=0.0,
+        le=1.0,
+    )
+    result: Result | None = Field(
+        None, description='Present once status is ``completed``.'
+    )
+    status: Status1 | None = None
+
+
+class V2ExtractJobsGetParametersQuery(BaseModel):
+    page: int | None = Field(
+        0, description='Page number (0-indexed).', ge=0, title='Page'
+    )
+    page_size: int | None = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    )
+    status: str | None = Field(
+        None, description='Filter by job status.', title='Status'
+    )
+
+
+class Job1(BaseModel):
+    completed_at: str | None = None
+    created_at: str | None = None
+    failure_reason: str | None = None
+    job_id: str | None = Field(
+        None,
+        description='The unique identifier for this v2-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    model_version: str | None = None
+    status: Status1 | None = None
+
+
+class V2ExtractJobsGetResponse(BaseModel):
+    has_more: bool | None = None
+    jobs: list[Job1] | None = None
+    page: int | None = None
+    page_size: int | None = None
+
+
+class V2ExtractJobsPostRequest(BaseModel):
+    """
+    Input to V2ExtractOperationWorkflow.
+
+    Provide the markdown as an inline ``markdown`` string, as a multipart file
+    part named ``markdown`` (for large inputs — the gateway stages the upload
+    internally), or via a public ``markdown_url``. Exactly one source must be
+    supplied.
+    """
+
+    markdown: str | None = Field(
+        None,
+        description='Markdown string to extract from, or a multipart FILE part carrying the markdown (large inputs — uploads are staged by the gateway). Can come from any source — LandingAI parse output, a third-party parser, or hand-authored text. When the markdown was produced by ``POST /v2/parse``, it ends with a ``<!-- doc_id=<id> -->`` comment that the service reads automatically and echoes as ``metadata.doc_id``.',
+        title='Markdown',
+    )
+    markdown_url: str | None = Field(
+        None,
+        description='URL to fetch the markdown from. Must be a public http(s) URL; private/loopback IPs are rejected at submit time.',
+        title='Markdown Url',
+    )
+    model: str | None = Field(
+        None,
+        description='The version of the model to use for extraction. Use ``extract-latest`` to use the latest version.',
+        title='Model',
+    )
+    options: V2ExtractOptions | None = Field(
+        None, description='Extraction options (``strict``). Omit for defaults.'
+    )
+    output_save_url: str | None = Field(
+        None,
+        description='URL to save the result to — e.g. a presigned S3 PUT URL. Async jobs only. When set, the finished result is delivered (HTTP PUT) to this URL and the completed job reports ``output_url`` instead of an inline ``result``. Must be a public http(s) URL; private/loopback IPs are rejected at submit time.',
+        title='Output Save Url',
+    )
+    schema_: dict[str, Any] = Field(
+        ...,
+        alias='schema',
+        description='JSON Schema describing the fields to extract. The schema must be an object type with a ``properties`` map of field names to their types and descriptions.',
+        examples=[
+            {
+                'properties': {
+                    'revenue': {'description': 'Q1 revenue figure', 'type': 'string'},
+                    'summary': {'description': 'Executive summary', 'type': 'string'},
+                },
+                'type': 'object',
+            }
+        ],
+        title='Schema',
+    )
+    service_tier: ServiceTier2 | None = Field(
+        None,
+        description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
+    )
+
+
+class V2ExtractJobsPostRequest1(BaseModel):
+    markdown: str | bytes | None = None
+    markdown_url: str | None = Field(
+        None,
+        description='URL to fetch the markdown from. Must be a public http(s) URL; private/loopback IPs are rejected at submit time. JSON-serialized string in form data.',
+        title='Markdown Url',
+    )
+    model: str | None = Field(
+        None,
+        description='The version of the model to use for extraction. Use ``extract-latest`` to use the latest version. JSON-serialized string in form data.',
+        title='Model',
+    )
+    options: V2ExtractOptions | None = Field(
+        None,
+        description='Extraction options (``strict``). Omit for defaults. JSON-serialized string in form data.',
+    )
+    output_save_url: str | None = Field(
+        None,
+        description='URL to save the result to — e.g. a presigned S3 PUT URL. Async jobs only. When set, the finished result is delivered (HTTP PUT) to this URL and the completed job reports ``output_url`` instead of an inline ``result``. Must be a public http(s) URL; private/loopback IPs are rejected at submit time. JSON-serialized string in form data.',
+        title='Output Save Url',
+    )
+    schema_: dict[str, Any] = Field(
+        ...,
+        alias='schema',
+        description='JSON Schema describing the fields to extract. The schema must be an object type with a ``properties`` map of field names to their types and descriptions. JSON-serialized string in form data.',
+        examples=[
+            {
+                'properties': {
+                    'revenue': {'description': 'Q1 revenue figure', 'type': 'string'},
+                    'summary': {'description': 'Executive summary', 'type': 'string'},
+                },
+                'type': 'object',
+            }
+        ],
+        title='Schema',
+    )
+    service_tier: ServiceTier2 | None = Field(
+        None,
+        description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
+    )
+
+
+class V2ExtractJobsPostResponse(BaseModel):
+    created_at: str | None = None
+    job_id: str | None = Field(
+        None,
+        description='The unique identifier for this v2-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    status: Status1 | None = None
+
+
+class Result1(BaseModel):
+    """
+    Result returned by V2ExtractOperationWorkflow — the ``/v2/extract``
+    response body (``docs/extract-v2-proposal.md`` → Response).
+
+    ``extraction`` and ``extraction_metadata`` mirror each other structurally:
+    leaf values in ``extraction`` are replaced by ``ExtractionFieldMetadata``
+    objects in ``extraction_metadata``.
+    """
+
+    extraction: dict[str, Any] = Field(
+        ...,
+        description='Extracted values conforming to the request ``schema``.',
+        title='Extraction',
+    )
+    extraction_metadata: dict[str, Any] = Field(
+        ...,
+        description='Per-field metadata, mirroring ``extraction`` with leaf values replaced by ``{value, ranges}`` objects.',
+        title='Extraction Metadata',
+    )
+    markdown: str = Field(..., description='Echoed input markdown.', title='Markdown')
+    metadata: V2ExtractMetadata = Field(
+        ...,
+        description='Request metadata (job_id, model_version, duration_ms, doc_id, billing).',
+    )
+    schema_violation_error: str | None = Field(
+        None,
+        description='Set when ``options.strict`` is false and the schema contained fields the model could not extract — the extraction is partial.',
+        title='Schema Violation Error',
+    )
+    warnings: list[dict[str, Any]] | None = Field(
+        None,
+        description='Non-fatal warnings emitted during extraction.',
+        title='Warnings',
+    )
+
+
+class V2ExtractJobsJobIdGetResponse(BaseModel):
+    completed_at: str | None = Field(
+        None, description='Present once the job is terminal.'
+    )
+    created_at: str | None = None
+    error: Error | None = Field(None, description='Present once status is ``failed``.')
+    job_id: str | None = Field(
+        None,
+        description='The unique identifier for this v2-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    output_url: str | None = Field(
+        None,
+        description='The URL the result was delivered to. Present once the job has ``completed`` and ``output_save_url`` was set, instead of inline ``result``.',
+    )
+    progress: float | None = Field(
+        None,
+        description='Job completion as a decimal from 0 (not started) to 1 (complete). Present while ``processing``.',
+        ge=0.0,
+        le=1.0,
+    )
+    result: Result1 | None = Field(
+        None,
+        description='Present once status is ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead.',
+    )
+    status: Status1 | None = None
+
+
+class V2GroundPostRequest(BaseModel):
+    """
+    Input to V2GroundOperationWorkflow — the ``/v2/ground`` request body.
+
+    A pure, stateless join: each ``extraction_metadata`` leaf's ``ranges``
+    (char offsets into the markdown both artifacts were produced from) is
+    overlapped against the ``grounding.range`` carried on every ``structure``
+    block, and the matching blocks are returned. Nothing is stored server-side,
+    so block ids in the response resolve only against the ``structure`` tree
+    supplied here — pairing an extraction with the parse result it actually
+    came from is the caller's responsibility.
+    """
+
+    extraction_metadata: dict[str, Any] = Field(
+        ...,
+        description="The ``extraction_metadata`` object returned by ``POST /v2/extract`` (or the pipeline's extract step): a tree mirroring your extraction schema whose leaves are ``{value, ranges}`` objects, where ``ranges`` are ``{start, end}`` Unicode code point offsets into the parse markdown.",
+        examples=[
+            {
+                'invoice_number': {
+                    'ranges': [{'end': 31, 'start': 13}],
+                    'value': 'INV-042',
+                }
+            }
+        ],
+        title='Extraction Metadata',
+    )
+    structure: dict[str, Any] = Field(
+        ...,
+        description='The ``structure`` tree from the parse response the extraction was produced from. Every block in the tree carries its ``grounding`` (``{page, range, box}``) inline; block ids in the response resolve against this exact tree.',
+        title='Structure',
+    )
+
+
+class V2GroundPostRequest1(BaseModel):
+    extraction_metadata: dict[str, Any] = Field(
+        ...,
+        description="The ``extraction_metadata`` object returned by ``POST /v2/extract`` (or the pipeline's extract step): a tree mirroring your extraction schema whose leaves are ``{value, ranges}`` objects, where ``ranges`` are ``{start, end}`` Unicode code point offsets into the parse markdown. JSON-serialized string in form data.",
+        examples=[
+            {
+                'invoice_number': {
+                    'ranges': [{'end': 31, 'start': 13}],
+                    'value': 'INV-042',
+                }
+            }
+        ],
+        title='Extraction Metadata',
+    )
+    structure: dict[str, Any] = Field(
+        ...,
+        description='The ``structure`` tree from the parse response the extraction was produced from. Every block in the tree carries its ``grounding`` (``{page, range, box}``) inline; block ids in the response resolve against this exact tree. JSON-serialized string in form data.',
+        title='Structure',
+    )
+
+
+class V2GroundPostResponse(BaseModel):
+    """
+    Result returned by V2GroundOperationWorkflow — the ``/v2/ground``
+    response body.
+
+    ``grounding`` MIRRORS the ``extraction_metadata`` tree: nested objects and
+    arrays keep their shape, and each ``{value, ranges}`` leaf is replaced by
+    the list of structure blocks its ranges overlap (the block-hit shape
+    documented on the field). It is NOT a flat map — a nested schema field like
+    ``issuer.name`` resolves to ``grounding["issuer"]["name"]``.
+    """
+
+    grounding: dict[str, Any] = Field(
+        ...,
+        description="A tree mirroring ``extraction_metadata``: nested objects and arrays keep their shape, and each ``{value, ranges}`` leaf is replaced by the list of blocks its ranges overlap, in reading order. Each entry carries ``block_id`` and ``type`` identifying the matched ``structure`` block, ``parent_id`` naming the enclosing block for nested blocks (table cells), and the block's own ``grounding`` object (``{page, range, box}``) verbatim. When the block itself carries ``atomic_grounding``, the entry also lists the overlapping subset as ``{index, page, range, box}`` objects, where ``index`` is the position in the block's own ``atomic_grounding`` array; ``[]`` means the block matched but no individual entry did, and the key is omitted for blocks that carry no ``atomic_grounding``. A leaf is ``null`` when its ``ranges`` was ``null`` (a synthesised value, with no supporting passage to look up) and ``[]`` when valid ranges overlapped no block (which usually indicates a mismatched extraction/structure pair).",
+        examples=[
+            {
+                'invoice_number': [
+                    {
+                        'atomic_grounding': [],
+                        'block_id': 'text-1',
+                        'grounding': {
+                            'box': {
+                                'xmax': 0.42,
+                                'xmin': 0.1,
+                                'ymax': 0.15,
+                                'ymin': 0.12,
+                            },
+                            'page': 1,
+                            'range': {'end': 31, 'start': 13},
+                        },
+                        'type': 'text',
+                    }
+                ]
+            }
+        ],
+        title='Grounding',
+    )
+    metadata: V2GroundMetadata = Field(
+        ..., description='Request metadata (job_id, duration_ms, credit_usage).'
+    )
+
+
+class V2ParseJobsGetParametersQuery(BaseModel):
+    page: int | None = Field(
+        0, description='Page number (0-indexed).', ge=0, title='Page'
+    )
+    page_size: int | None = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    )
+    status: str | None = Field(
+        None, description='Filter by job status.', title='Status'
+    )
+
+
+class Status7(Enum):
+    """
+    The job's current status: ``pending``, ``processing``, ``completed``, or ``failed``.
+    """
+
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+
+
+class Job2(BaseModel):
+    completed_at: str | None = Field(
+        None, description='ISO-8601 timestamp for when the job finished, if terminal.'
+    )
+    created_at: str | None = Field(
+        None, description='ISO-8601 timestamp for when the job was created.'
+    )
+    failure_reason: str | None = Field(
+        None,
+        description='The reason the job failed. Present only when ``status`` is ``failed``.',
+    )
+    job_id: str | None = Field(
+        None,
+        description='The unique identifier for the parse job. Format: ``<service>-<26-character Crockford base32 ULID>`` matching ``^(parse|extract)-[0-9a-hjkmnp-tv-z]{26}$``. Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    model_version: str | None = Field(
+        None, description='The model snapshot used to parse the document.'
+    )
+    status: Status7 | None = Field(
+        None,
+        description="The job's current status: ``pending``, ``processing``, ``completed``, or ``failed``.",
+    )
+
+
+class V2ParseJobsGetResponse(BaseModel):
+    has_more: bool | None = Field(
+        None,
+        description='Whether more jobs exist beyond this page; request the next ``page`` to fetch them.',
+    )
+    jobs: list[Job2] | None = Field(
+        None, description="The caller's parse jobs for this page, newest first."
+    )
+    page: int | None = Field(None, description='The 0-indexed page number.')
+    page_size: int | None = Field(None, description='Items per page.')
+
+
+class ServiceTier6(Enum):
+    """
+    Async service tier (``POST /jobs`` only). ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.
+    """
+
+    standard = 'standard'
+    priority = 'priority'
+
+
+class Status8(Enum):
+    """
+    The job's status at creation — normally ``pending`` (a just-created job that is still running is reported as ``pending``), but may already be a terminal ``completed`` / ``failed`` if the job finished before the create response was rendered.
+    """
+
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+
+
+class V2ParseJobsPostResponse(BaseModel):
+    created_at: str | None = Field(
+        ..., description='ISO-8601 timestamp for when the job was created.'
+    )
+    job_id: str = Field(
+        ...,
+        description='The unique identifier for the created parse job. Poll ``GET /v2/parse/jobs/{job_id}`` for its status and result. Format: ``<service>-<26-character Crockford base32 ULID>`` matching ``^(parse|extract)-[0-9a-hjkmnp-tv-z]{26}$``. Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    status: Status8 = Field(
+        ...,
+        description="The job's status at creation — normally ``pending`` (a just-created job that is still running is reported as ``pending``), but may already be a terminal ``completed`` / ``failed`` if the job finished before the create response was rendered.",
+    )
+
+
+class Error2(BaseModel):
+    """
+    Present once the job has ``failed`` — the failure code + message.
+    """
+
+    code: str | None = Field(None, description='Stable error code.')
+    message: str | None = None
+
+
+class Status9(Enum):
+    """
+    The job's current status: ``pending``, ``processing``, ``completed``, or ``failed``.
+    """
+
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+
+
+class V2WorkflowPostResponse(BaseModel):
+    """
+    Result returned by V2WorkflowOperationWorkflow.
+
+    ``output`` is keyed by step name (or by caller-chosen projection keys when
+    ``output`` was provided in the request). For the ``"parse-extract"`` pipeline
+    with no projection, the keys are ``"parse-extract"`` → ``{parse, extract, ground}``:
+
+    * ``output["parse-extract"]["parse"]`` — full parse response (markdown,
+      structure with per-node grounding inline, metadata).
+    * ``output["parse-extract"]["extract"]`` — extraction + ``extraction_metadata``
+      with ``{value, ranges}`` leaves.
+    * ``output["parse-extract"]["ground"]`` — a tree MIRRORING
+      ``extraction_metadata``: each ``{value, ranges}`` leaf is replaced by its
+      resolved block-hit list (``[{block_id, type, parent_id?, grounding,
+      atomic_grounding?}]`` — the same shape ``/v2/ground`` returns; see
+      ``V2GroundResult.grounding`` for the full field-level contract), or
+      ``null`` for a synthesised value. Nested objects and arrays keep their
+      shape, so ``ground.issuer.name`` parallels
+      ``extraction_metadata.issuer.name``. Resolved server-side — no
+      client-side span lookup needed.
+
+    References into the results use the ``$output.<step>.<field>...`` grammar
+    (see ``output`` field of the request).
+    """
+
+    metadata: V2WorkflowMetadata = Field(
+        ..., description='Request metadata (job_id, duration_ms, billing).'
+    )
+    output: dict[str, Any] = Field(
+        ...,
+        description='Step results keyed by step name, or a caller-defined projection. For ``parse-extract`` with no projection: ``{"parse-extract": {parse, extract, ground}}``.',
+        title='Output',
+    )
+
+
+class V2WorkflowJobsGetParametersQuery(BaseModel):
+    page: int | None = Field(
+        0, description='Page number (0-indexed).', ge=0, title='Page'
+    )
+    page_size: int | None = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    )
+    status: str | None = Field(
+        None, description='Filter by job status.', title='Status'
+    )
+
+
+class Status10(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+
+
+class Job3(BaseModel):
+    completed_at: str | None = None
+    created_at: str | None = None
+    failure_reason: str | None = None
+    job_id: str | None = Field(
+        None,
+        description='The unique identifier for this v2-workflow job. Format: ``v2-workflow-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    model_version: str | None = None
+    status: Status10 | None = None
+
+
+class V2WorkflowJobsGetResponse(BaseModel):
+    has_more: bool | None = None
+    jobs: list[Job3] | None = None
+    page: int | None = None
+    page_size: int | None = None
+
+
+class ServiceTier7(Enum):
+    """
+    Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.
+    """
+
+    standard = 'standard'
+    priority = 'priority'
+
+
+class V2WorkflowJobsPostResponse(BaseModel):
+    created_at: str | None = None
+    job_id: str | None = Field(
+        None,
+        description='The unique identifier for this v2-workflow job. Format: ``v2-workflow-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    status: Status10 | None = None
+
+
+class Error3(BaseModel):
+    """
+    Present once status is ``failed``.
+    """
+
+    code: str | None = Field(
+        None, description='Stable error code (``internal_error`` when unmapped).'
+    )
+    message: str | None = None
+
+
+class Result2(BaseModel):
+    """
+    Result returned by V2WorkflowOperationWorkflow.
+
+    ``output`` is keyed by step name (or by caller-chosen projection keys when
+    ``output`` was provided in the request). For the ``"parse-extract"`` pipeline
+    with no projection, the keys are ``"parse-extract"`` → ``{parse, extract, ground}``:
+
+    * ``output["parse-extract"]["parse"]`` — full parse response (markdown,
+      structure with per-node grounding inline, metadata).
+    * ``output["parse-extract"]["extract"]`` — extraction + ``extraction_metadata``
+      with ``{value, ranges}`` leaves.
+    * ``output["parse-extract"]["ground"]`` — a tree MIRRORING
+      ``extraction_metadata``: each ``{value, ranges}`` leaf is replaced by its
+      resolved block-hit list (``[{block_id, type, parent_id?, grounding,
+      atomic_grounding?}]`` — the same shape ``/v2/ground`` returns; see
+      ``V2GroundResult.grounding`` for the full field-level contract), or
+      ``null`` for a synthesised value. Nested objects and arrays keep their
+      shape, so ``ground.issuer.name`` parallels
+      ``extraction_metadata.issuer.name``. Resolved server-side — no
+      client-side span lookup needed.
+
+    References into the results use the ``$output.<step>.<field>...`` grammar
+    (see ``output`` field of the request).
+    """
+
+    metadata: V2WorkflowMetadata = Field(
+        ..., description='Request metadata (job_id, duration_ms, billing).'
+    )
+    output: dict[str, Any] = Field(
+        ...,
+        description='Step results keyed by step name, or a caller-defined projection. For ``parse-extract`` with no projection: ``{"parse-extract": {parse, extract, ground}}``.',
+        title='Output',
+    )
+
+
+class V2WorkflowJobsJobIdGetResponse(BaseModel):
+    completed_at: str | None = Field(
+        None, description='Present once the job is terminal.'
+    )
+    created_at: str | None = None
+    error: Error3 | None = Field(None, description='Present once status is ``failed``.')
+    job_id: str | None = Field(
+        None,
+        description='The unique identifier for this v2-workflow job. Format: ``v2-workflow-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    progress: float | None = Field(
+        None,
+        description='Job completion as a decimal from 0 (not started) to 1 (complete). Present while ``processing``.',
+        ge=0.0,
+        le=1.0,
+    )
+    result: Result2 | None = Field(
+        None, description='Present once status is ``completed``.'
+    )
+    status: Status10 | None = None
+
+
 class BlocksOptions(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    attestation: Optional[BaseElementOptions] = None
-    card: Optional[BaseElementOptions] = None
-    figure: Optional[FigureOptions] = None
-    logo: Optional[BaseElementOptions] = None
-    marginalia: Optional[BaseElementOptions] = None
-    scan_code: Optional[BaseElementOptions] = None
-    table: Optional[TableOptions] = None
-    text: Optional[BaseElementOptions] = None
+    attestation: BaseElementOptions | None = None
+    card: BaseElementOptions | None = None
+    figure: FigureOptions | None = None
+    logo: BaseElementOptions | None = None
+    marginalia: BaseElementOptions | None = None
+    scan_code: BaseElementOptions | None = None
+    table: TableOptions | None = None
+    text: BaseElementOptions | None = None
 
 
 class Grounding(BaseModel):
@@ -420,10 +1402,6 @@ class Grounding(BaseModel):
     )
 
 
-class HTTPValidationError(BaseModel):
-    detail: Optional[list[ValidationError]] = Field(None, title='Detail')
-
-
 class PrebuiltWorkflowStep(BaseModel):
     """
     A Phase 1 step: references a server-defined pipeline by name.
@@ -444,7 +1422,7 @@ class PrebuiltWorkflowStep(BaseModel):
         description='Workflow to run — doubles as the result key in ``output``. v1 only: ``"parse-extract"``.',
         title='Name',
     )
-    options: Optional[WorkflowStepOptions] = Field(
+    options: WorkflowStepOptions | None = Field(
         None, description='Parse + extract options for this step. Omit for defaults.'
     )
     schema_: dict[str, Any] = Field(
@@ -456,6 +1434,289 @@ class PrebuiltWorkflowStep(BaseModel):
     )
 
 
+class Options(BaseModel):
+    """
+    Optional object that customizes the parse. Use it to select which pages to process, adjust how content appears in the Markdown, or control how much detail the response includes. Sent as a JSON-serialized string in form data.
+    """
+
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    atomic_grounding: bool | None = Field(
+        True,
+        description='Include the fine-grained `atomic_grounding` array on leaf elements. Set `false` to omit the field entirely from every node.',
+        title='Atomic Grounding',
+    )
+    blocks: BlocksOptions | None = None
+    inline_markdown: bool | None = Field(
+        False,
+        description="Include each node's slice of the document `markdown` inline as a `markdown` field on every structure node: the document root, each page, and each element (including table cells). `atomic_grounding` entries do not carry it.",
+        title='Inline Markdown',
+    )
+    pages: list[int] | None = Field(None, title='Pages')
+    password: str | None = Field(
+        None,
+        description='Password for encrypted PDFs. Not currently supported — providing a value returns a 422 error; decrypt the file before uploading.',
+        title='Password',
+    )
+
+
+class V2ParsePostRequest(BaseModel):
+    document: bytes | None = Field(
+        None,
+        description='The file to parse. The file must be a PDF or image; see the list of [supported file types](https://docs.landing.ai/dpt3/file-types). Provide either `document` or `document_url`, not both.',
+    )
+    document_url: str | None = Field(
+        None,
+        description='A publicly accessible URL to the file to parse. The file must be a PDF or image; see the list of [supported file types](https://docs.landing.ai/dpt3/file-types). Provide either `document` or `document_url`, not both.',
+    )
+    model: str | None = Field(
+        None,
+        description='The DPT-3 model snapshot to use for this request. Accepts a dated snapshot (for example, `dpt-3-pro-20260710`), the `dpt-3-pro-latest` alias, or the bare `dpt-3-pro` family name (equivalent to `dpt-3-pro-latest`). Defaults to the latest DPT-3 Pro snapshot.',
+    )
+    options: Options | None = Field(
+        None,
+        description='Optional object that customizes the parse. Use it to select which pages to process, adjust how content appears in the Markdown, or control how much detail the response includes. Sent as a JSON-serialized string in form data.',
+        title='ParseOptions',
+    )
+
+
+class V2ParseJobsPostRequest(BaseModel):
+    document: bytes | None = Field(
+        None,
+        description='The file to parse. The file must be a PDF or image; see the list of [supported file types](https://docs.landing.ai/dpt3/file-types). Provide either `document` or `document_url`, not both.',
+    )
+    document_url: str | None = Field(
+        None,
+        description='A publicly accessible URL to the file to parse. The file must be a PDF or image; see the list of [supported file types](https://docs.landing.ai/dpt3/file-types). Provide either `document` or `document_url`, not both.',
+    )
+    model: str | None = Field(
+        None,
+        description='The DPT-3 model snapshot to use for this request. Accepts a dated snapshot (for example, `dpt-3-pro-20260710`), the `dpt-3-pro-latest` alias, or the bare `dpt-3-pro` family name (equivalent to `dpt-3-pro-latest`). Defaults to the latest DPT-3 Pro snapshot.',
+    )
+    options: Options | None = Field(
+        None,
+        description='Optional object that customizes the parse. Use it to select which pages to process, adjust how content appears in the Markdown, or control how much detail the response includes. Sent as a JSON-serialized string in form data.',
+        title='ParseOptions',
+    )
+    output_save_url: str | None = Field(
+        None,
+        description='Public URL the full response is delivered to; the API response then carries ``output_url`` instead of inline data.',
+    )
+    service_tier: ServiceTier6 | None = Field(
+        None,
+        description='Async service tier (``POST /jobs`` only). ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
+    )
+
+
+class V2WorkflowPostRequest(BaseModel):
+    """
+    Input to V2WorkflowOperationWorkflow.
+
+    Phase 1 API design (``docs/pipeline-v2-proposal.md``):
+
+    ``inputs`` declares named document sources. Each entry binds a logical name
+    to a binary upload (via ``document``, the multipart field name) or a URL
+    (via ``document_url``). The gateway stages uploads internally before the
+    workflow runs.
+
+    ``steps`` is a one-element array containing a prebuilt step. Its ``document``
+    field references an entry from ``inputs`` (``"$inputs.<name>"``). The ``schema``
+    field carries the JSON Schema for the extract stage.
+
+    ``output`` is an optional projection map. Each key maps to a ``$output.``
+    reference into the step results. Omitted → the full results tree is returned
+    under ``output``.
+
+    Example — minimal request (parse-extract, default options)::
+
+        inputs = {"report": {"document": "report_pdf"}}
+        steps  = [{"name": "parse-extract", "document": "$inputs.report",
+                   "schema": {"type": "object", "properties": {"revenue": {"type": "string"}}}}]
+        report_pdf = [binary]
+    """
+
+    inputs: dict[str, WorkflowDocumentInput] = Field(
+        ...,
+        description='Named document sources. Each key is a logical name referenced from steps as ``"$inputs.<name>"``. The gateway stages binary multipart uploads internally before the workflow runs.',
+        examples=[{'report': {'document': 'report_pdf'}}],
+        title='Inputs',
+    )
+    output: dict[str, str] | None = Field(
+        None,
+        description='Optional projection map. Keys are caller-chosen response field names; values are ``$output.<step>.<field>...`` references. Omitted → full results tree returned under ``output``.',
+        examples=[
+            {
+                'revenue': '$output.parse-extract.extract.extraction.revenue',
+                'revenue_blocks': '$output.parse-extract.ground.revenue',
+            }
+        ],
+        title='Output',
+    )
+    steps: list[PrebuiltWorkflowStep] = Field(
+        ...,
+        description='Phase 1: a single prebuilt-pipeline step (name must be ``"parse-extract"``). Its result appears in ``output`` under the step\'s name.',
+        examples=[
+            [
+                {
+                    'document': '$inputs.report',
+                    'name': 'parse-extract',
+                    'schema': {
+                        'properties': {'revenue': {'type': 'string'}},
+                        'type': 'object',
+                    },
+                }
+            ]
+        ],
+        title='Steps',
+    )
+
+
+class V2WorkflowPostRequest1(BaseModel):
+    inputs: dict[str, WorkflowDocumentInput] = Field(
+        ...,
+        description='Named document sources. Each key is a logical name referenced from steps as ``"$inputs.<name>"``. The gateway stages binary multipart uploads internally before the workflow runs. JSON-serialized string in form data.',
+        examples=[{'report': {'document': 'report_pdf'}}],
+        title='Inputs',
+    )
+    output: dict[str, str] | None = Field(
+        None,
+        description='Optional projection map. Keys are caller-chosen response field names; values are ``$output.<step>.<field>...`` references. Omitted → full results tree returned under ``output``. JSON-serialized string in form data.',
+        examples=[
+            {
+                'revenue': '$output.parse-extract.extract.extraction.revenue',
+                'revenue_blocks': '$output.parse-extract.ground.revenue',
+            }
+        ],
+        title='Output',
+    )
+    steps: list[PrebuiltWorkflowStep] = Field(
+        ...,
+        description='Phase 1: a single prebuilt-pipeline step (name must be ``"parse-extract"``). Its result appears in ``output`` under the step\'s name. JSON-serialized string in form data.',
+        examples=[
+            [
+                {
+                    'document': '$inputs.report',
+                    'name': 'parse-extract',
+                    'schema': {
+                        'properties': {'revenue': {'type': 'string'}},
+                        'type': 'object',
+                    },
+                }
+            ]
+        ],
+        title='Steps',
+    )
+
+
+class V2WorkflowJobsPostRequest(BaseModel):
+    """
+    Input to V2WorkflowOperationWorkflow.
+
+    Phase 1 API design (``docs/pipeline-v2-proposal.md``):
+
+    ``inputs`` declares named document sources. Each entry binds a logical name
+    to a binary upload (via ``document``, the multipart field name) or a URL
+    (via ``document_url``). The gateway stages uploads internally before the
+    workflow runs.
+
+    ``steps`` is a one-element array containing a prebuilt step. Its ``document``
+    field references an entry from ``inputs`` (``"$inputs.<name>"``). The ``schema``
+    field carries the JSON Schema for the extract stage.
+
+    ``output`` is an optional projection map. Each key maps to a ``$output.``
+    reference into the step results. Omitted → the full results tree is returned
+    under ``output``.
+
+    Example — minimal request (parse-extract, default options)::
+
+        inputs = {"report": {"document": "report_pdf"}}
+        steps  = [{"name": "parse-extract", "document": "$inputs.report",
+                   "schema": {"type": "object", "properties": {"revenue": {"type": "string"}}}}]
+        report_pdf = [binary]
+    """
+
+    inputs: dict[str, WorkflowDocumentInput] = Field(
+        ...,
+        description='Named document sources. Each key is a logical name referenced from steps as ``"$inputs.<name>"``. The gateway stages binary multipart uploads internally before the workflow runs.',
+        examples=[{'report': {'document': 'report_pdf'}}],
+        title='Inputs',
+    )
+    output: dict[str, str] | None = Field(
+        None,
+        description='Optional projection map. Keys are caller-chosen response field names; values are ``$output.<step>.<field>...`` references. Omitted → full results tree returned under ``output``.',
+        examples=[
+            {
+                'revenue': '$output.parse-extract.extract.extraction.revenue',
+                'revenue_blocks': '$output.parse-extract.ground.revenue',
+            }
+        ],
+        title='Output',
+    )
+    service_tier: ServiceTier7 | None = Field(
+        None,
+        description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
+    )
+    steps: list[PrebuiltWorkflowStep] = Field(
+        ...,
+        description='Phase 1: a single prebuilt-pipeline step (name must be ``"parse-extract"``). Its result appears in ``output`` under the step\'s name.',
+        examples=[
+            [
+                {
+                    'document': '$inputs.report',
+                    'name': 'parse-extract',
+                    'schema': {
+                        'properties': {'revenue': {'type': 'string'}},
+                        'type': 'object',
+                    },
+                }
+            ]
+        ],
+        title='Steps',
+    )
+
+
+class V2WorkflowJobsPostRequest1(BaseModel):
+    inputs: dict[str, WorkflowDocumentInput] = Field(
+        ...,
+        description='Named document sources. Each key is a logical name referenced from steps as ``"$inputs.<name>"``. The gateway stages binary multipart uploads internally before the workflow runs. JSON-serialized string in form data.',
+        examples=[{'report': {'document': 'report_pdf'}}],
+        title='Inputs',
+    )
+    output: dict[str, str] | None = Field(
+        None,
+        description='Optional projection map. Keys are caller-chosen response field names; values are ``$output.<step>.<field>...`` references. Omitted → full results tree returned under ``output``. JSON-serialized string in form data.',
+        examples=[
+            {
+                'revenue': '$output.parse-extract.extract.extraction.revenue',
+                'revenue_blocks': '$output.parse-extract.ground.revenue',
+            }
+        ],
+        title='Output',
+    )
+    service_tier: ServiceTier7 | None = Field(
+        None,
+        description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
+    )
+    steps: list[PrebuiltWorkflowStep] = Field(
+        ...,
+        description='Phase 1: a single prebuilt-pipeline step (name must be ``"parse-extract"``). Its result appears in ``output`` under the step\'s name. JSON-serialized string in form data.',
+        examples=[
+            [
+                {
+                    'document': '$inputs.report',
+                    'name': 'parse-extract',
+                    'schema': {
+                        'properties': {'revenue': {'type': 'string'}},
+                        'type': 'object',
+                    },
+                }
+            ]
+        ],
+        title='Steps',
+    )
+
+
 class Element(BaseModel):
     """
     Hierarchical document element. All non-page elements share this shape.
@@ -464,22 +1725,22 @@ class Element(BaseModel):
     via ``exclude_none=True`` when not set.
     """
 
-    atomic_grounding: Optional[list[Grounding]] = Field(
+    atomic_grounding: list[Grounding] | None = Field(
         None,
         description="Fine-grained grounding segments at the model's current granularity (visual lines today; finer in future versions, same schema). Present only on leaf elements — every type except `table`. `[]` only when segments are structurally impossible: `table_cell` (a cell has no finer granularity than itself) and elements whose markdown is suppressed via `blocks.<type>.markdown=false`. Any other leaf the model could not segment finer carries a single entry covering the element's full range and box. Omitted entirely when `options.atomic_grounding` is `false`.",
         title='Atomic Grounding',
     )
-    children: Optional[list[Element]] = Field(
+    children: list[Element] | None = Field(
         None,
         description='The cells (`table_cell` elements) of a `table` element. Present only when `type` is `table`.',
         title='Children',
     )
-    col: Optional[int] = Field(
+    col: int | None = Field(
         None,
         description='0-indexed column position of this cell within its parent `table`. Present only on `table_cell` elements.',
         title='Col',
     )
-    colspan: Optional[int] = Field(
+    colspan: int | None = Field(
         None,
         description='Number of columns this cell spans. `1` for unmerged cells. Present only on `table_cell` elements.',
         title='Colspan',
@@ -493,17 +1754,17 @@ class Element(BaseModel):
         description='Semantic element id, unique within the document. Format `<type>-<index>`, where `<index>` is a per-type 0-based counter assigned in reading order — `text-0` is the first text element in the document, `figure-0` the first figure, `table_cell-0` the first cell of the first table. Stable within a response but not across re-parses of the same document.',
         title='Id',
     )
-    markdown: Optional[str] = Field(
+    markdown: str | None = Field(
         None,
         description='The element\'s slice of the top-level `markdown` string (`markdown[grounding.range.start:grounding.range.end]`). `""` for zero-length ranges (e.g. blocks suppressed via `blocks.<type>.markdown=false`). Present only when `options.inline_markdown` is `true`.',
         title='Markdown',
     )
-    row: Optional[int] = Field(
+    row: int | None = Field(
         None,
         description='0-indexed row position of this cell within its parent `table`. Present only on `table_cell` elements.',
         title='Row',
     )
-    rowspan: Optional[int] = Field(
+    rowspan: int | None = Field(
         None,
         description='Number of rows this cell spans. `1` for unmerged cells. Present only on `table_cell` elements.',
         title='Rowspan',
@@ -516,7 +1777,7 @@ class Element(BaseModel):
 
 
 class Page(BaseModel):
-    children: Optional[list[Element]] = Field(
+    children: list[Element] | None = Field(
         None,
         description='The elements detected on this page, in reading order. Empty for failed pages.',
         title='Children',
@@ -525,17 +1786,17 @@ class Page(BaseModel):
         ...,
         description="The page's spatial data: `page` is the 1-indexed page number in the source document (not contiguous when `options.pages` filters out some pages); `range` covers this page's content in the top-level `markdown` string (zero-length `start == end` for failed pages); `box` is always the full page `{0, 0, 1, 1}`.",
     )
-    markdown: Optional[str] = Field(
+    markdown: str | None = Field(
         None,
         description='This page\'s slice of the top-level `markdown` string (`markdown[grounding.range.start:grounding.range.end]`). `""` for failed pages. Present only when `options.inline_markdown` is `true`.',
         title='Markdown',
     )
-    reason: Optional[str] = Field(
+    reason: str | None = Field(
         None,
         description='Failure reason. Present only when `status` is `failed`.',
         title='Reason',
     )
-    status: Optional[Status] = Field(
+    status: Status | None = Field(
         'ok',
         description='Whether this page was parsed successfully (`ok`) or failed (`failed`).',
         title='Status',
@@ -548,12 +1809,12 @@ class Page(BaseModel):
 
 
 class Document(BaseModel):
-    children: Optional[list[Page]] = Field(
+    children: list[Page] | None = Field(
         None,
         description='The pages of the document, in source order.',
         title='Children',
     )
-    markdown: Optional[str] = Field(
+    markdown: str | None = Field(
         None,
         description='The full document markdown — identical to the top-level `markdown` field, included so the structure tree is self-contained. Present only when `options.inline_markdown` is `true`.',
         title='Markdown',
@@ -584,6 +1845,39 @@ class ParseResponse(BaseModel):
     structure: Document = Field(
         ...,
         description="The document's hierarchical structure: pages and the elements detected on each page. Every node below the root carries its spatial data inline in a `grounding` object (`{page, range, box}`, normalized page coordinates); leaf elements additionally carry `atomic_grounding`.",
+    )
+
+
+class V2ParseJobsJobIdGetResponse(BaseModel):
+    completed_at: str | None = Field(
+        None, description='ISO-8601 timestamp; present once the job is terminal.'
+    )
+    created_at: str | None = Field(
+        None, description='ISO-8601 timestamp for when the job was created.'
+    )
+    error: Error2 | None = Field(
+        None,
+        description='Present once the job has ``failed`` — the failure code + message.',
+    )
+    job_id: str | None = Field(
+        None,
+        description='The unique identifier for this parse job. Format: ``<service>-<26-character Crockford base32 ULID>`` matching ``^(parse|extract)-[0-9a-hjkmnp-tv-z]{26}$``. Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    output_url: str | None = Field(
+        None,
+        description='The URL the result was delivered to. Present once the job has ``completed`` and ``output_save_url`` was set, instead of inline ``result``.',
+    )
+    progress: float | None = Field(
+        None,
+        description='Job completion as a decimal from 0 (not started) to 1 (complete). Present while ``processing``.',
+    )
+    result: ParseResponse | None = Field(
+        None,
+        description='The parse response, present once the job has ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead.',
+    )
+    status: Status9 | None = Field(
+        None,
+        description="The job's current status: ``pending``, ``processing``, ``completed``, or ``failed``.",
     )
 
 

--- a/specs/v2-aide.json
+++ b/specs/v2-aide.json
@@ -44,20 +44,6 @@
         "title": "BlocksOptions",
         "type": "object"
       },
-      "Body_stage_file_v1_files_post": {
-        "properties": {
-          "file": {
-            "contentMediaType": "application/octet-stream",
-            "title": "File",
-            "type": "string"
-          }
-        },
-        "required": [
-          "file"
-        ],
-        "title": "Body_stage_file_v1_files_post",
-        "type": "object"
-      },
       "Box": {
         "description": "Axis-aligned bounding box in normalized page coordinates.\n\nEvery value is a fraction of the page's width (`xmin`/`xmax`) or height\n(`ymin`/`ymax`) in `[0, 1]`, with at most 8 decimal places. To convert to\npixels, multiply by the dimensions of whatever raster of the page you are\ndrawing on. Coordinates are clamped and rounded at construction so the\nin-process value always equals the serialized one.",
         "properties": {
@@ -89,6 +75,27 @@
           "ymax"
         ],
         "title": "Box",
+        "type": "object"
+      },
+      "BuildSchemaWarning": {
+        "description": "A structured warning from the schema-generation process (VTRA\n``ExtractWarning``). ``code`` classifies the warning (e.g.\n``nonconformant_schema``); ``msg`` is the human-readable description.",
+        "properties": {
+          "code": {
+            "description": "The type of warning, used to translate to a status code downstream.",
+            "title": "Code",
+            "type": "string"
+          },
+          "msg": {
+            "description": "Human-readable description of the warning with more details.",
+            "title": "Msg",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "msg"
+        ],
+        "title": "BuildSchemaWarning",
         "type": "object"
       },
       "Document": {
@@ -312,19 +319,6 @@
           "box"
         ],
         "title": "Grounding",
-        "type": "object"
-      },
-      "HTTPValidationError": {
-        "properties": {
-          "detail": {
-            "items": {
-              "$ref": "#/components/schemas/ValidationError"
-            },
-            "title": "Detail",
-            "type": "array"
-          }
-        },
-        "title": "HTTPValidationError",
         "type": "object"
       },
       "Page": {
@@ -684,6 +678,90 @@
         "title": "V2Billing",
         "type": "object"
       },
+      "V2BuildSchemaMetadata": {
+        "description": "Response metadata for a v2 build-schema call (VTRA\n``BuildSchemaMetadata``).",
+        "properties": {
+          "billing": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/V2Billing"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Billing summary: the service tier the request ran in and the credits charged."
+          },
+          "duration_ms": {
+            "default": 0,
+            "description": "End-to-end request duration in milliseconds.",
+            "title": "Duration Ms",
+            "type": "integer"
+          },
+          "filename": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Name of the first source document. Retained for v1 compatibility but NOT populated in this version — always null (the source is staged as an opaque ref, so the original name isn't carried through). Do not depend on it.",
+            "title": "Filename"
+          },
+          "job_id": {
+            "default": "",
+            "description": "Gateway job id (workflow id). Matches the billing row id in vision-agent.",
+            "title": "Job Id",
+            "type": "string"
+          },
+          "openapi_spec": {
+            "description": "URL of the OpenAPI spec covering this API, for inspection and client generation.",
+            "type": "string"
+          },
+          "org_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Organization ID.",
+            "title": "Org Id"
+          },
+          "version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Model version used for generation. build-schema is version-free (no ``model``/``version`` input), so this is always null. Retained for v1 response-shape compatibility.",
+            "title": "Version"
+          },
+          "warnings": {
+            "description": "Structured warnings from the schema-generation process. Each is a ``{code, msg}`` object (e.g. code ``nonconformant_schema``).",
+            "items": {
+              "$ref": "#/components/schemas/BuildSchemaWarning"
+            },
+            "title": "Warnings",
+            "type": "array"
+          }
+        },
+        "required": [
+          "openapi_spec"
+        ],
+        "title": "V2BuildSchemaMetadata",
+        "type": "object"
+      },
       "V2ExtractMetadata": {
         "description": "Response metadata for a v2 extract call.",
         "properties": {
@@ -862,46 +940,6 @@
         "title": "V2WorkflowMetadata",
         "type": "object"
       },
-      "ValidationError": {
-        "properties": {
-          "ctx": {
-            "title": "Context",
-            "type": "object"
-          },
-          "input": {
-            "title": "Input"
-          },
-          "loc": {
-            "items": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "integer"
-                }
-              ]
-            },
-            "title": "Location",
-            "type": "array"
-          },
-          "msg": {
-            "title": "Message",
-            "type": "string"
-          },
-          "type": {
-            "title": "Error Type",
-            "type": "string"
-          }
-        },
-        "required": [
-          "loc",
-          "msg",
-          "type"
-        ],
-        "title": "ValidationError",
-        "type": "object"
-      },
       "WorkflowDocumentInput": {
         "description": "One declared document input in the ``inputs`` map.\n\nA caller supplies exactly one of ``document`` or ``document_url``:\n\n* ``document`` — name of a multipart form part carrying the raw bytes. The\n  gateway stages those bytes internally before the workflow runs.\n* ``document_url`` — public URL (SSRF-validated at submit; fetched and staged\n  by the gateway before the workflow starts).",
         "properties": {
@@ -975,52 +1013,6 @@
   },
   "openapi": "3.1.0",
   "paths": {
-    "/v1/files": {
-      "post": {
-        "description": "Stage bytes on the data plane; pass the returned ``file_ref`` in\njob inputs (the contract request types take ``*_ref`` fields).",
-        "operationId": "stage_file_v1_files_post",
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_stage_file_v1_files_post"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": {
-                    "type": "string"
-                  },
-                  "title": "Response Stage File V1 Files Post",
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Stage an input file",
-        "tags": [
-          "files"
-        ]
-      }
-    },
     "/v2/extract": {
       "post": {
         "description": "Extract structured data from a Markdown document according to a JSON schema, with character-span grounding into the source Markdown. Runs synchronously and returns the result inline.",
@@ -1268,6 +1260,674 @@
           }
         },
         "summary": "ADE Extract",
+        "tags": [
+          "Extract"
+        ]
+      }
+    },
+    "/v2/extract/build-schema": {
+      "post": {
+        "description": "Generate or edit a JSON Schema for extraction from one or more source Markdown documents and/or a natural-language prompt. Runs synchronously and returns the result inline.",
+        "operationId": "v2-build-schema_run_sync",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Input to V2BuildSchemaOperationWorkflow — the ``/v2/extract/build-schema``\nrequest body.\n\nMirrors VTRA's ``BuildSchemaRequest``: generate a JSON Schema from one or\nmore source markdown documents and/or a natural-language ``prompt``, and/or\niterate on an existing ``schema``. At least one of ``markdowns`` /\n``markdown_urls`` / ``prompt`` / ``schema`` must be provided.",
+                "properties": {
+                  "markdown_urls": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "URLs to Markdown files to analyze for schema generation.",
+                    "title": "Markdown Urls"
+                  },
+                  "markdowns": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Markdown files or inline content strings to analyze for schema generation. Multiple documents can be provided for better schema coverage.",
+                    "title": "Markdowns"
+                  },
+                  "prompt": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Instructions for how to generate or modify the schema.",
+                    "title": "Prompt"
+                  },
+                  "schema": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Existing JSON schema to iterate on or refine.",
+                    "title": "Schema"
+                  }
+                },
+                "title": "V2BuildSchemaRequest",
+                "type": "object"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "markdown_urls": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "URLs to Markdown files to analyze for schema generation. JSON-serialized string in form data.",
+                    "title": "Markdown Urls"
+                  },
+                  "markdowns": {
+                    "description": "Repeat the field for each file upload.",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "description": "Markdown files or inline content strings to analyze for schema generation. Multiple documents can be provided for better schema coverage.",
+                          "type": "string"
+                        },
+                        {
+                          "description": "File upload.",
+                          "format": "binary",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "type": "array"
+                  },
+                  "prompt": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Instructions for how to generate or modify the schema. JSON-serialized string in form data.",
+                    "title": "Prompt"
+                  },
+                  "schema": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Existing JSON schema to iterate on or refine. JSON-serialized string in form data.",
+                    "title": "Schema"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Result returned by V2BuildSchemaOperationWorkflow — the\n``/v2/extract/build-schema`` response body (VTRA ``BuildSchemaResponse``).\n\n``extraction_schema`` is the generated JSON Schema serialized as a STRING\n(VTRA parity — the v1 field is a string, not an object).",
+                  "properties": {
+                    "extraction_schema": {
+                      "description": "The generated JSON schema as a string.",
+                      "title": "Extraction Schema",
+                      "type": "string"
+                    },
+                    "metadata": {
+                      "$ref": "#/components/schemas/V2BuildSchemaMetadata",
+                      "description": "The metadata for the schema generation process."
+                    }
+                  },
+                  "required": [
+                    "extraction_schema",
+                    "metadata"
+                  ],
+                  "title": "V2BuildSchemaResponse",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "v2-build-schema result"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Extract",
+        "tags": [
+          "Extract"
+        ]
+      }
+    },
+    "/v2/extract/build-schema/jobs": {
+      "get": {
+        "description": "List your Extract jobs, newest first.",
+        "operationId": "v2-build-schema_list_jobs",
+        "parameters": [
+          {
+            "description": "Page number (0-indexed).",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Page number (0-indexed).",
+              "minimum": 0,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of items per page.",
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "description": "Number of items per page.",
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Page Size",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Filter by job status.",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by job status.",
+              "title": "Status"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "has_more": {
+                      "type": "boolean"
+                    },
+                    "jobs": {
+                      "items": {
+                        "properties": {
+                          "completed_at": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "created_at": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "failure_reason": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "job_id": {
+                            "description": "The unique identifier for this v2-build-schema job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                            "type": "string"
+                          },
+                          "model_version": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "status": {
+                            "enum": [
+                              "pending",
+                              "processing",
+                              "completed",
+                              "failed"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "page": {
+                      "type": "integer"
+                    },
+                    "page_size": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "The caller's jobs, newest first"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE List Extract Jobs",
+        "tags": [
+          "Extract"
+        ]
+      },
+      "post": {
+        "description": "Generate or edit a JSON Schema for extraction from one or more source Markdown documents and/or a natural-language prompt. Runs asynchronously and returns a job ID; use it to poll for status and retrieve the result once processing completes.",
+        "operationId": "v2-build-schema_create_job",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Input to V2BuildSchemaOperationWorkflow — the ``/v2/extract/build-schema``\nrequest body.\n\nMirrors VTRA's ``BuildSchemaRequest``: generate a JSON Schema from one or\nmore source markdown documents and/or a natural-language ``prompt``, and/or\niterate on an existing ``schema``. At least one of ``markdowns`` /\n``markdown_urls`` / ``prompt`` / ``schema`` must be provided.",
+                "properties": {
+                  "markdown_urls": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "URLs to Markdown files to analyze for schema generation.",
+                    "title": "Markdown Urls"
+                  },
+                  "markdowns": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Markdown files or inline content strings to analyze for schema generation. Multiple documents can be provided for better schema coverage.",
+                    "title": "Markdowns"
+                  },
+                  "prompt": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Instructions for how to generate or modify the schema.",
+                    "title": "Prompt"
+                  },
+                  "schema": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Existing JSON schema to iterate on or refine.",
+                    "title": "Schema"
+                  },
+                  "service_tier": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "standard",
+                          "priority"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
+                  }
+                },
+                "title": "V2BuildSchemaRequest",
+                "type": "object"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "markdown_urls": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "URLs to Markdown files to analyze for schema generation. JSON-serialized string in form data.",
+                    "title": "Markdown Urls"
+                  },
+                  "markdowns": {
+                    "description": "Repeat the field for each file upload.",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "description": "Markdown files or inline content strings to analyze for schema generation. Multiple documents can be provided for better schema coverage.",
+                          "type": "string"
+                        },
+                        {
+                          "description": "File upload.",
+                          "format": "binary",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "type": "array"
+                  },
+                  "prompt": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Instructions for how to generate or modify the schema. JSON-serialized string in form data.",
+                    "title": "Prompt"
+                  },
+                  "schema": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Existing JSON schema to iterate on or refine. JSON-serialized string in form data.",
+                    "title": "Schema"
+                  },
+                  "service_tier": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "standard",
+                          "priority"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "created_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "job_id": {
+                      "description": "The unique identifier for this v2-build-schema job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                      "type": "string"
+                    },
+                    "status": {
+                      "enum": [
+                        "pending",
+                        "processing",
+                        "completed",
+                        "failed"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Job created"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Extract Jobs",
+        "tags": [
+          "Extract"
+        ]
+      }
+    },
+    "/v2/extract/build-schema/jobs/{job_id}": {
+      "get": {
+        "description": "Get the status of an async Extract job, including its result once the job has completed.",
+        "operationId": "v2-build-schema_get_job",
+        "parameters": [
+          {
+            "description": "The identifier of the job to retrieve, as returned by the create-job request.",
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "description": "The identifier of the job to retrieve, as returned by the create-job request.",
+              "title": "Job Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "completed_at": {
+                      "description": "Present once the job is terminal.",
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "description": "Present once status is ``failed``.",
+                      "properties": {
+                        "code": {
+                          "description": "Stable error code (``internal_error`` when unmapped).",
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "job_id": {
+                      "description": "The unique identifier for this v2-build-schema job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                      "type": "string"
+                    },
+                    "progress": {
+                      "description": "Job completion as a decimal from 0 (not started) to 1 (complete). Present while ``processing``.",
+                      "maximum": 1,
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    "result": {
+                      "anyOf": [
+                        {
+                          "description": "Result returned by V2BuildSchemaOperationWorkflow — the\n``/v2/extract/build-schema`` response body (VTRA ``BuildSchemaResponse``).\n\n``extraction_schema`` is the generated JSON Schema serialized as a STRING\n(VTRA parity — the v1 field is a string, not an object).",
+                          "properties": {
+                            "extraction_schema": {
+                              "description": "The generated JSON schema as a string.",
+                              "title": "Extraction Schema",
+                              "type": "string"
+                            },
+                            "metadata": {
+                              "$ref": "#/components/schemas/V2BuildSchemaMetadata",
+                              "description": "The metadata for the schema generation process."
+                            }
+                          },
+                          "required": [
+                            "extraction_schema",
+                            "metadata"
+                          ],
+                          "title": "V2BuildSchemaResponse",
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Present once status is ``completed``."
+                    },
+                    "status": {
+                      "enum": [
+                        "pending",
+                        "processing",
+                        "completed",
+                        "failed"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Job status / result"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not found (e.g. no such job)."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Get Extract Jobs",
         "tags": [
           "Extract"
         ]
@@ -1994,417 +2654,6 @@
           }
         },
         "summary": "ADE Ground",
-        "tags": [
-          "Ground"
-        ]
-      }
-    },
-    "/v2/ground/jobs": {
-      "get": {
-        "description": "List your Ground jobs, newest first.",
-        "operationId": "v2-ground_list_jobs",
-        "parameters": [
-          {
-            "description": "Page number (0-indexed).",
-            "in": "query",
-            "name": "page",
-            "required": false,
-            "schema": {
-              "default": 0,
-              "description": "Page number (0-indexed).",
-              "minimum": 0,
-              "title": "Page",
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Number of items per page.",
-            "in": "query",
-            "name": "page_size",
-            "required": false,
-            "schema": {
-              "default": 10,
-              "description": "Number of items per page.",
-              "maximum": 100,
-              "minimum": 1,
-              "title": "Page Size",
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Filter by job status.",
-            "in": "query",
-            "name": "status",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Filter by job status.",
-              "title": "Status"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "has_more": {
-                      "type": "boolean"
-                    },
-                    "jobs": {
-                      "items": {
-                        "properties": {
-                          "completed_at": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "created_at": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "failure_reason": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "job_id": {
-                            "description": "The unique identifier for this v2-ground job. Format: ``ground-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
-                            "type": "string"
-                          },
-                          "model_version": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "status": {
-                            "enum": [
-                              "pending",
-                              "processing",
-                              "completed",
-                              "failed"
-                            ],
-                            "type": "string"
-                          }
-                        },
-                        "type": "object"
-                      },
-                      "type": "array"
-                    },
-                    "page": {
-                      "type": "integer"
-                    },
-                    "page_size": {
-                      "type": "integer"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "The caller's jobs, newest first"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Request validation failed."
-          }
-        },
-        "summary": "ADE List Ground Jobs",
-        "tags": [
-          "Ground"
-        ]
-      },
-      "post": {
-        "description": "Map extracted fields to the document blocks they were quoted from. Takes the extraction_metadata from an extract call and the structure tree from the parse call the markdown came from, and returns, for every extracted field, the overlapping blocks with their ids, page numbers, and bounding boxes. Runs asynchronously and returns a job ID; use it to poll for status and retrieve the result once processing completes.",
-        "operationId": "v2-ground_create_job",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "description": "Input to V2GroundOperationWorkflow — the ``/v2/ground`` request body.\n\nA pure, stateless join: each ``extraction_metadata`` leaf's ``ranges``\n(char offsets into the markdown both artifacts were produced from) is\noverlapped against the ``grounding.range`` carried on every ``structure``\nblock, and the matching blocks are returned. Nothing is stored server-side,\nso block ids in the response resolve only against the ``structure`` tree\nsupplied here — pairing an extraction with the parse result it actually\ncame from is the caller's responsibility.",
-                "properties": {
-                  "extraction_metadata": {
-                    "additionalProperties": true,
-                    "description": "The ``extraction_metadata`` object returned by ``POST /v2/extract`` (or the pipeline's extract step): a tree mirroring your extraction schema whose leaves are ``{value, ranges}`` objects, where ``ranges`` are ``{start, end}`` Unicode code point offsets into the parse markdown.",
-                    "example": {
-                      "invoice_number": {
-                        "ranges": [
-                          {
-                            "end": 31,
-                            "start": 13
-                          }
-                        ],
-                        "value": "INV-042"
-                      }
-                    },
-                    "title": "Extraction Metadata",
-                    "type": "object"
-                  },
-                  "structure": {
-                    "additionalProperties": true,
-                    "description": "The ``structure`` tree from the parse response the extraction was produced from. Every block in the tree carries its ``grounding`` (``{page, range, box}``) inline; block ids in the response resolve against this exact tree.",
-                    "title": "Structure",
-                    "type": "object"
-                  }
-                },
-                "required": [
-                  "extraction_metadata",
-                  "structure"
-                ],
-                "title": "V2GroundRequest",
-                "type": "object"
-              }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "properties": {
-                  "extraction_metadata": {
-                    "additionalProperties": true,
-                    "description": "The ``extraction_metadata`` object returned by ``POST /v2/extract`` (or the pipeline's extract step): a tree mirroring your extraction schema whose leaves are ``{value, ranges}`` objects, where ``ranges`` are ``{start, end}`` Unicode code point offsets into the parse markdown. JSON-serialized string in form data.",
-                    "example": {
-                      "invoice_number": {
-                        "ranges": [
-                          {
-                            "end": 31,
-                            "start": 13
-                          }
-                        ],
-                        "value": "INV-042"
-                      }
-                    },
-                    "title": "Extraction Metadata",
-                    "type": "object"
-                  },
-                  "structure": {
-                    "additionalProperties": true,
-                    "description": "The ``structure`` tree from the parse response the extraction was produced from. Every block in the tree carries its ``grounding`` (``{page, range, box}``) inline; block ids in the response resolve against this exact tree. JSON-serialized string in form data.",
-                    "title": "Structure",
-                    "type": "object"
-                  }
-                },
-                "required": [
-                  "extraction_metadata",
-                  "structure"
-                ],
-                "type": "object"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "202": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "created_at": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "job_id": {
-                      "description": "The unique identifier for this v2-ground job. Format: ``ground-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
-                      "type": "string"
-                    },
-                    "status": {
-                      "enum": [
-                        "pending",
-                        "processing",
-                        "completed",
-                        "failed"
-                      ],
-                      "type": "string"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Job created"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Request validation failed."
-          }
-        },
-        "summary": "ADE Ground Jobs",
-        "tags": [
-          "Ground"
-        ]
-      }
-    },
-    "/v2/ground/jobs/{job_id}": {
-      "get": {
-        "description": "Get the status of an async Ground job, including its result once the job has completed.",
-        "operationId": "v2-ground_get_job",
-        "parameters": [
-          {
-            "description": "The identifier of the job to retrieve, as returned by the create-job request.",
-            "in": "path",
-            "name": "job_id",
-            "required": true,
-            "schema": {
-              "description": "The identifier of the job to retrieve, as returned by the create-job request.",
-              "title": "Job Id",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "completed_at": {
-                      "description": "Present once the job is terminal.",
-                      "type": "string"
-                    },
-                    "created_at": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "error": {
-                      "description": "Present once status is ``failed``.",
-                      "properties": {
-                        "code": {
-                          "description": "Stable error code (``internal_error`` when unmapped).",
-                          "type": "string"
-                        },
-                        "message": {
-                          "type": "string"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    "job_id": {
-                      "description": "The unique identifier for this v2-ground job. Format: ``ground-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
-                      "type": "string"
-                    },
-                    "progress": {
-                      "description": "Job completion as a decimal from 0 (not started) to 1 (complete). Present while ``processing``.",
-                      "maximum": 1,
-                      "minimum": 0,
-                      "type": "number"
-                    },
-                    "result": {
-                      "anyOf": [
-                        {
-                          "description": "Result returned by V2GroundOperationWorkflow — the ``/v2/ground``\nresponse body.\n\n``grounding`` MIRRORS the ``extraction_metadata`` tree: nested objects and\narrays keep their shape, and each ``{value, ranges}`` leaf is replaced by\nthe list of structure blocks its ranges overlap (the block-hit shape\ndocumented on the field). It is NOT a flat map — a nested schema field like\n``issuer.name`` resolves to ``grounding[\"issuer\"][\"name\"]``.",
-                          "properties": {
-                            "grounding": {
-                              "additionalProperties": true,
-                              "description": "A tree mirroring ``extraction_metadata``: nested objects and arrays keep their shape, and each ``{value, ranges}`` leaf is replaced by the list of blocks its ranges overlap, in reading order. Each entry carries ``block_id`` and ``type`` identifying the matched ``structure`` block, ``parent_id`` naming the enclosing block for nested blocks (table cells), and the block's own ``grounding`` object (``{page, range, box}``) verbatim. When the block itself carries ``atomic_grounding``, the entry also lists the overlapping subset as ``{index, page, range, box}`` objects, where ``index`` is the position in the block's own ``atomic_grounding`` array; ``[]`` means the block matched but no individual entry did, and the key is omitted for blocks that carry no ``atomic_grounding``. A leaf is ``null`` when its ``ranges`` was ``null`` (a synthesised value, with no supporting passage to look up) and ``[]`` when valid ranges overlapped no block (which usually indicates a mismatched extraction/structure pair).",
-                              "example": {
-                                "invoice_number": [
-                                  {
-                                    "atomic_grounding": [],
-                                    "block_id": "text-1",
-                                    "grounding": {
-                                      "box": {
-                                        "xmax": 0.42,
-                                        "xmin": 0.1,
-                                        "ymax": 0.15,
-                                        "ymin": 0.12
-                                      },
-                                      "page": 1,
-                                      "range": {
-                                        "end": 31,
-                                        "start": 13
-                                      }
-                                    },
-                                    "type": "text"
-                                  }
-                                ]
-                              },
-                              "title": "Grounding",
-                              "type": "object"
-                            },
-                            "metadata": {
-                              "$ref": "#/components/schemas/V2GroundMetadata",
-                              "description": "Request metadata (job_id, duration_ms, credit_usage)."
-                            }
-                          },
-                          "required": [
-                            "grounding",
-                            "metadata"
-                          ],
-                          "title": "V2GroundResult",
-                          "type": "object"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "description": "Present once status is ``completed``."
-                    },
-                    "status": {
-                      "enum": [
-                        "pending",
-                        "processing",
-                        "completed",
-                        "failed"
-                      ],
-                      "type": "string"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Job status / result"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Not found (e.g. no such job)."
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Request validation failed."
-          }
-        },
-        "summary": "ADE Get Ground Jobs",
         "tags": [
           "Ground"
         ]

--- a/src/landingai_ade/resources/v2/_normalize.py
+++ b/src/landingai_ade/resources/v2/_normalize.py
@@ -6,9 +6,17 @@ from datetime import datetime
 
 from ..._types import StrBytesIntFloat
 from ..._utils import parse_datetime
-from ...types.v2 import Job, JobError, JobStatus, V2GroundResult, V2ExtractResult, V2ParseResponse
+from ...types.v2 import (
+    Job,
+    JobError,
+    JobStatus,
+    V2GroundResult,
+    V2ExtractResult,
+    V2ParseResponse,
+    V2BuildSchemaResponse,
+)
 
-__all__ = ["normalize_parse_job", "normalize_extract_job", "normalize_ground_job"]
+__all__ = ["normalize_parse_job", "normalize_extract_job", "normalize_ground_job", "normalize_build_schema_job"]
 
 
 def _ts(value: Optional[Union[datetime, StrBytesIntFloat]]) -> Optional[datetime]:
@@ -85,6 +93,33 @@ def normalize_extract_job(raw: Mapping[str, Any]) -> Job:
         err = cast(Dict[str, Any], err)
         error = JobError(code=err.get("code"), message=err.get("message"))
     elif raw.get("failure_reason"):  # extract *list* uses failure_reason
+        error = JobError(message=str(raw["failure_reason"]))
+
+    return Job(
+        job_id=str(raw["job_id"]),
+        status=status,
+        created_at=_ts(raw.get("created_at")),
+        completed_at=_ts(raw.get("completed_at")),
+        progress=_progress(raw.get("progress")),
+        result=result,
+        error=error,
+        raw=dict(raw),
+    )
+
+
+def normalize_build_schema_job(raw: Mapping[str, Any]) -> Job:
+    status = _status(raw)
+    payload = raw.get("result")
+    # Build leniently (like the sync-response path) so unexpected upstream drift
+    # doesn't fail construction.
+    result = V2BuildSchemaResponse.construct(**cast(Dict[str, Any], payload)) if isinstance(payload, Mapping) else None
+
+    error = None
+    err = raw.get("error")
+    if isinstance(err, Mapping):
+        err = cast(Dict[str, Any], err)
+        error = JobError(code=err.get("code"), message=err.get("message"))
+    elif raw.get("failure_reason"):  # build-schema *list* uses failure_reason
         error = JobError(message=str(raw["failure_reason"]))
 
     return Job(

--- a/src/landingai_ade/resources/v2/build_schema.py
+++ b/src/landingai_ade/resources/v2/build_schema.py
@@ -1,0 +1,437 @@
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, Dict, List, Type, Union, Mapping, Callable, Optional, cast
+from typing_extensions import Literal
+
+import httpx
+from pydantic import BaseModel
+
+from ._base import DEFAULT_WAIT_TIMEOUT, JobList, V2ResourceMixin, poll_until_terminal, apoll_until_terminal
+from ..._files import deepcopy_with_paths
+from ..._types import Body, Omit, Query, Headers, NotGiven, FileTypes, omit, not_given
+from ..._utils import is_given, extract_files
+from ...types.v2 import Job, V2BuildSchemaResponse
+from ._normalize import normalize_build_schema_job
+from ..._resource import SyncAPIResource, AsyncAPIResource
+from ..._exceptions import APIStatusError
+from ..._base_client import make_request_options
+from ...lib.v2_errors import raise_if_sync_timeout
+from ...lib.schema_utils import coerce_schema_to_dict
+
+__all__ = [
+    "BuildSchemaResource",
+    "AsyncBuildSchemaResource",
+    "BuildSchemaJobsResource",
+    "AsyncBuildSchemaJobsResource",
+]
+
+
+def _coerce_schema_string(schema: Union[str, Mapping[str, object], Type[BaseModel]]) -> str:
+    """Accept a pydantic model, a dict, or a JSON string; return a JSON-Schema string.
+
+    The build-schema `schema` field is sent as a string (VTRA parity), so the
+    coerced dict is re-serialized to JSON.
+    """
+    return json.dumps(coerce_schema_to_dict(schema))
+
+
+def _build_build_schema_body(
+    markdowns: object,
+    markdown_urls: object,
+    prompt: object,
+    schema: object,
+    service_tier: object = omit,
+) -> Dict[str, Any]:
+    body: Dict[str, Any] = {}
+    if markdowns is not omit and markdowns is not None:
+        body["markdowns"] = list(cast("List[Any]", markdowns))
+    if markdown_urls is not omit and markdown_urls is not None:
+        body["markdown_urls"] = list(cast(List[str], markdown_urls))
+    if prompt is not omit and prompt is not None:
+        body["prompt"] = prompt
+    if schema is not omit and schema is not None:
+        body["schema"] = _coerce_schema_string(cast(Union[str, Mapping[str, object], Type[BaseModel]], schema))
+    if not body:
+        raise ValueError(
+            "build_schema requires at least one source: provide one of "
+            "`markdowns`, `markdown_urls`, `prompt`, or `schema`."
+        )
+    if service_tier is not omit and service_tier is not None:
+        body["service_tier"] = service_tier
+    return body
+
+
+# The `markdowns` array is the only file-capable field: the spec's
+# `multipart/form-data` variant types each entry as `str | binary`.
+_MARKDOWNS_FILE_PATHS = [["markdowns", "<array>"]]
+
+
+def _markdowns_has_file(markdowns: object) -> bool:
+    """True when any `markdowns` entry is a file upload rather than inline text.
+
+    A plain `str` is inline markdown content (JSON-capable); anything else
+    (`Path`, `bytes`, a file object, or a `(filename, content)` tuple) is a file
+    upload, which forces the multipart request variant. Decided from the value's
+    type per the spec's `format: binary` markdowns item -- never from a generated
+    model's class name.
+    """
+    if not is_given(markdowns) or markdowns is None:
+        return False
+    return any(not isinstance(item, str) for item in cast("List[Any]", markdowns))
+
+
+def _prepare_build_schema_request(
+    body: Dict[str, Any],
+    markdowns: object,
+    extra_headers: Headers | None,
+) -> tuple[Dict[str, Any], Optional[List[tuple[str, FileTypes]]], Headers | None]:
+    """Route the request through multipart when `markdowns` carries a file.
+
+    Returns `(body, files, extra_headers)`. When no markdown is a file this is a
+    no-op and the caller sends JSON (`files` is `None`); otherwise the markdown
+    entries are pulled out as `multipart/form-data` parts, mirroring how
+    `parse.py` uploads its `document`.
+    """
+    if not _markdowns_has_file(markdowns):
+        return body, None, extra_headers
+    body = deepcopy_with_paths(body, _MARKDOWNS_FILE_PATHS)
+    files = extract_files(cast(Mapping[str, object], body), paths=_MARKDOWNS_FILE_PATHS)
+    extra_headers = {"Content-Type": "multipart/form-data", **(extra_headers or {})}
+    return body, files, extra_headers
+
+
+class BuildSchemaResource(V2ResourceMixin, SyncAPIResource):
+    def run(
+        self,
+        *,
+        markdowns: Optional[List[FileTypes]] | Omit = omit,
+        markdown_urls: Optional[List[str]] | Omit = omit,
+        prompt: Optional[str] | Omit = omit,
+        schema: Optional[Union[str, Mapping[str, object], Type[BaseModel]]] | Omit = omit,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> V2BuildSchemaResponse:
+        """Generate or refine a JSON Schema for extraction synchronously against the
+        V2 (ADE) `/v2/extract/build-schema` endpoint.
+
+        Sends a JSON body, or `multipart/form-data` when any `markdowns` entry is a
+        file upload (a `Path`/`bytes`/file object rather than an inline string).
+        At least one of `markdowns`, `markdown_urls`, `prompt`, or `schema` must be
+        provided. Raises `V2SyncTimeoutError` when the server times out the
+        synchronous request (HTTP 504); use the async jobs route for long-running
+        inputs in that case.
+
+        Args:
+          markdowns: Markdown files or inline content strings to analyze for schema
+              generation. Multiple documents can be provided for better coverage.
+
+          markdown_urls: URLs to Markdown files to analyze for schema generation.
+
+          prompt: Natural-language instructions for how to generate or modify the schema.
+
+          schema: An existing JSON schema to iterate on or refine. Accepts a pydantic
+              `BaseModel` subclass, a dict, or a JSON-encoded string; it is coerced to a
+              JSON Schema and sent as the `schema` string in the request body.
+
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        body = _build_build_schema_body(markdowns, markdown_urls, prompt, schema)
+        body, files, extra_headers = _prepare_build_schema_request(body, markdowns, extra_headers)
+        try:
+            return self._post(
+                self._v2_url("/v2/extract/build-schema"),
+                body=body,
+                files=files,
+                options=make_request_options(
+                    extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+                ),
+                cast_to=V2BuildSchemaResponse,
+            )
+        except APIStatusError as exc:
+            raise_if_sync_timeout(exc)
+            raise
+
+
+class AsyncBuildSchemaResource(V2ResourceMixin, AsyncAPIResource):
+    async def run(
+        self,
+        *,
+        markdowns: Optional[List[FileTypes]] | Omit = omit,
+        markdown_urls: Optional[List[str]] | Omit = omit,
+        prompt: Optional[str] | Omit = omit,
+        schema: Optional[Union[str, Mapping[str, object], Type[BaseModel]]] | Omit = omit,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> V2BuildSchemaResponse:
+        """Async mirror of `BuildSchemaResource.run`. See there for full documentation."""
+        body = _build_build_schema_body(markdowns, markdown_urls, prompt, schema)
+        body, files, extra_headers = _prepare_build_schema_request(body, markdowns, extra_headers)
+        try:
+            return await self._post(
+                self._v2_url("/v2/extract/build-schema"),
+                body=body,
+                files=files,
+                options=make_request_options(
+                    extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+                ),
+                cast_to=V2BuildSchemaResponse,
+            )
+        except APIStatusError as exc:
+            raise_if_sync_timeout(exc)
+            raise
+
+
+class BuildSchemaJobsResource(V2ResourceMixin, SyncAPIResource):
+    def create(
+        self,
+        *,
+        markdowns: Optional[List[FileTypes]] | Omit = omit,
+        markdown_urls: Optional[List[str]] | Omit = omit,
+        prompt: Optional[str] | Omit = omit,
+        schema: Optional[Union[str, Mapping[str, object], Type[BaseModel]]] | Omit = omit,
+        service_tier: Optional[Literal["standard", "priority"]] | Omit = omit,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> Job:
+        """Create an asynchronous build-schema job against `/v2/extract/build-schema/jobs`.
+
+        Returns a normalized `Job` immediately (typically `pending`). Poll for
+        completion via `.get(job_id)`, or block until the job is terminal with
+        `.wait(job_id)`.
+
+        Args:
+          markdowns: Markdown files or inline content strings to analyze for schema
+              generation. Multiple documents can be provided for better coverage.
+
+          markdown_urls: URLs to Markdown files to analyze for schema generation.
+
+          prompt: Natural-language instructions for how to generate or modify the schema.
+
+          schema: An existing JSON schema to iterate on or refine. Accepts a pydantic
+              `BaseModel` subclass, a dict, or a JSON-encoded string.
+
+          service_tier: Service tier for the job: ``standard`` or ``priority``.
+
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        body = _build_build_schema_body(markdowns, markdown_urls, prompt, schema, service_tier)
+        body, files, extra_headers = _prepare_build_schema_request(body, markdowns, extra_headers)
+        raw = self._post(
+            self._v2_url("/v2/extract/build-schema/jobs"),
+            body=body,
+            files=files,
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=cast("type[Any]", object),
+        )
+        return normalize_build_schema_job(cast(Mapping[str, Any], raw))
+
+    def get(
+        self,
+        job_id: str,
+        *,
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> Job:
+        """Get the current status of an async build-schema job by `job_id`."""
+        if not job_id:
+            raise ValueError(f"Expected a non-empty value for `job_id` but received {job_id!r}")
+        raw = self._get(
+            self._v2_url(f"/v2/extract/build-schema/jobs/{job_id}"),
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=cast("type[Any]", object),
+        )
+        return normalize_build_schema_job(cast(Mapping[str, Any], raw))
+
+    def list(
+        self,
+        *,
+        page: int | Omit = omit,
+        page_size: int | Omit = omit,
+        status: Optional[str] | Omit = omit,
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> JobList:
+        """List async build-schema jobs associated with your API key, newest first."""
+        query = {
+            key: value
+            for key, value in {"page": page, "page_size": page_size, "status": status}.items()
+            if is_given(value) and value is not None
+        }
+        raw = self._get(
+            self._v2_url("/v2/extract/build-schema/jobs"),
+            options=make_request_options(
+                extra_headers=extra_headers,
+                extra_query=extra_query,
+                extra_body=extra_body,
+                timeout=timeout,
+                query=query,
+            ),
+            cast_to=cast("type[Any]", object),
+        )
+        env = cast(Mapping[str, Any], raw)
+        jobs = [normalize_build_schema_job(cast(Mapping[str, Any], item)) for item in env.get("jobs", [])]
+        return JobList.build(jobs, has_more=env.get("has_more"), page=env.get("page"), page_size=env.get("page_size"))
+
+    def wait(
+        self,
+        job_id: str,
+        *,
+        timeout: float = DEFAULT_WAIT_TIMEOUT,
+        poll_interval: Optional[float] = None,
+        raise_on_failure: bool = False,
+        _monotonic: Optional[Callable[[], float]] = None,
+    ) -> Job:
+        """Block, polling `.get(job_id)` with backoff, until the job is terminal.
+
+        Raises `JobWaitTimeoutError` if `timeout` seconds elapse before the job
+        reaches a terminal state, and `JobFailedError` if `raise_on_failure` is
+        set and the job ends failed with an error attached. Build-schema jobs have
+        no `cancelled` status.
+
+        `_monotonic` is a test seam for injecting a fake clock; production
+        callers should leave it unset (defaults to `time.monotonic`).
+        """
+        return poll_until_terminal(
+            lambda: self.get(job_id),
+            monotonic=_monotonic or time.monotonic,
+            sleep=self._sleep,
+            timeout=timeout,
+            poll_interval=poll_interval,
+            raise_on_failure=raise_on_failure,
+        )
+
+
+class AsyncBuildSchemaJobsResource(V2ResourceMixin, AsyncAPIResource):
+    async def create(
+        self,
+        *,
+        markdowns: Optional[List[FileTypes]] | Omit = omit,
+        markdown_urls: Optional[List[str]] | Omit = omit,
+        prompt: Optional[str] | Omit = omit,
+        schema: Optional[Union[str, Mapping[str, object], Type[BaseModel]]] | Omit = omit,
+        service_tier: Optional[Literal["standard", "priority"]] | Omit = omit,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> Job:
+        """Async mirror of `BuildSchemaJobsResource.create`. See there for full documentation."""
+        body = _build_build_schema_body(markdowns, markdown_urls, prompt, schema, service_tier)
+        body, files, extra_headers = _prepare_build_schema_request(body, markdowns, extra_headers)
+        raw = await self._post(
+            self._v2_url("/v2/extract/build-schema/jobs"),
+            body=body,
+            files=files,
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=cast("type[Any]", object),
+        )
+        return normalize_build_schema_job(cast(Mapping[str, Any], raw))
+
+    async def get(
+        self,
+        job_id: str,
+        *,
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> Job:
+        """Async mirror of `BuildSchemaJobsResource.get`. See there for full documentation."""
+        if not job_id:
+            raise ValueError(f"Expected a non-empty value for `job_id` but received {job_id!r}")
+        raw = await self._get(
+            self._v2_url(f"/v2/extract/build-schema/jobs/{job_id}"),
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=cast("type[Any]", object),
+        )
+        return normalize_build_schema_job(cast(Mapping[str, Any], raw))
+
+    async def list(
+        self,
+        *,
+        page: int | Omit = omit,
+        page_size: int | Omit = omit,
+        status: Optional[str] | Omit = omit,
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> JobList:
+        """Async mirror of `BuildSchemaJobsResource.list`. See there for full documentation."""
+        query = {
+            key: value
+            for key, value in {"page": page, "page_size": page_size, "status": status}.items()
+            if is_given(value) and value is not None
+        }
+        raw = await self._get(
+            self._v2_url("/v2/extract/build-schema/jobs"),
+            options=make_request_options(
+                extra_headers=extra_headers,
+                extra_query=extra_query,
+                extra_body=extra_body,
+                timeout=timeout,
+                query=query,
+            ),
+            cast_to=cast("type[Any]", object),
+        )
+        env = cast(Mapping[str, Any], raw)
+        jobs = [normalize_build_schema_job(cast(Mapping[str, Any], item)) for item in env.get("jobs", [])]
+        return JobList.build(jobs, has_more=env.get("has_more"), page=env.get("page"), page_size=env.get("page_size"))
+
+    async def wait(
+        self,
+        job_id: str,
+        *,
+        timeout: float = DEFAULT_WAIT_TIMEOUT,
+        poll_interval: Optional[float] = None,
+        raise_on_failure: bool = False,
+        _monotonic: Optional[Callable[[], float]] = None,
+    ) -> Job:
+        """Async mirror of `BuildSchemaJobsResource.wait`; sleeps via `anyio.sleep` instead of blocking."""
+        return await apoll_until_terminal(
+            lambda: self.get(job_id),
+            monotonic=_monotonic or time.monotonic,
+            timeout=timeout,
+            poll_interval=poll_interval,
+            raise_on_failure=raise_on_failure,
+        )

--- a/src/landingai_ade/resources/v2/v2.py
+++ b/src/landingai_ade/resources/v2/v2.py
@@ -1,7 +1,7 @@
 # src/landingai_ade/resources/v2/v2.py
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Type, Union, Mapping, Optional
+from typing import TYPE_CHECKING, List, Type, Union, Mapping, Optional
 from pathlib import Path
 
 import httpx
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 from ._base import V2ResourceMixin
 from ..._types import Body, Omit, Query, Headers, NotGiven, FileTypes, omit, not_given
 from ..._compat import cached_property
-from ...types.v2 import V2GroundResult, V2ExtractResult, V2ParseResponse
+from ...types.v2 import V2GroundResult, V2ExtractResult, V2ParseResponse, V2BuildSchemaResponse
 from ..._resource import SyncAPIResource, AsyncAPIResource
 
 if TYPE_CHECKING:
@@ -18,6 +18,12 @@ if TYPE_CHECKING:
     from .parse import ParseResource, ParseJobsResource, AsyncParseResource, AsyncParseJobsResource
     from .ground import GroundResource, GroundJobsResource, AsyncGroundResource, AsyncGroundJobsResource
     from .extract import ExtractResource, ExtractJobsResource, AsyncExtractResource, AsyncExtractJobsResource
+    from .build_schema import (
+        BuildSchemaResource,
+        BuildSchemaJobsResource,
+        AsyncBuildSchemaResource,
+        AsyncBuildSchemaJobsResource,
+    )
 
 __all__ = ["V2Resource", "AsyncV2Resource"]
 
@@ -116,6 +122,44 @@ class V2Resource(SyncAPIResource, V2ResourceMixin):
             model=model,
             strict=strict,
             save_to=save_to,
+            extra_headers=extra_headers,
+            extra_query=extra_query,
+            extra_body=extra_body,
+            timeout=timeout,
+        )
+
+    @cached_property
+    def _build_schema(self) -> BuildSchemaResource:
+        from .build_schema import BuildSchemaResource
+
+        return BuildSchemaResource(self._client)
+
+    @cached_property
+    def build_schema_jobs(self) -> BuildSchemaJobsResource:
+        from .build_schema import BuildSchemaJobsResource
+
+        return BuildSchemaJobsResource(self._client)
+
+    def build_schema(
+        self,
+        *,
+        markdowns: Optional[List[FileTypes]] | Omit = omit,
+        markdown_urls: Optional[List[str]] | Omit = omit,
+        prompt: Optional[str] | Omit = omit,
+        schema: Optional[Union[str, Mapping[str, object], Type[BaseModel]]] | Omit = omit,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> V2BuildSchemaResponse:
+        """Generate or refine an extraction JSON Schema synchronously. See ``BuildSchemaResource.run`` for full documentation."""
+        return self._build_schema.run(
+            markdowns=markdowns,
+            markdown_urls=markdown_urls,
+            prompt=prompt,
+            schema=schema,
             extra_headers=extra_headers,
             extra_query=extra_query,
             extra_body=extra_body,
@@ -244,6 +288,44 @@ class AsyncV2Resource(AsyncAPIResource, V2ResourceMixin):
             model=model,
             strict=strict,
             save_to=save_to,
+            extra_headers=extra_headers,
+            extra_query=extra_query,
+            extra_body=extra_body,
+            timeout=timeout,
+        )
+
+    @cached_property
+    def _build_schema(self) -> AsyncBuildSchemaResource:
+        from .build_schema import AsyncBuildSchemaResource
+
+        return AsyncBuildSchemaResource(self._client)
+
+    @cached_property
+    def build_schema_jobs(self) -> AsyncBuildSchemaJobsResource:
+        from .build_schema import AsyncBuildSchemaJobsResource
+
+        return AsyncBuildSchemaJobsResource(self._client)
+
+    async def build_schema(
+        self,
+        *,
+        markdowns: Optional[List[FileTypes]] | Omit = omit,
+        markdown_urls: Optional[List[str]] | Omit = omit,
+        prompt: Optional[str] | Omit = omit,
+        schema: Optional[Union[str, Mapping[str, object], Type[BaseModel]]] | Omit = omit,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> V2BuildSchemaResponse:
+        """Async mirror of :meth:`V2Resource.build_schema`."""
+        return await self._build_schema.run(
+            markdowns=markdowns,
+            markdown_urls=markdown_urls,
+            prompt=prompt,
+            schema=schema,
             extra_headers=extra_headers,
             extra_query=extra_query,
             extra_body=extra_body,

--- a/src/landingai_ade/types/v2/__init__.py
+++ b/src/landingai_ade/types/v2/__init__.py
@@ -27,3 +27,9 @@ from .extract_response import (
     V2ExtractMetadata as V2ExtractMetadata,
 )
 from .file_upload_response import V2FileUploadResponse as V2FileUploadResponse
+from .build_schema_response import (
+    V2BuildSchemaBilling as V2BuildSchemaBilling,
+    V2BuildSchemaWarning as V2BuildSchemaWarning,
+    V2BuildSchemaMetadata as V2BuildSchemaMetadata,
+    V2BuildSchemaResponse as V2BuildSchemaResponse,
+)

--- a/src/landingai_ade/types/v2/build_schema_response.py
+++ b/src/landingai_ade/types/v2/build_schema_response.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from ..._models import BaseModel
+
+__all__ = [
+    "V2BuildSchemaWarning",
+    "V2BuildSchemaBilling",
+    "V2BuildSchemaMetadata",
+    "V2BuildSchemaResponse",
+]
+
+
+class V2BuildSchemaWarning(BaseModel):
+    """A structured warning from the schema-generation process (`{code, msg}`)."""
+
+    # The type of warning, used to translate to a status code downstream
+    # (e.g. `nonconformant_schema`).
+    code: Optional[str] = None
+    # Human-readable description of the warning with more details.
+    msg: Optional[str] = None
+
+
+class V2BuildSchemaBilling(BaseModel):
+    """Billing summary: the service tier the request ran in and the credits charged."""
+
+    service_tier: Optional[str] = None
+    total_credits: Optional[float] = None
+
+
+class V2BuildSchemaMetadata(BaseModel):
+    """Response metadata for a v2 build-schema call."""
+
+    # Gateway job id (workflow id). Matches the billing row id in vision-agent.
+    job_id: Optional[str] = None
+    # End-to-end request duration in milliseconds.
+    duration_ms: Optional[int] = None
+    # Name of the first source document. Retained for v1 compatibility but NOT
+    # populated in this version -- always None.
+    filename: Optional[str] = None
+    # Organization ID.
+    org_id: Optional[str] = None
+    # Model version used for generation. build-schema is version-free, so this is
+    # always None; retained for v1 response-shape compatibility.
+    version: Optional[str] = None
+    # URL of the OpenAPI spec covering this API.
+    openapi_spec: Optional[str] = None
+    billing: Optional[V2BuildSchemaBilling] = None
+    # Structured warnings from the schema-generation process, each a `{code, msg}`.
+    warnings: Optional[List[V2BuildSchemaWarning]] = None
+
+
+class V2BuildSchemaResponse(BaseModel):
+    # The generated JSON Schema serialized as a STRING (VTRA parity -- the field
+    # is a string, not an object).
+    extraction_schema: str
+    metadata: V2BuildSchemaMetadata

--- a/tests/api_resources/v2/test_async_smoke.py
+++ b/tests/api_resources/v2/test_async_smoke.py
@@ -7,7 +7,7 @@ import respx
 import pytest
 
 from landingai_ade import AsyncLandingAIADE
-from landingai_ade.types.v2 import Job, JobStatus, V2ExtractResult, V2ParseResponse
+from landingai_ade.types.v2 import Job, JobStatus, V2ExtractResult, V2ParseResponse, V2BuildSchemaResponse
 
 APIKEY = "My Apikey"
 
@@ -42,6 +42,27 @@ async def test_async_extract() -> None:
     respx.post("https://api.ade.landing.ai/v2/extract").mock(return_value=httpx.Response(200, json=EXTRACT_BODY))
     r = await client.v2.extract(schema={"type": "object"}, markdown="m")
     assert isinstance(r, V2ExtractResult)
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_async_build_schema_and_jobs() -> None:
+    client = AsyncLandingAIADE(apikey=APIKEY)
+    build_schema_body: Dict[str, Any] = {
+        "extraction_schema": '{"type": "object"}',
+        "metadata": {"job_id": "bs1", "openapi_spec": "https://x/openapi.json"},
+    }
+    respx.post("https://api.ade.landing.ai/v2/extract/build-schema").mock(
+        return_value=httpx.Response(200, json=build_schema_body)
+    )
+    r = await client.v2.build_schema(prompt="build me a schema")
+    assert isinstance(r, V2BuildSchemaResponse)
+
+    respx.post("https://api.ade.landing.ai/v2/extract/build-schema/jobs").mock(
+        return_value=httpx.Response(202, json={"job_id": "bs1", "status": "pending"})
+    )
+    job = await client.v2.build_schema_jobs.create(prompt="build me a schema")
+    assert isinstance(job, Job) and job.status is JobStatus.PENDING
 
 
 @respx.mock

--- a/tests/api_resources/v2/test_build_schema.py
+++ b/tests/api_resources/v2/test_build_schema.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+import httpx
+import respx
+import pytest
+from pydantic import Field, BaseModel
+
+from landingai_ade import LandingAIADE
+from landingai_ade.types.v2 import JobStatus, V2BuildSchemaResponse
+from landingai_ade.lib.v2_errors import V2SyncTimeoutError
+
+APIKEY = "My Apikey"
+BUILD_SCHEMA_BODY: Dict[str, Any] = {
+    "extraction_schema": json.dumps({"type": "object", "properties": {"revenue": {"type": "string"}}}),
+    "metadata": {"job_id": "bs1", "duration_ms": 5, "openapi_spec": "https://x/openapi.json"},
+}
+
+
+class Invoice(BaseModel):
+    revenue: str = Field(description="Q1 revenue")
+
+
+@respx.mock
+def test_build_schema_sync_json_body_with_pydantic_schema() -> None:
+    client = LandingAIADE(apikey=APIKEY)
+    route = respx.post("https://api.ade.landing.ai/v2/extract/build-schema").mock(
+        return_value=httpx.Response(200, json=BUILD_SCHEMA_BODY)
+    )
+    result = client.v2.build_schema(schema=Invoice, prompt="tighten it up")
+    assert isinstance(result, V2BuildSchemaResponse)
+    assert isinstance(result.extraction_schema, str)
+    assert result.metadata.job_id == "bs1"
+    req = json.loads(route.calls.last.request.content)
+    # `schema` is sent as a JSON *string* (VTRA parity), not an object.
+    assert isinstance(req["schema"], str)
+    assert json.loads(req["schema"])["properties"]["revenue"]["type"] == "string"
+    assert req["prompt"] == "tighten it up"
+    assert route.calls.last.request.headers["content-type"].startswith("application/json")
+
+
+@respx.mock
+def test_build_schema_sync_sends_markdowns_and_urls() -> None:
+    client = LandingAIADE(apikey=APIKEY)
+    route = respx.post("https://api.ade.landing.ai/v2/extract/build-schema").mock(
+        return_value=httpx.Response(200, json=BUILD_SCHEMA_BODY)
+    )
+    client.v2.build_schema(markdowns=["# a", "# b"], markdown_urls=["https://x/y.md"])
+    # All-string markdowns stay on the JSON path.
+    assert route.calls.last.request.headers["content-type"].startswith("application/json")
+    req = json.loads(route.calls.last.request.content)
+    assert req["markdowns"] == ["# a", "# b"]
+    assert req["markdown_urls"] == ["https://x/y.md"]
+
+
+@respx.mock
+def test_build_schema_sync_uploads_markdown_file_as_multipart() -> None:
+    # A file entry (here raw bytes; a Path/file object behaves the same) must
+    # switch the request to the spec's multipart/form-data variant instead of
+    # being JSON-serialized. Detected from the value type, not a model name.
+    client = LandingAIADE(apikey=APIKEY)
+    route = respx.post("https://api.ade.landing.ai/v2/extract/build-schema").mock(
+        return_value=httpx.Response(200, json=BUILD_SCHEMA_BODY)
+    )
+    result = client.v2.build_schema(markdowns=[b"# uploaded markdown"], prompt="tighten it up")
+    assert isinstance(result, V2BuildSchemaResponse)
+    req = route.calls.last.request
+    assert req.headers["content-type"].startswith("multipart/form-data")
+    # The uploaded bytes and the string form fields both ride in the multipart body.
+    assert b"# uploaded markdown" in req.content
+    assert b"tighten it up" in req.content
+
+
+@respx.mock
+def test_build_schema_requires_a_source() -> None:
+    # api.md documents the contract: provide at least one of markdowns /
+    # markdown_urls / prompt / schema. No route is registered, so a regression in
+    # the guard would fail loudly on an unmocked request.
+    client = LandingAIADE(apikey=APIKEY)
+    with pytest.raises(ValueError, match="at least one"):
+        client.v2.build_schema()
+
+
+@respx.mock
+def test_build_schema_job_create_requires_a_source() -> None:
+    client = LandingAIADE(apikey=APIKEY)
+    with pytest.raises(ValueError, match="at least one"):
+        client.v2.build_schema_jobs.create()
+
+
+@respx.mock
+def test_build_schema_sync_504() -> None:
+    client = LandingAIADE(apikey=APIKEY, max_retries=0)
+    respx.post("https://api.ade.landing.ai/v2/extract/build-schema").mock(
+        return_value=httpx.Response(504, json={"detail": "x"})
+    )
+    with pytest.raises(V2SyncTimeoutError):
+        client.v2.build_schema(prompt="x")
+
+
+@respx.mock
+def test_build_schema_sync_parses_billing_and_warnings() -> None:
+    client = LandingAIADE(apikey=APIKEY)
+    body: Dict[str, Any] = dict(BUILD_SCHEMA_BODY)
+    metadata: Dict[str, Any] = dict(BUILD_SCHEMA_BODY["metadata"])
+    metadata["billing"] = {"service_tier": "priority", "total_credits": 3.5}
+    metadata["warnings"] = [{"code": "nonconformant_schema", "msg": "heads up"}]
+    body["metadata"] = metadata
+    respx.post("https://api.ade.landing.ai/v2/extract/build-schema").mock(return_value=httpx.Response(200, json=body))
+    result = client.v2.build_schema(prompt="x")
+    assert result.metadata.billing is not None
+    assert result.metadata.billing.service_tier == "priority"
+    assert result.metadata.warnings is not None
+    assert result.metadata.warnings[0].code == "nonconformant_schema"
+    assert result.metadata.warnings[0].msg == "heads up"
+
+
+@respx.mock
+def test_build_schema_job_create_and_get() -> None:
+    client = LandingAIADE(apikey=APIKEY)
+    respx.post("https://api.ade.landing.ai/v2/extract/build-schema/jobs").mock(
+        return_value=httpx.Response(
+            202, json={"job_id": "bs1", "status": "pending", "created_at": "2026-01-01T00:00:00Z"}
+        )
+    )
+    job = client.v2.build_schema_jobs.create(prompt="x", service_tier="priority")
+    assert job.job_id == "bs1" and job.status is JobStatus.PENDING
+
+    respx.get("https://api.ade.landing.ai/v2/extract/build-schema/jobs/bs1").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "job_id": "bs1",
+                "status": "completed",
+                "created_at": "2026-01-01T00:00:00Z",
+                "completed_at": "2026-01-01T00:00:09Z",
+                "result": BUILD_SCHEMA_BODY,
+            },
+        )
+    )
+    done = client.v2.build_schema_jobs.get("bs1")
+    assert done.status is JobStatus.COMPLETED
+    assert isinstance(done.result, V2BuildSchemaResponse)
+    assert done.result.metadata.job_id == "bs1"
+
+
+def test_build_schema_job_create_sends_service_tier(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = LandingAIADE(apikey=APIKEY)
+    captured: Dict[str, Any] = {}
+
+    def fake_post(path: str, *, cast_to: Any, body: Any = None, options: Any = None, **kwargs: Any) -> Any:  # noqa: ARG001
+        captured["body"] = body
+        return {"job_id": "bs1", "status": "pending"}
+
+    monkeypatch.setattr(client.v2.build_schema_jobs, "_post", fake_post)
+    client.v2.build_schema_jobs.create(prompt="x", service_tier="priority")
+    assert captured["body"]["service_tier"] == "priority"
+
+
+@respx.mock
+def test_build_schema_job_get_failed_maps_error_object() -> None:
+    client = LandingAIADE(apikey=APIKEY)
+    respx.get("https://api.ade.landing.ai/v2/extract/build-schema/jobs/bs2").mock(
+        return_value=httpx.Response(
+            200, json={"job_id": "bs2", "status": "failed", "error": {"code": "internal_error", "message": "boom"}}
+        )
+    )
+    job = client.v2.build_schema_jobs.get("bs2")
+    assert job.status is JobStatus.FAILED and job.error is not None and job.error.code == "internal_error"
+
+
+@respx.mock
+def test_build_schema_job_get_empty_job_id_raises() -> None:
+    client = LandingAIADE(apikey=APIKEY)
+    with pytest.raises(ValueError):
+        client.v2.build_schema_jobs.get("")
+
+
+@respx.mock
+def test_build_schema_job_list_carries_envelope() -> None:
+    client = LandingAIADE(apikey=APIKEY)
+    respx.get("https://api.ade.landing.ai/v2/extract/build-schema/jobs").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "jobs": [{"job_id": "bs1", "status": "completed", "failure_reason": None}],
+                "page": 0,
+                "page_size": 10,
+                "has_more": True,
+            },
+        )
+    )
+    jobs = client.v2.build_schema_jobs.list()
+    assert len(jobs) == 1 and jobs[0].job_id == "bs1" and jobs[0].status is JobStatus.COMPLETED
+    assert jobs.has_more is True
+    assert jobs.page == 0
+    assert jobs.page_size == 10

--- a/tests/contract/test_v2_smoke.py
+++ b/tests/contract/test_v2_smoke.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import json
 from typing import Iterator
 from pathlib import Path
 
@@ -8,7 +9,13 @@ import pytest
 from pydantic import Field, BaseModel
 
 from landingai_ade import LandingAIADE
-from landingai_ade.types.v2 import JobStatus, V2GroundResult, V2ExtractResult, V2ParseResponse
+from landingai_ade.types.v2 import (
+    JobStatus,
+    V2GroundResult,
+    V2ExtractResult,
+    V2ParseResponse,
+    V2BuildSchemaResponse,
+)
 
 pytestmark = pytest.mark.contract
 
@@ -55,6 +62,25 @@ def test_extract_jobs(staging_client: LandingAIADE) -> None:
     done = staging_client.v2.extract_jobs.wait(job.job_id, timeout=300)
     assert done.status is JobStatus.COMPLETED
     assert isinstance(done.result, V2ExtractResult)
+
+
+def test_build_schema_sync(staging_client: LandingAIADE) -> None:
+    res = staging_client.v2.build_schema(
+        markdowns=[SAMPLE_MARKDOWN], prompt="Extract the total revenue and the company name."
+    )
+    assert isinstance(res, V2BuildSchemaResponse)
+    # The generated schema is a JSON Schema serialized as a string.
+    assert isinstance(res.extraction_schema, str)
+    assert isinstance(json.loads(res.extraction_schema), dict)
+
+
+def test_build_schema_jobs(staging_client: LandingAIADE) -> None:
+    job = staging_client.v2.build_schema_jobs.create(
+        markdowns=[SAMPLE_MARKDOWN], prompt="Extract the total revenue and the company name."
+    )
+    done = staging_client.v2.build_schema_jobs.wait(job.job_id, timeout=300)
+    assert done.status is JobStatus.COMPLETED
+    assert isinstance(done.result, V2BuildSchemaResponse)
 
 
 def test_parse_sync(staging_client: LandingAIADE) -> None:

--- a/tests/test_v2_normalize.py
+++ b/tests/test_v2_normalize.py
@@ -4,11 +4,18 @@ from __future__ import annotations
 from typing import Any, Dict
 from datetime import datetime, timezone
 
-from landingai_ade.types.v2 import JobStatus, V2GroundResult, V2ExtractResult, V2ParseResponse
+from landingai_ade.types.v2 import (
+    JobStatus,
+    V2GroundResult,
+    V2ExtractResult,
+    V2ParseResponse,
+    V2BuildSchemaResponse,
+)
 from landingai_ade.resources.v2._normalize import (
     normalize_parse_job,
     normalize_ground_job,
     normalize_extract_job,
+    normalize_build_schema_job,
 )
 
 
@@ -108,6 +115,44 @@ def test_normalize_extract_job_error_object() -> None:
     job = normalize_extract_job(raw)
     assert job.status is JobStatus.FAILED
     assert job.error is not None and job.error.code == "internal_error"
+
+
+def test_normalize_build_schema_job_iso_and_result() -> None:
+    raw: Dict[str, Any] = {
+        "job_id": "extract-bs1",
+        "status": "completed",
+        "created_at": "2026-01-02T03:04:05Z",
+        "completed_at": "2026-01-02T03:04:09Z",
+        "result": {
+            "extraction_schema": '{"type": "object"}',
+            "metadata": {"job_id": "extract-bs1", "duration_ms": 10, "openapi_spec": "https://x/openapi.json"},
+        },
+    }
+    job = normalize_build_schema_job(raw)
+    assert job.status is JobStatus.COMPLETED
+    assert job.created_at is not None and job.created_at.year == 2026
+    assert job.completed_at is not None
+    assert isinstance(job.result, V2BuildSchemaResponse)
+    assert job.result.extraction_schema == '{"type": "object"}'
+    assert job.result.metadata.job_id == "extract-bs1"
+
+
+def test_normalize_build_schema_job_failure_reason() -> None:
+    # The build-schema *list* envelope reports failures via `failure_reason`.
+    raw = {"job_id": "extract-bs2", "status": "failed", "failure_reason": "bad markdown"}
+    job = normalize_build_schema_job(raw)
+    assert job.status is JobStatus.FAILED
+    assert job.error is not None and job.error.message == "bad markdown"
+    assert job.result is None
+
+
+def test_normalize_build_schema_job_minimal_create_envelope_defaults_to_pending() -> None:
+    raw = {"job_id": "extract-bs3"}
+    job = normalize_build_schema_job(raw)
+    assert job.job_id == "extract-bs3"
+    assert job.status is JobStatus.PENDING
+    assert job.result is None
+    assert job.error is None
 
 
 def test_normalize_parse_job_minimal_create_envelope_defaults_to_pending() -> None:

--- a/tests/test_v2_types.py
+++ b/tests/test_v2_types.py
@@ -11,6 +11,7 @@ from landingai_ade.types.v2 import (
     V2ExtractResult,
     V2ParseResponse,
     V2FileUploadResponse,
+    V2BuildSchemaResponse,
 )
 
 
@@ -271,3 +272,32 @@ def test_ground_result_retains_unknown_fields() -> None:
 
 def test_file_upload_response() -> None:
     assert V2FileUploadResponse(file_ref="abc").file_ref == "abc"
+
+
+def test_build_schema_response_parses_nested_metadata() -> None:
+    r = V2BuildSchemaResponse(
+        extraction_schema='{"type": "object"}',
+        metadata={  # type: ignore[arg-type]
+            "job_id": "extract-bs1",
+            "duration_ms": 5,
+            "openapi_spec": "https://x/openapi.json",
+            "billing": {"service_tier": "priority", "total_credits": 2.0},
+            "warnings": [{"code": "nonconformant_schema", "msg": "heads up"}],
+        },
+    )
+    assert r.extraction_schema == '{"type": "object"}'
+    assert r.metadata.job_id == "extract-bs1"
+    assert r.metadata.billing is not None and r.metadata.billing.service_tier == "priority"
+    assert r.metadata.warnings is not None and r.metadata.warnings[0].code == "nonconformant_schema"
+    # `filename` / `version` are v1-compat fields, absent here → None.
+    assert r.metadata.filename is None
+    assert r.metadata.version is None
+
+
+def test_build_schema_response_retains_unknown_fields() -> None:
+    r = V2BuildSchemaResponse(
+        extraction_schema="{}",
+        metadata={"job_id": "b"},  # type: ignore[arg-type]
+        surprise=1,  # type: ignore[call-arg]
+    )
+    assert r.to_dict()["surprise"] == 1


### PR DESCRIPTION
**Throwaway test PR — do not merge.** Validates the spec-sync pipeline change on branch `ci/spec-sync-request-body-models` by reproducing #126 with the improved reference + prompt.

- **Commit 1 (mechanical):** V2 spec snapshot + `_generated/v2_models.py` regenerated with `--openapi-scopes schemas paths parameters`, so the reference now includes request-body models — incl. the multipart file variant (`markdowns: list[str | bytes]`).
- **Commit 2 (AI wiring):** #126's `client.v2.build_schema` wiring + the correction the richer reference drives — `markdowns` accepts file uploads and routes through `multipart/form-data` when any entry is a file, keeping JSON for all-string inputs. Multipart is decided from the value type, never from a generated class-name suffix.

Diff vs #126: `git diff origin/spec-sync/v2..origin/test/spec-sync-v2-regen`. Local tests pass (107, incl. a new multipart upload test).