### PR TITLE
fix: do not dump both class and class_ on Split

### DIFF
--- a/src/landingai_ade/_models.py
+++ b/src/landingai_ade/_models.py
@@ -105,9 +105,12 @@ class BaseModel(pydantic.BaseModel):
 
         class Config(pydantic.BaseConfig):  # pyright: ignore[reportDeprecated]
             extra: Any = pydantic.Extra.allow  # type: ignore
+            allow_population_by_field_name = True
     else:
         model_config: ClassVar[ConfigDict] = ConfigDict(
-            extra="allow", defer_build=coerce_boolean(os.environ.get("DEFER_PYDANTIC_BUILD", "true"))
+            extra="allow",
+            populate_by_name=True,
+            defer_build=coerce_boolean(os.environ.get("DEFER_PYDANTIC_BUILD", "true")),
         )
 
     def to_dict(
@@ -210,6 +213,7 @@ class BaseModel(pydantic.BaseModel):
         if _fields_set is None:
             _fields_set = set()
 
+        consumed_keys: set[str] = set()
         model_fields = get_model_fields(__cls)
         for name, field in model_fields.items():
             key = field.alias
@@ -219,14 +223,16 @@ class BaseModel(pydantic.BaseModel):
             if key in values:
                 fields_values[name] = _construct_field(value=values[key], field=field, key=key)
                 _fields_set.add(name)
+                consumed_keys.add(key)
             else:
                 fields_values[name] = field_get_default(field)
 
         extra_field_type = _get_extra_fields_type(__cls)
 
+        # Aliases that populated a field must not also be stored as extras (e.g. class vs class_).
         _extra = {}
         for key, value in values.items():
-            if key not in model_fields:
+            if key not in model_fields and key not in consumed_keys:
                 parsed = construct_type(value=value, type_=extra_field_type) if extra_field_type is not None else value
 
                 if PYDANTIC_V1:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -180,6 +180,27 @@ def test_aliases() -> None:
     assert cast(Any, m.my_field) == {"hello": False}
 
 
+def test_aliased_field_not_duplicated_in_dump() -> None:
+    class Model(BaseModel):
+        my_field: int = Field(alias="myField")
+
+    m = Model.construct(myField=1)
+    dumped = m.model_dump()
+    assert dumped == {"my_field": 1}
+    assert json.loads(m.model_dump_json()) == {"my_field": 1}
+
+    dumped_alias = m.model_dump(by_alias=True)
+    assert dumped_alias == {"myField": 1}
+
+
+def test_validate_aliased_field_by_name() -> None:
+    class Model(BaseModel):
+        my_field: int = Field(alias="myField")
+
+    m = parse_obj(Model, {"my_field": 1})
+    assert m.my_field == 1
+
+
 def test_repr() -> None:
     model = BasicModel(foo="bar")
     assert str(model) == "BasicModel(foo='bar')"

--- a/tests/test_parse_response.py
+++ b/tests/test_parse_response.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+from landingai_ade._compat import PYDANTIC_V1, parse_obj
+from landingai_ade.types.parse_response import ParseResponse
+
+
+def _payload(*, class_key: str) -> Dict[str, Any]:
+    return {
+        "chunks": [
+            {
+                "id": "c1",
+                "grounding": {"box": {"left": 0.0, "top": 0.0, "right": 1.0, "bottom": 1.0}, "page": 0},
+                "markdown": "hello",
+                "type": "text",
+            }
+        ],
+        "markdown": "hello",
+        "metadata": {
+            "credit_usage": 1.0,
+            "duration_ms": 1,
+            "filename": "doc.pdf",
+            "job_id": "j1",
+            "page_count": 1,
+        },
+        "splits": [
+            {
+                class_key: "full",
+                "identifier": "full",
+                "markdown": "hello",
+                "pages": [0],
+                "chunks": ["c1"],
+            }
+        ],
+    }
+
+
+def _validate(raw: str) -> ParseResponse:
+    if PYDANTIC_V1:
+        return parse_obj(ParseResponse, json.loads(raw))
+    return ParseResponse.model_validate_json(raw)
+
+
+def test_parse_response_dump_does_not_duplicate_class_keys() -> None:
+    response = ParseResponse.construct(**_payload(class_key="class"))
+    dumped = json.loads(response.model_dump_json(indent=2))
+    split = dumped["splits"][0]
+    assert not ("class" in split and "class_" in split)
+    assert split.get("class") == "full" or split.get("class_") == "full"
+
+
+def test_parse_response_validates_json_with_class_underscore() -> None:
+    parsed = _validate(json.dumps(_payload(class_key="class_")))
+    assert parsed.splits[0].class_ == "full"
+
+
+def test_parse_response_round_trips_dumped_json() -> None:
+    response = ParseResponse.construct(**_payload(class_key="class"))
+    raw = response.model_dump_json(indent=2)
+    parsed = _validate(raw)
+    assert parsed.splits[0].class_ == "full"


### PR DESCRIPTION
Fixes #64.

`Split.class_` is aliased to `class`. `construct()` treated the alias as an extra field, so `model_dump_json()` emitted both `class` and `class_`. JSON that only had `class_` then failed validation unless `by_name=True`.

Consumed aliases are no longer stored as extras, and models can also be populated by field name. Dump now emits one key; dumped JSON round-trips.

## Test plan
- [x] `pytest tests/test_parse_response.py tests/test_models.py::test_aliased_field_not_duplicated_in_dump tests/test_models.py::test_validate_aliased_field_by_name`