### PR TITLE
ci(spec-sync): scope the 504 timeout remediation per endpoint in the wiring prompt

### DIFF
--- a/.github/workflows/spec-sync.yml
+++ b/.github/workflows/spec-sync.yml
@@ -406,7 +406,11 @@ jobs:
 
             - Add a resource module under src/landingai_ade/resources/v2/ with a sync run()
               (multipart or JSON per the spec; route a 504 through
-              lib/v2_errors.raise_if_sync_timeout) and, for an async route, a *JobsResource with
+              lib/v2_errors.raise_if_sync_timeout, passing THIS endpoint's own async route as
+              `jobs_resource` — e.g. `build_schema_jobs` — so the 504 remediation names the right
+              resource; never let it fall back to a parse/extract-specific message, and if the
+              helper doesn't yet take a per-endpoint `jobs_resource`, extend it rather than reusing
+              another endpoint's wording) and, for an async route, a *JobsResource with
               create / get / wait / list. Decide multipart-vs-JSON from the SPEC, not from a
               generated class name: an operation accepts file uploads iff its
               `requestBody.content` has a `multipart/form-data` variant with a property (or array

--- a/.github/workflows/spec-sync.yml
+++ b/.github/workflows/spec-sync.yml
@@ -409,8 +409,9 @@ jobs:
               lib/v2_errors.raise_if_sync_timeout, passing THIS endpoint's own async route as
               `jobs_resource` — e.g. `build_schema_jobs` — so the 504 remediation names the right
               resource; never let it fall back to a parse/extract-specific message, and if the
-              helper doesn't yet take a per-endpoint `jobs_resource`, extend it rather than reusing
-              another endpoint's wording) and, for an async route, a *JobsResource with
+              helper doesn't yet take a per-endpoint `jobs_resource`, extend it and update every
+              existing call site and helper test to pass its own matching resource rather than
+              reusing another endpoint's wording) and, for an async route, a *JobsResource with
               create / get / wait / list. Decide multipart-vs-JSON from the SPEC, not from a
               generated class name: an operation accepts file uploads iff its
               `requestBody.content` has a `multipart/form-data` variant with a property (or array


### PR DESCRIPTION
Follow-up to the Copilot finding on #129: a wired \`build_schema\` reused \`raise_if_sync_timeout\`, whose message was hardcoded to \`parse_jobs\`/\`extract_jobs\` — so a build-schema 504 pointed users at the wrong async resource.

The code fix lands on the #129 branch (parameterize \`raise_if_sync_timeout\` with a required \`jobs_resource\`, pass the correct route at every call site). This PR is the **pipeline** half: the V2 wiring prompt now tells the AI to pass the endpoint's own \`jobs_resource\` (and extend the helper if it lacks per-endpoint support), so future regenerations don't reintroduce the wrong remediation.

Prompt-only change; no SDK surface touched.