### PR TITLE
feat: send structured User-Agent and X-Source: sdk on every request

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,19 @@ parsed = response.parse()  # the object the method would have returned
 
 Use `.with_streaming_response` instead (also v1 methods only) to stream the body rather than reading it eagerly; it requires a context manager and reads the body only when you call `.read()`, `.text()`, `.json()`, `.iter_bytes()`, `.iter_text()`, `.iter_lines()`, or `.parse()`. These return [`APIResponse`](https://github.com/landing-ai/ade-python/tree/main/src/landingai_ade/_response.py) (or `AsyncAPIResponse`) objects.
 
+### Client identity headers
+
+Every request carries two headers that let the platform attribute traffic to this SDK:
+
+- `X-Source: sdk`
+- a structured `User-Agent`, e.g. `ade-python/1.15.0 (Darwin arm64) python/3.12 httpx/0.28.1`
+
+You can override either one by passing the same header (using its canonical name) via `default_headers` on the client or `extra_headers` on a call — a caller-supplied value replaces the SDK default. Leave them untouched to keep accurate attribution.
+
+```python
+client = LandingAIADE(default_headers={"User-Agent": "my-app/1.0"})  # replaces the SDK User-Agent
+```
+
 ### Nested params and file uploads
 
 Nested request parameters are [TypedDicts](https://docs.python.org/3/library/typing.html#typing.TypedDict); responses are [Pydantic models](https://docs.pydantic.dev) with helpers such as `model.to_json()` and `model.to_dict()`. File upload parameters accept `bytes`, a [`PathLike`](https://docs.python.org/3/library/os.html#os.PathLike) instance, or a `(filename, contents, media type)` tuple; the async client reads `PathLike` files asynchronously.

--- a/src/landingai_ade/_base_client.py
+++ b/src/landingai_ade/_base_client.py
@@ -87,6 +87,7 @@ from ._exceptions import (
     APIResponseValidationError,
 )
 from ._utils._json import openapi_dumps
+from ._client_identity import SOURCE, build_user_agent
 
 log: logging.Logger = logging.getLogger(__name__)
 
@@ -674,6 +675,10 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
             "Accept": "application/json",
             "Content-Type": "application/json",
             "User-Agent": self.user_agent,
+            # Client identity (landing-ai/ade-python#131). Placed before
+            # `_custom_headers` so a caller-supplied `default_headers` / per-request
+            # `extra_headers` value can still override the identity if it must.
+            "X-Source": SOURCE,
             **self.platform_headers(),
             **self.auth_headers,
             **self._custom_headers,
@@ -698,7 +703,11 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
 
     @property
     def user_agent(self) -> str:
-        return f"{self.__class__.__name__}/Python {self._version}"
+        # Structured client identity (landing-ai/ade-python#131), built in the
+        # single seam in `_client_identity`. Thread the version the client
+        # already holds so it isn't re-derived from an importlib.metadata scan
+        # on every request.
+        return build_user_agent(self._version)
 
     @property
     def base_url(self) -> URL:

--- a/src/landingai_ade/_client_identity.py
+++ b/src/landingai_ade/_client_identity.py
@@ -42,10 +42,12 @@ PRODUCT = "ade-python"
 
 _PLACEHOLDER = "unknown"
 
-# Anything that would break the parser's ``(<os> <arch>)`` shape — whitespace,
-# ``;``/``,``, or parentheses — is collapsed into a single ``-`` so an exotic
-# platform never splits into extra "words".
-_UNSAFE_COMMENT_CHARS = re.compile(r"[\s;,()]+")
+# Keep only visible-ASCII token characters; collapse everything else into a
+# single ``-``. This covers what would break the parser's ``(<os> <arch>)`` shape
+# (whitespace, ``;``/``,``, parentheses) AND non-ASCII values (which httpx cannot
+# latin-1 encode — an exotic ``platform.machine()`` like ``arm<emoji>`` would
+# otherwise raise while building the header and fail the request).
+_UNSAFE_COMMENT_CHARS = re.compile(r"[^A-Za-z0-9._:+-]+")
 
 
 def _product_version() -> str:

--- a/src/landingai_ade/_client_identity.py
+++ b/src/landingai_ade/_client_identity.py
@@ -1,0 +1,118 @@
+"""Client identity attached to every API request (see landing-ai/ade-python#131).
+
+The AIDE gateway relays these two headers into the recorded ``inference_history``
+row so SDK traffic is distinguishable from raw API calls:
+
+* ``X-Source: sdk`` — names the row's ``source`` column (the coarse API/CLI/SDK
+  split; ``sdk`` is already live in the platform's ``InferenceHistorySource`` enum).
+* a structured ``User-Agent`` — parsed platform-side into os/arch/runtime
+  dimensions.
+
+The User-Agent grammar is shared with ade-cli (its ``docs/user-agent.md``) and
+parsed by vision-agent-ui's ``parseUserAgent.ts``::
+
+    ade-python/<version> (<os> <arch>) python/<major.minor> httpx/<version>
+
+The parser owns the grammar, not the vocabulary: the leading token identifies
+the product, the parenthesized comment fills os/arch *only* when it is exactly
+two space-separated words with no ``;``/``,``, and every remaining ``key/value``
+token is captured generically — so appending further tokens later needs no
+platform change.
+
+This is the single construction seam for the identity string. Nothing here may
+raise: identity must never fail a request, so every lookup degrades to a
+placeholder rather than propagating an error.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import platform
+
+import httpx
+
+# ``X-Source`` value: the coarse API/CLI/SDK split.
+SOURCE = "sdk"
+
+# Leading product token. ``ade-python`` (not the distribution name
+# ``landingai-ade``) keeps the two SDKs separable — the TypeScript SDK uses
+# ``ade-typescript``.
+PRODUCT = "ade-python"
+
+_PLACEHOLDER = "unknown"
+
+# Anything that would break the parser's ``(<os> <arch>)`` shape — whitespace,
+# ``;``/``,``, or parentheses — is collapsed into a single ``-`` so an exotic
+# platform never splits into extra "words".
+_UNSAFE_COMMENT_CHARS = re.compile(r"[\s;,()]+")
+
+
+def _product_version() -> str:
+    # The installed distribution version is the true runtime version; fall back
+    # to the packaged ``__version__``, then to a placeholder — never raise.
+    try:
+        from importlib.metadata import version
+
+        return version("landingai-ade")
+    except Exception:
+        pass
+    try:
+        from ._version import __version__
+
+        return __version__
+    except Exception:
+        return _PLACEHOLDER
+
+
+def _clean_comment_word(value: str) -> str:
+    return _UNSAFE_COMMENT_CHARS.sub("-", value).strip("-") or _PLACEHOLDER
+
+
+def _platform_comment() -> str:
+    # `(<os> <arch>)`: exactly two space-separated words, no `;`/`,`, so the
+    # platform parser fills the os/arch dimensions. Uses the raw
+    # platform.system()/machine() values (e.g. "Darwin", "arm64") to match
+    # ade-cli, so a given machine reports identical os/arch across the CLI and
+    # this SDK.
+    try:
+        os_name = _clean_comment_word(platform.system())
+    except Exception:
+        os_name = _PLACEHOLDER
+    try:
+        arch = _clean_comment_word(platform.machine())
+    except Exception:
+        arch = _PLACEHOLDER
+    return f"({os_name} {arch})"
+
+
+def _python_token() -> str:
+    # sys.version_info is always present and its fields are ints, so this can't
+    # raise — no guard needed (unlike the platform/httpx lookups below).
+    return f"python/{sys.version_info.major}.{sys.version_info.minor}"
+
+
+def _httpx_token() -> str:
+    try:
+        return f"httpx/{httpx.__version__}"
+    except Exception:
+        return f"httpx/{_PLACEHOLDER}"
+
+
+def build_user_agent(version: str | None = None) -> str:
+    """Build the structured ``User-Agent``. Never raises.
+
+    ``version`` lets the caller pass the SDK version it already holds — the
+    client threads its ``self._version`` here (mirroring ``platform_headers``)
+    so the process-constant identity isn't rebuilt from an
+    ``importlib.metadata`` distribution scan on every request. When omitted, the
+    installed distribution version is resolved as a fallback.
+    """
+    return " ".join(
+        [
+            f"{PRODUCT}/{version or _product_version()}",
+            _platform_comment(),
+            _python_token(),
+            _httpx_token(),
+        ]
+    )

--- a/tests/test_client_identity.py
+++ b/tests/test_client_identity.py
@@ -105,6 +105,18 @@ class TestNeverFailsARequest:
         assert ua.startswith("ade-python/")
         assert "unknown" in ua[ua.index("(") : ua.index(")") + 1]
 
+    def test_non_ascii_platform_value_stays_ascii(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # An exotic platform.machine() must not smuggle non-latin-1 bytes into the
+        # header (httpx would raise while encoding and fail the request).
+        import platform
+
+        monkeypatch.setattr(platform, "machine", lambda: "arm\U0001f525")  # arm🔥
+        ua = build_user_agent()
+        ua.encode("ascii")  # must not raise
+        comment = ua[ua.index("(") + 1 : ua.index(")")]
+        assert len(comment.split()) == 2
+        assert "arm" in comment
+
     def test_missing_package_metadata_degrades(self, monkeypatch: pytest.MonkeyPatch) -> None:
         import importlib.metadata as metadata
 

--- a/tests/test_client_identity.py
+++ b/tests/test_client_identity.py
@@ -1,0 +1,147 @@
+"""Client identity headers — User-Agent + X-Source (landing-ai/ade-python#131)."""
+
+from __future__ import annotations
+
+import re
+
+import httpx
+import pytest
+
+from landingai_ade import LandingAIADE, AsyncLandingAIADE
+from landingai_ade._models import FinalRequestOptions
+from landingai_ade._client_identity import SOURCE, build_user_agent
+
+base_url = "http://127.0.0.1:4010"
+apikey = "My Apikey"
+
+# Endpoints spanning the operations called out in the issue: parse, extract,
+# and job submit (POST .../jobs) + poll (GET .../jobs/{id}).
+ENDPOINTS = [
+    ("post", "/v1/ade/parse"),
+    ("post", "/v1/ade/extract"),
+    ("post", "/v1/ade/parse/jobs"),  # submit
+    ("get", "/v1/ade/parse/jobs/job_123"),  # poll
+    ("post", "/v1/ade/extract/jobs"),  # submit
+    ("get", "/v1/ade/extract/jobs/job_123"),  # poll
+]
+
+
+def _parse_user_agent(raw: str) -> dict[str, str]:
+    """Faithful port of vision-agent-ui's ``parseUserAgent.ts``.
+
+    Kept in lockstep with the platform parser so these tests fail if our
+    User-Agent ever drifts from the shape the platform actually reads.
+    """
+    analysis: dict[str, str] = {"raw": raw}
+
+    comment = re.search(r"\(([^)]*)\)", raw)
+    if comment:
+        parts = comment.group(1).strip().split()
+        if len(parts) == 2 and not re.search(r"[;,]", comment.group(1)):
+            analysis["os"] = parts[0]
+            analysis["arch"] = parts[1]
+        tokens = raw.replace(comment.group(0), " ").strip().split()
+    else:
+        tokens = raw.strip().split()
+
+    product, *rest = tokens
+    product_match = re.match(r"^([^/]+)/(.+)$", product)
+    if product_match:
+        analysis["product"] = product_match.group(1)
+        analysis["productVersion"] = product_match.group(2)
+
+    reserved = {"raw", "product", "productVersion", "os", "arch"}
+    for token in rest:
+        slash = token.find("/")
+        if slash <= 0 or slash == len(token) - 1:
+            continue
+        key = token[:slash]
+        if key in reserved or key in analysis:
+            continue
+        analysis[key] = token[slash + 1 :]
+
+    return analysis
+
+
+class TestUserAgentGrammar:
+    def test_parses_per_platform_contract(self) -> None:
+        parsed = _parse_user_agent(build_user_agent())
+        assert parsed["product"] == "ade-python"
+        assert parsed.get("productVersion")
+        # The `(<os> <arch>)` comment fills both dimensions.
+        assert parsed.get("os") and parsed.get("arch")
+        # Runtime + HTTP-lib key/value tokens.
+        assert parsed.get("python")
+        assert parsed.get("httpx")
+
+    def test_platform_comment_shape(self) -> None:
+        # Exactly two space-separated words, no `;`/`,` — the only shape the
+        # platform parser reads into os/arch.
+        comment = re.search(r"\(([^)]*)\)", build_user_agent())
+        assert comment is not None
+        inner = comment.group(1)
+        assert ";" not in inner and "," not in inner
+        assert len(inner.split()) == 2
+
+    def test_python_token_is_major_minor(self) -> None:
+        assert re.search(r"\bpython/\d+\.\d+\b", build_user_agent())
+
+
+class TestSource:
+    def test_source_constant(self) -> None:
+        assert SOURCE == "sdk"
+
+
+class TestNeverFailsARequest:
+    @pytest.mark.parametrize("target", ["system", "machine"])
+    def test_platform_detection_failure_degrades(self, monkeypatch: pytest.MonkeyPatch, target: str) -> None:
+        import platform
+
+        def boom(*_args: object, **_kwargs: object) -> object:
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(platform, target, boom)
+        ua = build_user_agent()
+        assert ua.startswith("ade-python/")
+        assert "unknown" in ua[ua.index("(") : ua.index(")") + 1]
+
+    def test_missing_package_metadata_degrades(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import importlib.metadata as metadata
+
+        def boom(_name: str) -> str:
+            raise metadata.PackageNotFoundError(_name)
+
+        monkeypatch.setattr(metadata, "version", boom)
+        # Falls back to the packaged __version__ rather than raising.
+        assert build_user_agent().startswith("ade-python/")
+
+
+def _request_headers(client: LandingAIADE | AsyncLandingAIADE, method: str, url: str) -> httpx.Headers:
+    return client._build_request(FinalRequestOptions(method=method, url=url)).headers
+
+
+class TestEveryRequestCarriesIdentity:
+    @pytest.mark.parametrize("method,url", ENDPOINTS)
+    def test_sync(self, client: LandingAIADE, method: str, url: str) -> None:
+        headers = _request_headers(client, method, url)
+        assert headers["x-source"] == "sdk"
+        assert headers["user-agent"].startswith("ade-python/")
+
+    @pytest.mark.parametrize("method,url", ENDPOINTS)
+    async def test_async(self, async_client: AsyncLandingAIADE, method: str, url: str) -> None:
+        headers = _request_headers(async_client, method, url)
+        assert headers["x-source"] == "sdk"
+        assert headers["user-agent"].startswith("ade-python/")
+
+
+class TestCallerOverride:
+    def test_default_is_the_sdk_identity(self) -> None:
+        with LandingAIADE(base_url=base_url, apikey=apikey) as client:
+            assert client.default_headers["X-Source"] == "sdk"
+            assert str(client.default_headers["User-Agent"]).startswith("ade-python/")
+
+    def test_caller_supplied_header_overrides(self) -> None:
+        # A caller who explicitly supplies the header wins (documented override);
+        # the identity is never *silently* dropped for callers who don't.
+        with LandingAIADE(base_url=base_url, apikey=apikey, default_headers={"X-Source": "myapp"}) as client:
+            assert client.default_headers["X-Source"] == "myapp"


### PR DESCRIPTION
Attach client identity to every SDK request so the platform can attribute traffic to the SDK.

- `_client_identity.build_user_agent()` — single seam; `ade-python/<ver> (<os> <arch>) python/<maj.min> httpx/<ver>` (ade-cli's grammar). Never raises; degrades to placeholders.
- `X-Source: sdk` + the UA wired into `BaseClient` → both sync/async clients and all resources (v1, v2 jobs submit + poll) carry them.
- Version threaded from `self._version` (no per-request `importlib.metadata` scan).

Fixes:
- Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)