### PR TITLE
spec-sync(v2): split & classify support (sync + async jobs)

### DIFF
--- a/api.md
+++ b/api.md
@@ -77,6 +77,9 @@ from landingai_ade.types.v2 import (
     V2BuildSchemaMetadata,
     V2BuildSchemaResponse,
     V2BuildSchemaWarning,
+    V2ClassificationItem,
+    V2ClassifyMetadata,
+    V2ClassifyResponse,
     V2ExtractBilling,
     V2ExtractMetadata,
     V2ExtractResult,
@@ -96,14 +99,19 @@ from landingai_ade.types.v2 import (
     V2ParseRange,
     V2ParseResponse,
     V2ParseStructure,
+    V2Split,
+    V2SplitMetadata,
+    V2SplitResponse,
 )
 ```
 
-- <code><a href="./src/landingai_ade/types/v2/job.py">Job</a></code> -- unified job shape: `job_id`, `status` (<code><a href="./src/landingai_ade/types/v2/job.py">JobStatus</a></code>: `pending` / `processing` / `completed` / `failed` / `cancelled`), `created_at`, `completed_at`, `progress`, `result` (a `V2ParseResponse` for parse jobs, a `V2ExtractResult` for extract jobs, a `V2BuildSchemaResponse` for build-schema jobs, or `None` until completion), `error` (<code><a href="./src/landingai_ade/types/v2/job.py">JobError</a></code>), `metadata` (the result's metadata receipt as a `dict`, populated top-level only when `output_save_url` was set and the result was delivered to `output_url` instead of inline; `None` otherwise, since inline jobs carry it on `result.metadata`), `raw` (the full original envelope as a `dict`), and the `.is_terminal` property.
+- <code><a href="./src/landingai_ade/types/v2/job.py">Job</a></code> -- unified job shape: `job_id`, `status` (<code><a href="./src/landingai_ade/types/v2/job.py">JobStatus</a></code>: `pending` / `processing` / `completed` / `failed` / `cancelled`), `created_at`, `completed_at`, `progress`, `result` (a `V2ParseResponse` for parse jobs, a `V2ExtractResult` for extract jobs, a `V2ClassifyResponse` for classify jobs, a `V2BuildSchemaResponse` for build-schema jobs, or `None` until completion), `error` (<code><a href="./src/landingai_ade/types/v2/job.py">JobError</a></code>), `metadata` (the result's metadata receipt as a `dict`, populated top-level only when `output_save_url` was set and the result was delivered to `output_url` instead of inline; `None` otherwise, since inline jobs carry it on `result.metadata`), `raw` (the full original envelope as a `dict`), and the `.is_terminal` property.
 - <code><a href="./src/landingai_ade/types/v2/parse_response.py">V2ParseResponse</a></code> -- `markdown`, `structure`, `grounding`, `metadata` (<code><a href="./src/landingai_ade/types/v2/parse_response.py">V2ParseMetadata</a></code>, which nests <code><a href="./src/landingai_ade/types/v2/parse_response.py">V2ParseBilling</a></code> and carries `output_markdown_chars`, `range_units`, and `openapi_spec`). `structure` is a typed <code><a href="./src/landingai_ade/types/v2/parse_response.py">V2ParseStructure</a></code> tree (`document` → <code><a href="./src/landingai_ade/types/v2/parse_response.py">V2ParsePage</a></code> → <code><a href="./src/landingai_ade/types/v2/parse_response.py">V2ParseElement</a></code>); each node below the root carries its spatial data inline in a <code><a href="./src/landingai_ade/types/v2/parse_response.py">V2ParseNodeGrounding</a></code> (`page`, <code><a href="./src/landingai_ade/types/v2/parse_response.py">V2ParseRange</a></code>, <code><a href="./src/landingai_ade/types/v2/parse_response.py">V2ParseBox</a></code>, normalized page coordinates, and an optional `confidence` in `[0, 1]` that is present only on word-granularity `atomic_grounding` segments (`dpt-3-verity`), where it is the lowest per-character OCR confidence in the word, and that is `None` on node-level grounding and on line-granularity models (`dpt-3-pro`)), and leaf elements additionally carry an `atomic_grounding` list. With `options.inline_markdown`, each node also carries its `markdown` slice. The legacy top-level `grounding` tree (<code><a href="./src/landingai_ade/types/v2/parse_response.py">V2ParseGrounding</a></code> → `V2ParseGroundingPage` → `V2ParseGroundingElement` → `V2ParseGroundingEntry`) is retained for older gateway responses. Element `type`/page `status` are permissive strings and unknown keys are retained.
 - <code><a href="./src/landingai_ade/types/v2/extract_response.py">V2ExtractResult</a></code> -- `extraction`, `extraction_metadata`, `markdown`, `output_ref`, `schema_violation_error` (set when `strict=False` and the schema had unextractable fields), `warnings`, and `metadata` (<code><a href="./src/landingai_ade/types/v2/extract_response.py">V2ExtractMetadata</a></code>, which carries `model_version`, `input_markdown_chars`, `output_extraction_chars`, `range_units`, `openapi_spec`, and nests <code><a href="./src/landingai_ade/types/v2/extract_response.py">V2ExtractBilling</a></code>).
 - <code><a href="./src/landingai_ade/types/v2/build_schema_response.py">V2BuildSchemaResponse</a></code> -- `extraction_schema` (the generated JSON Schema serialized as a string) and `metadata` (<code><a href="./src/landingai_ade/types/v2/build_schema_response.py">V2BuildSchemaMetadata</a></code>: `job_id`, `duration_ms`, `openapi_spec`, `filename`/`org_id`/`version` (retained for compatibility), a `warnings` list of <code><a href="./src/landingai_ade/types/v2/build_schema_response.py">V2BuildSchemaWarning</a></code> (`code`, `msg`), and nested <code><a href="./src/landingai_ade/types/v2/build_schema_response.py">V2BuildSchemaBilling</a></code>).
 - <code><a href="./src/landingai_ade/types/v2/ground_response.py">V2GroundResult</a></code> -- `grounding` (a tree mirroring the input `extraction_metadata`, each `{value, ranges}` leaf replaced by the list of `structure` blocks its ranges overlap) and `metadata` (<code><a href="./src/landingai_ade/types/v2/ground_response.py">V2GroundMetadata</a></code>: `job_id`, `duration_ms`, `openapi_spec`, and nested <code><a href="./src/landingai_ade/types/v2/ground_response.py">V2GroundBilling</a></code>).
+- <code><a href="./src/landingai_ade/types/v2/classify_response.py">V2ClassifyResponse</a></code> -- `classification` (one <code><a href="./src/landingai_ade/types/v2/classify_response.py">V2ClassificationItem</a></code> per page, in page order: `class_` (the predicted label, or `"unknown"`; aliased from the wire key `class`), `page` (0-indexed), `reason`, and an optional `suggested_class`) and `metadata` (<code><a href="./src/landingai_ade/types/v2/classify_response.py">V2ClassifyMetadata</a></code>: `page_count`, `duration_ms`, `openapi_spec`, and the optional `credit_usage`, `filename`, `job_id`, `org_id`, `version`).
+- <code><a href="./src/landingai_ade/types/v2/split_response.py">V2SplitResponse</a></code> -- `splits` (a list of <code><a href="./src/landingai_ade/types/v2/split_response.py">V2Split</a></code> segments, in page order: `classification`, `markdowns` (per-page Markdown), `pages` (0-indexed), and an optional `identifier`) and `metadata` (<code><a href="./src/landingai_ade/types/v2/split_response.py">V2SplitMetadata</a></code>: `credit_usage`, `duration_ms`, `filename`, `job_id`, `page_count`, `version`, and optional `org_id`).
 
 Methods:
 
@@ -132,6 +140,21 @@ Methods:
 - <code title="post /v2/ground">client.v2.<a href="./src/landingai_ade/resources/v2/v2.py">ground</a>(\*, extraction_metadata, structure) -> <a href="./src/landingai_ade/types/v2/ground_response.py">V2GroundResult</a></code>
 
   Synchronous ground. Maps each extracted field back to the `structure` blocks it was quoted from by overlapping `extraction_metadata` ranges against every block's inline `grounding.range`. Both `extraction_metadata` (e.g. `client.v2.extract(...).extraction_metadata`) and `structure` (e.g. `client.v2.parse(...).structure`) accept a `dict` or a pydantic model. Block ids resolve only against the `structure` supplied here, so pass the parse result the extraction actually came from. `/v2/ground` is synchronous-only (no async jobs route).
+
+- <code title="post /v1/classify">client.v2.<a href="./src/landingai_ade/resources/v2/v2.py">classify</a>(\*, classes, document=..., document_url=..., model=...) -> <a href="./src/landingai_ade/types/v2/classify_response.py">V2ClassifyResponse</a></code>
+
+  Synchronous classify. `classes` is the list of candidate classes (each a mapping with a `class` name and an optional `description`), sent as a JSON-encoded form field. Provide exactly one of `document` (file) or `document_url`. Returns one predicted class per page. Raises `V2SyncTimeoutError` on a 504; use `classify_jobs` for long-running documents.
+
+- <code title="post /v1/classify/jobs">client.v2.classify_jobs.<a href="./src/landingai_ade/resources/v2/classify.py">create</a>(\*, classes, document=..., document_url=..., model=..., service_tier=...) -> <a href="./src/landingai_ade/types/v2/job.py">Job</a></code>
+- <code title="get /v1/classify/jobs/{job_id}">client.v2.classify_jobs.<a href="./src/landingai_ade/resources/v2/classify.py">get</a>(job_id) -> <a href="./src/landingai_ade/types/v2/job.py">Job</a></code>
+- <code title="get /v1/classify/jobs">client.v2.classify_jobs.<a href="./src/landingai_ade/resources/v2/classify.py">list</a>(\*, page=..., page_size=..., status=...) -> JobList[<a href="./src/landingai_ade/types/v2/job.py">Job</a>]</code>
+- <code>client.v2.classify_jobs.<a href="./src/landingai_ade/resources/v2/classify.py">wait</a>(job_id, \*, timeout=600, poll_interval=None, raise_on_failure=False) -> <a href="./src/landingai_ade/types/v2/job.py">Job</a></code>
+
+  Same polling/timeout semantics as `parse_jobs.wait`. A completed classify `Job` carries a `V2ClassifyResponse` on `result`.
+
+- <code title="post /v1/split">client.v2.<a href="./src/landingai_ade/resources/v2/v2.py">split</a>(\*, split_class, markdown=..., markdown_url=..., model=...) -> <a href="./src/landingai_ade/types/v2/split_response.py">V2SplitResponse</a></code>
+
+  Synchronous split. `split_class` is the list of split classification entries (each a mapping with a `name` and optional `description` / `identifier`; at most 19), sent as a JSON-encoded form field. Provide exactly one of `markdown` (an inline string or a file) or `markdown_url`. `/v1/split` is synchronous-only (no async jobs route).
 
 Notes:
 

--- a/docs/v2-testing.md
+++ b/docs/v2-testing.md
@@ -8,8 +8,8 @@ what to check when the upstream spec (`specs/v2-aide.json`) changes.
 
 | Layer | Location | What it covers |
 | --- | --- | --- |
-| Response models | `tests/test_v2_types.py` | Deserialization of `V2ParseResponse` / `V2ExtractResult` / `V2BuildSchemaResponse` / `V2GroundResult` and their nested models from plain dicts, including unknown-key tolerance. |
-| Job normalization | `tests/test_v2_normalize.py` | `normalize_parse_job` / `normalize_extract_job` / `normalize_build_schema_job`: envelope → unified `Job` (status, timestamps, `result`, `error`). |
+| Response models | `tests/test_v2_types.py` | Deserialization of `V2ParseResponse` / `V2ExtractResult` / `V2ClassifyResponse` / `V2SplitResponse` / `V2BuildSchemaResponse` / `V2GroundResult` and their nested models from plain dicts, including unknown-key tolerance. |
+| Job normalization | `tests/test_v2_normalize.py` | `normalize_parse_job` / `normalize_extract_job` / `normalize_classify_job` / `normalize_build_schema_job`: envelope → unified `Job` (status, timestamps, `result`, `error`). |
 | Resource wiring | `tests/api_resources/v2/` | `respx`-mocked HTTP: host routing, multipart/JSON bodies, options serialization, job polling. No network. |
 | Live smoke | `tests/contract/test_v2_smoke.py` | End-to-end calls against staging (marked `contract`; skipped unless `LANDINGAI_ADE_STAGING_APIKEY` is set). |
 
@@ -112,11 +112,57 @@ each extracted field back to the `structure` blocks it was quoted from:
 accepts a plain `dict` or a pydantic model (so a parse response's `.structure` can
 be passed directly). `/v2/ground` is synchronous-only (no async jobs route).
 
+## Current classify-response shape
+
+`POST /v1/classify` (and the completed `classify_jobs` result) returns a
+`V2ClassifyResponse` — served on the ADE host, so it lives under `client.v2`
+alongside parse/extract. It carries:
+
+- `classification` — one `V2ClassificationItem` per page, in page order:
+  - `class_` — the predicted class label, or `"unknown"`. The wire key is
+    `class` (a Python keyword), so the field is `class_` with the alias carrying
+    the wire name.
+  - `page` — 0-indexed page number.
+  - `reason` — why the page was classified this way.
+  - `suggested_class` — optional; a class the model proposes when the prediction
+    is `"unknown"`. Absent/`None` otherwise.
+- `metadata` (`V2ClassifyMetadata`) — `page_count`, `duration_ms`, and
+  `openapi_spec` (required per the spec), plus optional `credit_usage`,
+  `filename`, `job_id`, `org_id`, and `version`.
+
+`client.v2.classify(...)` takes `classes` (the candidate classes, each a mapping
+with a `class` name and optional `description`), plus exactly one of `document`
+(a file) or `document_url`; the request is multipart and `classes` is sent as a
+JSON-encoded form field. The async surface (`client.v2.classify_jobs`) mirrors
+`parse_jobs` (`create` / `get` / `list` / `wait`, with a `service_tier`), and a
+completed classify `Job` carries a `V2ClassifyResponse` on `result`. A 504 on the
+sync call raises `V2SyncTimeoutError` pointing at `classify_jobs`.
+
+## Current split-response shape
+
+`POST /v1/split` returns a `V2SplitResponse` — also an ADE-host route surfaced
+under `client.v2`. It is synchronous-only (no async jobs route). It carries:
+
+- `splits` — a list of `V2Split` segments, in page order. Consecutive pages with
+  the same classification merge into one segment; an identifier change starts a
+  new one. Each segment has `classification`, `markdowns` (the per-page Markdown,
+  in order), `pages` (0-indexed), and an optional `identifier` (present when the
+  matching split classification requested one; the key is always present on the
+  wire but may be null, which deserializes to `None`).
+- `metadata` (`V2SplitMetadata`) — `credit_usage`, `duration_ms`, `filename`,
+  `job_id`, `page_count`, and `version` (all required per the spec), plus optional
+  `org_id`.
+
+`client.v2.split(...)` takes `split_class` (the split classification entries, each
+a mapping with a `name` and optional `description` / `identifier`; at most 19),
+plus exactly one of `markdown` (an inline string or a file) or `markdown_url`; the
+request is multipart and `split_class` is sent as a JSON-encoded form field.
+
 ## Async job envelopes
 
-`normalize_parse_job`, `normalize_extract_job`, and `normalize_build_schema_job`
-fold the upstream job envelopes into the unified `Job`. All are tolerant of
-field-name drift:
+`normalize_parse_job`, `normalize_extract_job`, `normalize_classify_job`, and
+`normalize_build_schema_job` fold the upstream job envelopes into the unified
+`Job`. All are tolerant of field-name drift:
 
 - The parse response lives under `result` (older envelopes used `data`).
 - Failures arrive as a structured `error` object (`{code, message}`); older parse

--- a/specs/_generated/v2_models.py
+++ b/specs/_generated/v2_models.py
@@ -68,6 +68,29 @@ class BuildSchemaWarning(BaseModel):
     )
 
 
+class ClassifyClass(BaseModel):
+    """
+    One classification option: a class name plus an optional description.
+
+    Wire key ``class`` (VTRA's ``ClassifyClass``); the field is ``class_name``
+    because ``class`` is a Python keyword, with the alias carrying the wire
+    name. ``populate_by_name`` lets the Temporal round-trip (which serializes by
+    FIELD name) rebuild the object on the worker side.
+    """
+
+    class_: str = Field(
+        ...,
+        alias='class',
+        description='Class name assigned to a page when it matches.',
+        title='Class',
+    )
+    description: Optional[str] = Field(
+        None,
+        description='What this class represents. Improves classification.',
+        title='Description',
+    )
+
+
 class CreditUsage(BaseModel):
     """
     The standard credit-usage shape a billable WORK result carries.
@@ -219,6 +242,86 @@ class Range(BaseModel):
     )
 
 
+class Split(BaseModel):
+    """
+    One split segment: consecutive pages of one classification (an
+    identifier change starts a new segment).
+    """
+
+    classification: str = Field(
+        ...,
+        description='The split classification name this segment was assigned.',
+        title='Classification',
+    )
+    identifier: Optional[str] = Field(
+        ...,
+        description='The identifier value extracted for this segment, when the matching split classification requested one. Null otherwise.',
+        title='Identifier',
+    )
+    markdowns: list[str] = Field(
+        ...,
+        description='The Markdown content of each page in this segment, in order.',
+        title='Markdowns',
+    )
+    pages: list[int] = Field(
+        ...,
+        description='0-indexed page numbers belonging to this segment, in order.',
+        title='Pages',
+    )
+
+
+class SplitMetadata(BaseModel):
+    """
+    Information about a split request.
+    """
+
+    credit_usage: float = Field(
+        ...,
+        description='Credits consumed by this request: the input Markdown length in characters divided by 5000. Billed usage rounds this up to the next 0.1 credit.',
+        title='Credit Usage',
+    )
+    duration_ms: int = Field(
+        ..., description='Total processing time in milliseconds.', title='Duration Ms'
+    )
+    filename: str = Field(
+        ...,
+        description="Display name of the split document: the URL path's file name for `markdown_url` inputs, or a generated name for inline and uploaded Markdown.",
+        title='Filename',
+    )
+    job_id: str = Field(
+        ...,
+        description="The split job identifier — server-minted and unique per request. Correlates with the request's entry in your billing dashboard.",
+        title='Job Id',
+    )
+    org_id: Optional[str] = Field(..., description='Organization ID.', title='Org Id')
+    page_count: int = Field(
+        ...,
+        description='Total number of pages in the input Markdown.',
+        title='Page Count',
+    )
+    version: str = Field(
+        ...,
+        description='The exact split model snapshot that processed the document, e.g. `split-20251105`.',
+        title='Version',
+    )
+
+
+class SplitResponse(BaseModel):
+    """
+    The split result: the merged `splits` segments and request `metadata`.
+    """
+
+    metadata: SplitMetadata = Field(
+        ...,
+        description='Information about the request: file name, page count, duration, credits, and the resolved model version.',
+    )
+    splits: list[Split] = Field(
+        ...,
+        description='The split segments, in page order. Consecutive pages with the same classification merge into one segment; an identifier change starts a new segment.',
+        title='Splits',
+    )
+
+
 class Format(Enum):
     markdown = 'markdown'
     html = 'html'
@@ -278,6 +381,42 @@ class V1BuildSchemaMetadata(BaseModel):
         None,
         description='Structured warnings from the schema-generation process. Each is a ``{code, msg}`` object (e.g. code ``nonconformant_schema``).',
         title='Warnings',
+    )
+
+
+class V1ClassifyMetadata(BaseModel):
+    """
+    Response metadata for a classify call — VTRA's ``ClassifyMetadata``.
+    """
+
+    credit_usage: Optional[float] = Field(
+        0.0, description='Credits billed for this request.', title='Credit Usage'
+    )
+    duration_ms: int = Field(
+        ...,
+        description='End-to-end request duration in milliseconds.',
+        title='Duration Ms',
+    )
+    filename: Optional[str] = Field(
+        '', description='Name of the classified file.', title='Filename'
+    )
+    job_id: Optional[str] = Field(
+        '',
+        description='Gateway job id (workflow id). Matches the billing row id in vision-agent.',
+        title='Job Id',
+    )
+    openapi_spec: str = Field(
+        ...,
+        description='URL of the OpenAPI spec covering this API, for inspection and client generation.',
+    )
+    org_id: Optional[str] = Field(None, description='Organization ID.', title='Org Id')
+    page_count: int = Field(
+        ..., description='Number of pages classified.', title='Page Count'
+    )
+    version: Optional[str] = Field(
+        None,
+        description='Resolved classify pipeline version that produced this response.',
+        title='Version',
     )
 
 
@@ -552,7 +691,14 @@ class V1AdeParsePostRequest1(BaseModel):
     custom_prompts: Optional[dict[str, str]] = Field(
         None, description='JSON-serialized string in form data.', title='Custom Prompts'
     )
-    document_ref: bytes = Field(..., description='File upload.')
+    document: Optional[bytes] = Field(
+        None,
+        description='The file to process. Provide either `document` or `document_url`, not both.',
+    )
+    document_url: Optional[str] = Field(
+        None,
+        description='A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.',
+    )
     filename: str = Field(..., title='Filename')
     job_id: Optional[str] = Field(
         None, description='JSON-serialized string in form data.', title='Job Id'
@@ -596,6 +742,7 @@ class V1AdeParsePostResponse(BaseModel):
 
     base_credit: Optional[float] = Field(0.0, title='Base Credit')
     billable_pages: Optional[int] = Field(0, title='Billable Pages')
+    billing_suppressed: Optional[bool] = Field(False, title='Billing Suppressed')
     completion_tokens: Optional[int] = Field(0, title='Completion Tokens')
     credit_usage: Optional[CreditUsage] = None
     duration_ms: Optional[int] = Field(0, title='Duration Ms')
@@ -690,7 +837,14 @@ class V1AdeParseJobsPostRequest1(BaseModel):
     custom_prompts: Optional[dict[str, str]] = Field(
         None, description='JSON-serialized string in form data.', title='Custom Prompts'
     )
-    document_ref: bytes = Field(..., description='File upload.')
+    document: Optional[bytes] = Field(
+        None,
+        description='The file to process. Provide either `document` or `document_url`, not both.',
+    )
+    document_url: Optional[str] = Field(
+        None,
+        description='A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.',
+    )
     filename: str = Field(..., title='Filename')
     job_id: Optional[str] = Field(
         None, description='JSON-serialized string in form data.', title='Job Id'
@@ -763,6 +917,7 @@ class Result(BaseModel):
 
     base_credit: Optional[float] = Field(0.0, title='Base Credit')
     billable_pages: Optional[int] = Field(0, title='Billable Pages')
+    billing_suppressed: Optional[bool] = Field(False, title='Billing Suppressed')
     completion_tokens: Optional[int] = Field(0, title='Completion Tokens')
     credit_usage: Optional[CreditUsage] = None
     duration_ms: Optional[int] = Field(0, title='Duration Ms')
@@ -807,6 +962,213 @@ class V1AdeParseJobsJobIdGetResponse(BaseModel):
     result: Optional[Result] = Field(
         None,
         description='Present once status is ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead.',
+    )
+    status: Optional[Status1] = None
+
+
+class V1ClassifyPostRequest(BaseModel):
+    """
+    Input to ``V1ClassifyOperationWorkflow`` (gateway) and, threaded
+    unchanged, to ``ClassifyWorkflow`` (work) — the ``/v1/classify`` request
+    body. Mirrors VTRA's ``ClassifyRequest``.
+    """
+
+    classes: list[ClassifyClass] = Field(
+        ...,
+        description="The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string.",
+        title='Classes',
+    )
+    content_type: Optional[str] = Field('', title='Content Type')
+    document_ref: str = Field(..., title='Document Ref')
+    filename: Optional[str] = Field('', title='Filename')
+    model: Optional[str] = Field(
+        None,
+        description='Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version.',
+        title='Model',
+    )
+
+
+class V1ClassifyPostRequest1(BaseModel):
+    classes: list[ClassifyClass] = Field(
+        ...,
+        description="The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string. JSON-serialized string in form data.",
+        title='Classes',
+    )
+    content_type: Optional[str] = Field('', title='Content Type')
+    document: Optional[bytes] = Field(
+        None,
+        description='The file to process. Provide either `document` or `document_url`, not both.',
+    )
+    document_url: Optional[str] = Field(
+        None,
+        description='A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.',
+    )
+    filename: Optional[str] = Field('', title='Filename')
+    model: Optional[str] = Field(
+        None,
+        description='Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version. JSON-serialized string in form data.',
+        title='Model',
+    )
+
+
+class ClassificationItem(BaseModel):
+    class_: str = Field(
+        ..., alias='class', description="Predicted class label, or 'unknown'."
+    )
+    page: int = Field(
+        ..., description='Page number, zero-indexed (the first page is 0).'
+    )
+    reason: str = Field(..., description='Why the page was classified this way.')
+    suggested_class: Optional[str] = Field(
+        None, description="A class the model proposes when the prediction is 'unknown'."
+    )
+
+
+class V1ClassifyPostResponse(BaseModel):
+    """
+    Result returned by ``V1ClassifyOperationWorkflow`` — the
+    ``/v1/classify`` response body (VTRA's ``ClassifyResponse``).
+    """
+
+    classification: list[ClassificationItem] = Field(
+        ...,
+        description='One classification result per page, in page order.',
+        title='Classification',
+    )
+    metadata: V1ClassifyMetadata = Field(
+        ..., description='Metadata for the classification request.'
+    )
+
+
+class V1ClassifyJobsGetParametersQuery(BaseModel):
+    page: Optional[int] = Field(
+        0, description='Page number (0-indexed).', ge=0, title='Page'
+    )
+    page_size: Optional[int] = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    )
+    status: Optional[str] = Field(
+        None, description='Filter by job status.', title='Status'
+    )
+
+
+class Job1(BaseModel):
+    completed_at: Optional[str] = None
+    created_at: Optional[str] = None
+    failure_reason: Optional[str] = None
+    job_id: Optional[str] = Field(
+        None,
+        description='The unique identifier for this classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    model_version: Optional[str] = None
+    status: Optional[Status1] = None
+
+
+class V1ClassifyJobsGetResponse(BaseModel):
+    has_more: Optional[bool] = None
+    jobs: Optional[list[Job1]] = None
+    page: Optional[int] = None
+    page_size: Optional[int] = None
+
+
+class V1ClassifyJobsPostRequest(BaseModel):
+    """
+    Input to ``V1ClassifyOperationWorkflow`` (gateway) and, threaded
+    unchanged, to ``ClassifyWorkflow`` (work) — the ``/v1/classify`` request
+    body. Mirrors VTRA's ``ClassifyRequest``.
+    """
+
+    classes: list[ClassifyClass] = Field(
+        ...,
+        description="The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string.",
+        title='Classes',
+    )
+    content_type: Optional[str] = Field('', title='Content Type')
+    document_ref: str = Field(..., title='Document Ref')
+    filename: Optional[str] = Field('', title='Filename')
+    model: Optional[str] = Field(
+        None,
+        description='Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version.',
+        title='Model',
+    )
+    service_tier: Optional[ServiceTier2] = Field(
+        None,
+        description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
+    )
+
+
+class V1ClassifyJobsPostRequest1(BaseModel):
+    classes: list[ClassifyClass] = Field(
+        ...,
+        description="The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string. JSON-serialized string in form data.",
+        title='Classes',
+    )
+    content_type: Optional[str] = Field('', title='Content Type')
+    document: Optional[bytes] = Field(
+        None,
+        description='The file to process. Provide either `document` or `document_url`, not both.',
+    )
+    document_url: Optional[str] = Field(
+        None,
+        description='A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.',
+    )
+    filename: Optional[str] = Field('', title='Filename')
+    model: Optional[str] = Field(
+        None,
+        description='Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version. JSON-serialized string in form data.',
+        title='Model',
+    )
+    service_tier: Optional[ServiceTier2] = Field(
+        None,
+        description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
+    )
+
+
+class V1ClassifyJobsPostResponse(BaseModel):
+    created_at: Optional[str] = None
+    job_id: Optional[str] = Field(
+        None,
+        description='The unique identifier for this classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    status: Optional[Status1] = None
+
+
+class Result1(BaseModel):
+    """
+    Result returned by ``V1ClassifyOperationWorkflow`` — the
+    ``/v1/classify`` response body (VTRA's ``ClassifyResponse``).
+    """
+
+    classification: list[ClassificationItem] = Field(
+        ...,
+        description='One classification result per page, in page order.',
+        title='Classification',
+    )
+    metadata: V1ClassifyMetadata = Field(
+        ..., description='Metadata for the classification request.'
+    )
+
+
+class V1ClassifyJobsJobIdGetResponse(BaseModel):
+    completed_at: Optional[str] = Field(
+        None, description='Present once the job is terminal.'
+    )
+    created_at: Optional[str] = None
+    error: Optional[Error] = Field(
+        None, description='Present once status is ``failed``.'
+    )
+    job_id: Optional[str] = Field(
+        None,
+        description='The unique identifier for this classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    progress: Optional[float] = Field(
+        None,
+        description='Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.',
+        ge=0.0,
+        le=1.0,
+    )
+    result: Optional[Result1] = Field(
+        None, description='Present once status is ``completed``.'
     )
     status: Optional[Status1] = None
 
@@ -975,7 +1337,7 @@ class V1ExtractBuildSchemaJobsGetParametersQuery(BaseModel):
     )
 
 
-class Job1(BaseModel):
+class Job2(BaseModel):
     completed_at: Optional[str] = None
     created_at: Optional[str] = None
     failure_reason: Optional[str] = None
@@ -989,7 +1351,7 @@ class Job1(BaseModel):
 
 class V1ExtractBuildSchemaJobsGetResponse(BaseModel):
     has_more: Optional[bool] = None
-    jobs: Optional[list[Job1]] = None
+    jobs: Optional[list[Job2]] = None
     page: Optional[int] = None
     page_size: Optional[int] = None
 
@@ -1090,7 +1452,7 @@ class V1ExtractBuildSchemaJobsPostResponse(BaseModel):
     status: Optional[Status1] = None
 
 
-class Result1(BaseModel):
+class Result2(BaseModel):
     """
     Result of a **v1** build-schema call — VTRA's ``BuildSchemaResponse``.
 
@@ -1126,7 +1488,7 @@ class V1ExtractBuildSchemaJobsJobIdGetResponse(BaseModel):
         ge=0.0,
         le=1.0,
     )
-    result: Optional[Result1] = Field(
+    result: Optional[Result2] = Field(
         None, description='Present once status is ``completed``.'
     )
     status: Optional[Status1] = None
@@ -1144,7 +1506,7 @@ class V1ExtractJobsGetParametersQuery(BaseModel):
     )
 
 
-class Job2(BaseModel):
+class Job3(BaseModel):
     completed_at: Optional[str] = None
     created_at: Optional[str] = None
     failure_reason: Optional[str] = None
@@ -1158,7 +1520,7 @@ class Job2(BaseModel):
 
 class V1ExtractJobsGetResponse(BaseModel):
     has_more: Optional[bool] = None
-    jobs: Optional[list[Job2]] = None
+    jobs: Optional[list[Job3]] = None
     page: Optional[int] = None
     page_size: Optional[int] = None
 
@@ -1217,7 +1579,7 @@ class V1ExtractJobsPostResponse(BaseModel):
     status: Optional[Status1] = None
 
 
-class Result2(BaseModel):
+class Result3(BaseModel):
     """
     VTRA's ``ExtractResponse`` — the ``/v1/extract`` response body.
 
@@ -1253,7 +1615,7 @@ class V1ExtractJobsJobIdGetResponse(BaseModel):
         ge=0.0,
         le=1.0,
     )
-    result: Optional[Result2] = Field(
+    result: Optional[Result3] = Field(
         None, description='Present once status is ``completed``.'
     )
     status: Optional[Status1] = None
@@ -1286,7 +1648,14 @@ class V1ParsePostRequest1(BaseModel):
     custom_prompts: Optional[dict[str, str]] = Field(
         None, description='JSON-serialized string in form data.', title='Custom Prompts'
     )
-    document_ref: bytes = Field(..., description='File upload.')
+    document: Optional[bytes] = Field(
+        None,
+        description='The file to process. Provide either `document` or `document_url`, not both.',
+    )
+    document_url: Optional[str] = Field(
+        None,
+        description='A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.',
+    )
     filename: str = Field(..., title='Filename')
     job_id: Optional[str] = Field(
         None, description='JSON-serialized string in form data.', title='Job Id'
@@ -1330,6 +1699,7 @@ class V1ParsePostResponse(BaseModel):
 
     base_credit: Optional[float] = Field(0.0, title='Base Credit')
     billable_pages: Optional[int] = Field(0, title='Billable Pages')
+    billing_suppressed: Optional[bool] = Field(False, title='Billing Suppressed')
     completion_tokens: Optional[int] = Field(0, title='Completion Tokens')
     credit_usage: Optional[CreditUsage] = None
     duration_ms: Optional[int] = Field(0, title='Duration Ms')
@@ -1357,7 +1727,7 @@ class V1ParseJobsGetParametersQuery(BaseModel):
     )
 
 
-class Job3(BaseModel):
+class Job4(BaseModel):
     completed_at: Optional[str] = None
     created_at: Optional[str] = None
     failure_reason: Optional[str] = None
@@ -1371,7 +1741,7 @@ class Job3(BaseModel):
 
 class V1ParseJobsGetResponse(BaseModel):
     has_more: Optional[bool] = None
-    jobs: Optional[list[Job3]] = None
+    jobs: Optional[list[Job4]] = None
     page: Optional[int] = None
     page_size: Optional[int] = None
 
@@ -1408,7 +1778,14 @@ class V1ParseJobsPostRequest1(BaseModel):
     custom_prompts: Optional[dict[str, str]] = Field(
         None, description='JSON-serialized string in form data.', title='Custom Prompts'
     )
-    document_ref: bytes = Field(..., description='File upload.')
+    document: Optional[bytes] = Field(
+        None,
+        description='The file to process. Provide either `document` or `document_url`, not both.',
+    )
+    document_url: Optional[str] = Field(
+        None,
+        description='A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.',
+    )
     filename: str = Field(..., title='Filename')
     job_id: Optional[str] = Field(
         None, description='JSON-serialized string in form data.', title='Job Id'
@@ -1454,7 +1831,7 @@ class V1ParseJobsPostResponse(BaseModel):
     status: Optional[Status1] = None
 
 
-class Result3(BaseModel):
+class Result4(BaseModel):
     """
     Output of ``Parse2DocumentWorkflow``. Carries the customer response plus the
     billing inputs hoisted to the top level so the gateway operation reads them
@@ -1470,6 +1847,7 @@ class Result3(BaseModel):
 
     base_credit: Optional[float] = Field(0.0, title='Base Credit')
     billable_pages: Optional[int] = Field(0, title='Billable Pages')
+    billing_suppressed: Optional[bool] = Field(False, title='Billing Suppressed')
     completion_tokens: Optional[int] = Field(0, title='Completion Tokens')
     credit_usage: Optional[CreditUsage] = None
     duration_ms: Optional[int] = Field(0, title='Duration Ms')
@@ -1511,11 +1889,30 @@ class V1ParseJobsJobIdGetResponse(BaseModel):
         ge=0.0,
         le=1.0,
     )
-    result: Optional[Result3] = Field(
+    result: Optional[Result4] = Field(
         None,
         description='Present once status is ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead.',
     )
     status: Optional[Status1] = None
+
+
+class V1SplitPostRequest(BaseModel):
+    markdown: Optional[Union[bytes, str]] = Field(
+        None,
+        description='Markdown content to split, as an inline string or an uploaded file. Provide either `markdown` or `markdown_url`, not both.',
+    )
+    markdown_url: Optional[str] = Field(
+        None,
+        description='A publicly accessible URL to the Markdown file to split. Provide either `markdown` or `markdown_url`, not both.',
+    )
+    model: Optional[str] = Field(
+        None,
+        description='The split model version to use. Accepts a dated snapshot (`split-20251105`), `split-latest`, or `split` (both aliases resolve to the latest snapshot). Defaults to the latest snapshot. The resolved version is echoed back as `metadata.version`.',
+    )
+    split_class: str = Field(
+        ...,
+        description='The split classification entries, as a JSON-encoded array of objects with `name` (required), `description`, and `identifier` keys. At most 19 entries. Sent as a JSON-serialized string in form data.',
+    )
 
 
 class V2ExtractPostRequest(BaseModel):
@@ -1645,7 +2042,7 @@ class V2ExtractJobsGetParametersQuery(BaseModel):
     )
 
 
-class Job4(BaseModel):
+class Job5(BaseModel):
     completed_at: Optional[str] = None
     created_at: Optional[str] = None
     failure_reason: Optional[str] = None
@@ -1659,7 +2056,7 @@ class Job4(BaseModel):
 
 class V2ExtractJobsGetResponse(BaseModel):
     has_more: Optional[bool] = None
-    jobs: Optional[list[Job4]] = None
+    jobs: Optional[list[Job5]] = None
     page: Optional[int] = None
     page_size: Optional[int] = None
 
@@ -1769,7 +2166,7 @@ class V2ExtractJobsPostResponse(BaseModel):
     status: Optional[Status1] = None
 
 
-class Result4(BaseModel):
+class Result5(BaseModel):
     """
     Result returned by V2ExtractOperationWorkflow — the ``/v2/extract``
     response body (``docs/extract-v2-contract.md`` → Response).
@@ -1832,7 +2229,7 @@ class V2ExtractJobsJobIdGetResponse(BaseModel):
         ge=0.0,
         le=1.0,
     )
-    result: Optional[Result4] = Field(
+    result: Optional[Result5] = Field(
         None,
         description='Present once status is ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead.',
     )
@@ -1948,7 +2345,7 @@ class V2ParseJobsGetParametersQuery(BaseModel):
     )
 
 
-class Status16(Enum):
+class Status19(Enum):
     """
     The job's current status: ``pending``, ``processing``, ``completed``, or ``failed``.
     """
@@ -1959,7 +2356,7 @@ class Status16(Enum):
     failed = 'failed'
 
 
-class Job5(BaseModel):
+class Job6(BaseModel):
     completed_at: Optional[str] = Field(
         None, description='ISO-8601 timestamp for when the job finished, if terminal.'
     )
@@ -1977,7 +2374,7 @@ class Job5(BaseModel):
     model_version: Optional[str] = Field(
         None, description='The model snapshot used to parse the document.'
     )
-    status: Optional[Status16] = Field(
+    status: Optional[Status19] = Field(
         None,
         description="The job's current status: ``pending``, ``processing``, ``completed``, or ``failed``.",
     )
@@ -1988,14 +2385,14 @@ class V2ParseJobsGetResponse(BaseModel):
         None,
         description='Whether more jobs exist beyond this page; request the next ``page`` to fetch them.',
     )
-    jobs: Optional[list[Job5]] = Field(
+    jobs: Optional[list[Job6]] = Field(
         None, description="The caller's parse jobs for this page, newest first."
     )
     page: Optional[int] = Field(None, description='The 0-indexed page number.')
     page_size: Optional[int] = Field(None, description='Items per page.')
 
 
-class ServiceTier12(Enum):
+class ServiceTier14(Enum):
     """
     Async service tier (``POST /jobs`` only). ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.
     """
@@ -2004,7 +2401,7 @@ class ServiceTier12(Enum):
     priority = 'priority'
 
 
-class Status17(Enum):
+class Status20(Enum):
     """
     The job's status at creation — normally ``pending`` (a just-created job that is still running is reported as ``pending``), but may already be a terminal ``completed`` / ``failed`` if the job finished before the create response was rendered.
     """
@@ -2023,13 +2420,13 @@ class V2ParseJobsPostResponse(BaseModel):
         ...,
         description='The unique identifier for the created parse job. Poll ``GET /v2/parse/jobs/{job_id}`` for its status and result. Format: ``<service>-<26-character Crockford base32 ULID>`` matching ``^(parse|extract)-[0-9a-hjkmnp-tv-z]{26}$``. Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
-    status: Status17 = Field(
+    status: Status20 = Field(
         ...,
         description="The job's status at creation — normally ``pending`` (a just-created job that is still running is reported as ``pending``), but may already be a terminal ``completed`` / ``failed`` if the job finished before the create response was rendered.",
     )
 
 
-class Error5(BaseModel):
+class Error6(BaseModel):
     """
     Present once the job has ``failed`` — the failure code + message.
     """
@@ -2038,7 +2435,7 @@ class Error5(BaseModel):
     message: Optional[str] = None
 
 
-class Status18(Enum):
+class Status21(Enum):
     """
     The job's current status: ``pending``, ``processing``, ``completed``, or ``failed``.
     """
@@ -2097,14 +2494,14 @@ class V2WorkflowJobsGetParametersQuery(BaseModel):
     )
 
 
-class Status19(Enum):
+class Status22(Enum):
     pending = 'pending'
     processing = 'processing'
     completed = 'completed'
     failed = 'failed'
 
 
-class Job6(BaseModel):
+class Job7(BaseModel):
     completed_at: Optional[str] = None
     created_at: Optional[str] = None
     failure_reason: Optional[str] = None
@@ -2113,17 +2510,17 @@ class Job6(BaseModel):
         description='The unique identifier for this v2-workflow job. Format: ``v2-workflow-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
     model_version: Optional[str] = None
-    status: Optional[Status19] = None
+    status: Optional[Status22] = None
 
 
 class V2WorkflowJobsGetResponse(BaseModel):
     has_more: Optional[bool] = None
-    jobs: Optional[list[Job6]] = None
+    jobs: Optional[list[Job7]] = None
     page: Optional[int] = None
     page_size: Optional[int] = None
 
 
-class ServiceTier13(Enum):
+class ServiceTier15(Enum):
     """
     Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.
     """
@@ -2138,10 +2535,10 @@ class V2WorkflowJobsPostResponse(BaseModel):
         None,
         description='The unique identifier for this v2-workflow job. Format: ``v2-workflow-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
-    status: Optional[Status19] = None
+    status: Optional[Status22] = None
 
 
-class Error6(BaseModel):
+class Error7(BaseModel):
     """
     Present once status is ``failed``.
     """
@@ -2152,7 +2549,7 @@ class Error6(BaseModel):
     message: Optional[str] = None
 
 
-class Result5(BaseModel):
+class Result6(BaseModel):
     """
     Result returned by V2WorkflowOperationWorkflow.
 
@@ -2193,7 +2590,7 @@ class V2WorkflowJobsJobIdGetResponse(BaseModel):
         None, description='Present once the job is terminal.'
     )
     created_at: Optional[str] = None
-    error: Optional[Error6] = Field(
+    error: Optional[Error7] = Field(
         None, description='Present once status is ``failed``.'
     )
     job_id: Optional[str] = Field(
@@ -2206,10 +2603,10 @@ class V2WorkflowJobsJobIdGetResponse(BaseModel):
         ge=0.0,
         le=1.0,
     )
-    result: Optional[Result5] = Field(
+    result: Optional[Result6] = Field(
         None, description='Present once status is ``completed``.'
     )
-    status: Optional[Status19] = None
+    status: Optional[Status22] = None
 
 
 class BlocksOptions(BaseModel):
@@ -2356,7 +2753,7 @@ class V2ParseJobsPostRequest(BaseModel):
         None,
         description="Public URL the full response is delivered to; the API response then carries ``output_url`` instead of inline data. A presigned URL must stay valid until the job COMPLETES, not just past submit: an already-expired URL, or one whose remaining validity is too short for the document's page count, is rejected at submit (422). By default the URL must retain at least 15 minutes of validity at submit, plus 3 seconds per document page; the 422 message names the exact window required. Sign with credentials that outlive the expected job duration — a URL signed with temporary (assumed-role/session) credentials dies when that session expires, regardless of the URL's stated expiry.",
     )
-    service_tier: Optional[ServiceTier12] = Field(
+    service_tier: Optional[ServiceTier14] = Field(
         None,
         description='Async service tier (``POST /jobs`` only). ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
     )
@@ -2506,7 +2903,7 @@ class V2WorkflowJobsPostRequest(BaseModel):
         ],
         title='Output',
     )
-    service_tier: Optional[ServiceTier13] = Field(
+    service_tier: Optional[ServiceTier15] = Field(
         None,
         description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
     )
@@ -2547,7 +2944,7 @@ class V2WorkflowJobsPostRequest1(BaseModel):
         ],
         title='Output',
     )
-    service_tier: Optional[ServiceTier13] = Field(
+    service_tier: Optional[ServiceTier15] = Field(
         None,
         description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
     )
@@ -2708,7 +3105,7 @@ class V2ParseJobsJobIdGetResponse(BaseModel):
     created_at: Optional[str] = Field(
         None, description='ISO-8601 timestamp for when the job was created.'
     )
-    error: Optional[Error5] = Field(
+    error: Optional[Error6] = Field(
         None,
         description='Present once the job has ``failed`` — the failure code + message.',
     )
@@ -2732,7 +3129,7 @@ class V2ParseJobsJobIdGetResponse(BaseModel):
         None,
         description='The parse response, present once the job has ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead.',
     )
-    status: Optional[Status18] = Field(
+    status: Optional[Status21] = Field(
         None,
         description="The job's current status: ``pending``, ``processing``, ``completed``, or ``failed``.",
     )

--- a/specs/v2-aide.json
+++ b/specs/v2-aide.json
@@ -98,6 +98,34 @@
         "title": "BuildSchemaWarning",
         "type": "object"
       },
+      "ClassifyClass": {
+        "description": "One classification option: a class name plus an optional description.\n\nWire key ``class`` (VTRA's ``ClassifyClass``); the field is ``class_name``\nbecause ``class`` is a Python keyword, with the alias carrying the wire\nname. ``populate_by_name`` lets the Temporal round-trip (which serializes by\nFIELD name) rebuild the object on the worker side.",
+        "properties": {
+          "class": {
+            "description": "Class name assigned to a page when it matches.",
+            "title": "Class",
+            "type": "string"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "What this class represents. Improves classification.",
+            "title": "Description"
+          }
+        },
+        "required": [
+          "class"
+        ],
+        "title": "ClassifyClass",
+        "type": "object"
+      },
       "CreditUsage": {
         "description": "The standard credit-usage shape a billable WORK result carries.\n\nA billed passthrough operation's work result declares\n``credit_usage: CreditUsage`` and the gateway's default\n``build_success_record`` bills it verbatim — no per-op billing code\n(operations/base.py requires it: a result carrying anything else raises).\n\nStdlib result modules embedding CreditUsage should follow the pdf.py posture\n(no ``from __future__ import annotations``) or use pydantic dataclasses (the\nextract_v2 posture).",
         "properties": {
@@ -675,6 +703,133 @@
         "title": "Range",
         "type": "object"
       },
+      "Split": {
+        "description": "One split segment: consecutive pages of one classification (an\nidentifier change starts a new segment).",
+        "properties": {
+          "classification": {
+            "description": "The split classification name this segment was assigned.",
+            "title": "Classification",
+            "type": "string"
+          },
+          "identifier": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The identifier value extracted for this segment, when the matching split classification requested one. Null otherwise.",
+            "title": "Identifier"
+          },
+          "markdowns": {
+            "description": "The Markdown content of each page in this segment, in order.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Markdowns",
+            "type": "array"
+          },
+          "pages": {
+            "description": "0-indexed page numbers belonging to this segment, in order.",
+            "items": {
+              "type": "integer"
+            },
+            "title": "Pages",
+            "type": "array"
+          }
+        },
+        "required": [
+          "classification",
+          "identifier",
+          "pages",
+          "markdowns"
+        ],
+        "title": "Split",
+        "type": "object"
+      },
+      "SplitMetadata": {
+        "description": "Information about a split request.",
+        "properties": {
+          "credit_usage": {
+            "description": "Credits consumed by this request: the input Markdown length in characters divided by 5000. Billed usage rounds this up to the next 0.1 credit.",
+            "title": "Credit Usage",
+            "type": "number"
+          },
+          "duration_ms": {
+            "description": "Total processing time in milliseconds.",
+            "title": "Duration Ms",
+            "type": "integer"
+          },
+          "filename": {
+            "description": "Display name of the split document: the URL path's file name for `markdown_url` inputs, or a generated name for inline and uploaded Markdown.",
+            "title": "Filename",
+            "type": "string"
+          },
+          "job_id": {
+            "description": "The split job identifier — server-minted and unique per request. Correlates with the request's entry in your billing dashboard.",
+            "title": "Job Id",
+            "type": "string"
+          },
+          "org_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Organization ID.",
+            "title": "Org Id"
+          },
+          "page_count": {
+            "description": "Total number of pages in the input Markdown.",
+            "title": "Page Count",
+            "type": "integer"
+          },
+          "version": {
+            "description": "The exact split model snapshot that processed the document, e.g. `split-20251105`.",
+            "title": "Version",
+            "type": "string"
+          }
+        },
+        "required": [
+          "filename",
+          "org_id",
+          "page_count",
+          "duration_ms",
+          "credit_usage",
+          "job_id",
+          "version"
+        ],
+        "title": "SplitMetadata",
+        "type": "object"
+      },
+      "SplitResponse": {
+        "description": "The split result: the merged `splits` segments and request `metadata`.",
+        "properties": {
+          "metadata": {
+            "$ref": "#/components/schemas/SplitMetadata",
+            "description": "Information about the request: file name, page count, duration, credits, and the resolved model version."
+          },
+          "splits": {
+            "description": "The split segments, in page order. Consecutive pages with the same classification merge into one segment; an identifier change starts a new segment.",
+            "items": {
+              "$ref": "#/components/schemas/Split"
+            },
+            "title": "Splits",
+            "type": "array"
+          }
+        },
+        "required": [
+          "splits",
+          "metadata"
+        ],
+        "title": "SplitResponse",
+        "type": "object"
+      },
       "TableOptions": {
         "additionalProperties": false,
         "properties": {
@@ -773,6 +928,76 @@
           "openapi_spec"
         ],
         "title": "V1BuildSchemaMetadata",
+        "type": "object"
+      },
+      "V1ClassifyMetadata": {
+        "description": "Response metadata for a classify call — VTRA's ``ClassifyMetadata``.",
+        "properties": {
+          "credit_usage": {
+            "default": 0.0,
+            "description": "Credits billed for this request.",
+            "title": "Credit Usage",
+            "type": "number"
+          },
+          "duration_ms": {
+            "description": "End-to-end request duration in milliseconds.",
+            "title": "Duration Ms",
+            "type": "integer"
+          },
+          "filename": {
+            "default": "",
+            "description": "Name of the classified file.",
+            "title": "Filename",
+            "type": "string"
+          },
+          "job_id": {
+            "default": "",
+            "description": "Gateway job id (workflow id). Matches the billing row id in vision-agent.",
+            "title": "Job Id",
+            "type": "string"
+          },
+          "openapi_spec": {
+            "description": "URL of the OpenAPI spec covering this API, for inspection and client generation.",
+            "type": "string"
+          },
+          "org_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Organization ID.",
+            "title": "Org Id"
+          },
+          "page_count": {
+            "description": "Number of pages classified.",
+            "title": "Page Count",
+            "type": "integer"
+          },
+          "version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Resolved classify pipeline version that produced this response.",
+            "title": "Version"
+          }
+        },
+        "required": [
+          "page_count",
+          "duration_ms",
+          "openapi_spec"
+        ],
+        "title": "V1ClassifyMetadata",
         "type": "object"
       },
       "V1ExtractMetadata": {
@@ -1399,9 +1624,13 @@
                     "description": "JSON-serialized string in form data.",
                     "title": "Custom Prompts"
                   },
-                  "document_ref": {
-                    "description": "File upload.",
+                  "document": {
+                    "description": "The file to process. Provide either `document` or `document_url`, not both.",
                     "format": "binary",
+                    "type": "string"
+                  },
+                  "document_url": {
+                    "description": "A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.",
                     "type": "string"
                   },
                   "filename": {
@@ -1502,7 +1731,6 @@
                   }
                 },
                 "required": [
-                  "document_ref",
                   "filename",
                   "content_type"
                 ],
@@ -1528,6 +1756,11 @@
                       "default": 0,
                       "title": "Billable Pages",
                       "type": "integer"
+                    },
+                    "billing_suppressed": {
+                      "default": false,
+                      "title": "Billing Suppressed",
+                      "type": "boolean"
                     },
                     "completion_tokens": {
                       "default": 0,
@@ -1968,9 +2201,13 @@
                     "description": "JSON-serialized string in form data.",
                     "title": "Custom Prompts"
                   },
-                  "document_ref": {
-                    "description": "File upload.",
+                  "document": {
+                    "description": "The file to process. Provide either `document` or `document_url`, not both.",
                     "format": "binary",
+                    "type": "string"
+                  },
+                  "document_url": {
+                    "description": "A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.",
                     "type": "string"
                   },
                   "filename": {
@@ -2099,7 +2336,6 @@
                   }
                 },
                 "required": [
-                  "document_ref",
                   "filename",
                   "content_type"
                 ],
@@ -2242,6 +2478,11 @@
                               "default": 0,
                               "title": "Billable Pages",
                               "type": "integer"
+                            },
+                            "billing_suppressed": {
+                              "default": false,
+                              "title": "Billing Suppressed",
+                              "type": "boolean"
                             },
                             "completion_tokens": {
                               "default": 0,
@@ -2394,6 +2635,672 @@
         "summary": "ADE Get Parse v1 Jobs",
         "tags": [
           "Parse v1"
+        ]
+      }
+    },
+    "/v1/classify": {
+      "post": {
+        "description": "Classify each page of a document into classes you define. Accepts a PDF, an image, or an Office document, plus the list of candidate classes; returns one predicted class per page. Runs synchronously and returns the result inline.",
+        "operationId": "classify_run_sync",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Input to ``V1ClassifyOperationWorkflow`` (gateway) and, threaded\nunchanged, to ``ClassifyWorkflow`` (work) — the ``/v1/classify`` request\nbody. Mirrors VTRA's ``ClassifyRequest``.",
+                "properties": {
+                  "classes": {
+                    "description": "The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string.",
+                    "items": {
+                      "$ref": "#/components/schemas/ClassifyClass"
+                    },
+                    "title": "Classes",
+                    "type": "array"
+                  },
+                  "content_type": {
+                    "default": "",
+                    "title": "Content Type",
+                    "type": "string"
+                  },
+                  "document_ref": {
+                    "title": "Document Ref",
+                    "type": "string"
+                  },
+                  "filename": {
+                    "default": "",
+                    "title": "Filename",
+                    "type": "string"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version.",
+                    "title": "Model"
+                  }
+                },
+                "required": [
+                  "document_ref",
+                  "classes"
+                ],
+                "title": "ClassifyRequest",
+                "type": "object"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "classes": {
+                    "description": "The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string. JSON-serialized string in form data.",
+                    "items": {
+                      "$ref": "#/components/schemas/ClassifyClass"
+                    },
+                    "title": "Classes",
+                    "type": "array"
+                  },
+                  "content_type": {
+                    "default": "",
+                    "title": "Content Type",
+                    "type": "string"
+                  },
+                  "document": {
+                    "description": "The file to process. Provide either `document` or `document_url`, not both.",
+                    "format": "binary",
+                    "type": "string"
+                  },
+                  "document_url": {
+                    "description": "A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.",
+                    "type": "string"
+                  },
+                  "filename": {
+                    "default": "",
+                    "title": "Filename",
+                    "type": "string"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version. JSON-serialized string in form data.",
+                    "title": "Model"
+                  }
+                },
+                "required": [
+                  "classes"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Result returned by ``V1ClassifyOperationWorkflow`` — the\n``/v1/classify`` response body (VTRA's ``ClassifyResponse``).",
+                  "properties": {
+                    "classification": {
+                      "description": "One classification result per page, in page order.",
+                      "items": {
+                        "properties": {
+                          "class": {
+                            "description": "Predicted class label, or 'unknown'.",
+                            "type": "string"
+                          },
+                          "page": {
+                            "description": "Page number, zero-indexed (the first page is 0).",
+                            "type": "integer"
+                          },
+                          "reason": {
+                            "description": "Why the page was classified this way.",
+                            "type": "string"
+                          },
+                          "suggested_class": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "description": "A class the model proposes when the prediction is 'unknown'."
+                          }
+                        },
+                        "required": [
+                          "class",
+                          "reason",
+                          "page"
+                        ],
+                        "title": "ClassificationItem",
+                        "type": "object"
+                      },
+                      "title": "Classification",
+                      "type": "array"
+                    },
+                    "metadata": {
+                      "$ref": "#/components/schemas/V1ClassifyMetadata",
+                      "description": "Metadata for the classification request."
+                    }
+                  },
+                  "required": [
+                    "classification",
+                    "metadata"
+                  ],
+                  "title": "V1ClassifyResponse",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "classify result"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Classify",
+        "tags": [
+          "Classify"
+        ]
+      }
+    },
+    "/v1/classify/jobs": {
+      "get": {
+        "description": "List your Classify jobs, newest first.",
+        "operationId": "classify_list_jobs",
+        "parameters": [
+          {
+            "description": "Page number (0-indexed).",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Page number (0-indexed).",
+              "minimum": 0,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of items per page.",
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "description": "Number of items per page.",
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Page Size",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Filter by job status.",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by job status.",
+              "title": "Status"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "has_more": {
+                      "type": "boolean"
+                    },
+                    "jobs": {
+                      "items": {
+                        "properties": {
+                          "completed_at": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "created_at": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "failure_reason": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "job_id": {
+                            "description": "The unique identifier for this classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                            "type": "string"
+                          },
+                          "model_version": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "status": {
+                            "enum": [
+                              "pending",
+                              "processing",
+                              "completed",
+                              "failed"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "page": {
+                      "type": "integer"
+                    },
+                    "page_size": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "The caller's jobs, newest first"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE List Classify Jobs",
+        "tags": [
+          "Classify"
+        ]
+      },
+      "post": {
+        "description": "Classify each page of a document into classes you define. Accepts a PDF, an image, or an Office document, plus the list of candidate classes; returns one predicted class per page. Runs asynchronously and returns a job ID; use it to poll for status and retrieve the result once processing completes.",
+        "operationId": "classify_create_job",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Input to ``V1ClassifyOperationWorkflow`` (gateway) and, threaded\nunchanged, to ``ClassifyWorkflow`` (work) — the ``/v1/classify`` request\nbody. Mirrors VTRA's ``ClassifyRequest``.",
+                "properties": {
+                  "classes": {
+                    "description": "The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string.",
+                    "items": {
+                      "$ref": "#/components/schemas/ClassifyClass"
+                    },
+                    "title": "Classes",
+                    "type": "array"
+                  },
+                  "content_type": {
+                    "default": "",
+                    "title": "Content Type",
+                    "type": "string"
+                  },
+                  "document_ref": {
+                    "title": "Document Ref",
+                    "type": "string"
+                  },
+                  "filename": {
+                    "default": "",
+                    "title": "Filename",
+                    "type": "string"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version.",
+                    "title": "Model"
+                  },
+                  "service_tier": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "standard",
+                          "priority"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
+                  }
+                },
+                "required": [
+                  "document_ref",
+                  "classes"
+                ],
+                "title": "ClassifyRequest",
+                "type": "object"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "classes": {
+                    "description": "The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string. JSON-serialized string in form data.",
+                    "items": {
+                      "$ref": "#/components/schemas/ClassifyClass"
+                    },
+                    "title": "Classes",
+                    "type": "array"
+                  },
+                  "content_type": {
+                    "default": "",
+                    "title": "Content Type",
+                    "type": "string"
+                  },
+                  "document": {
+                    "description": "The file to process. Provide either `document` or `document_url`, not both.",
+                    "format": "binary",
+                    "type": "string"
+                  },
+                  "document_url": {
+                    "description": "A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.",
+                    "type": "string"
+                  },
+                  "filename": {
+                    "default": "",
+                    "title": "Filename",
+                    "type": "string"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version. JSON-serialized string in form data.",
+                    "title": "Model"
+                  },
+                  "service_tier": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "standard",
+                          "priority"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
+                  }
+                },
+                "required": [
+                  "classes"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "created_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "job_id": {
+                      "description": "The unique identifier for this classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                      "type": "string"
+                    },
+                    "status": {
+                      "enum": [
+                        "pending",
+                        "processing",
+                        "completed",
+                        "failed"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Job created"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Classify Jobs",
+        "tags": [
+          "Classify"
+        ]
+      }
+    },
+    "/v1/classify/jobs/{job_id}": {
+      "get": {
+        "description": "Get the status of an async Classify job, including its result once the job has completed.",
+        "operationId": "classify_get_job",
+        "parameters": [
+          {
+            "description": "The identifier of the job to retrieve, as returned by the create-job request.",
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "description": "The identifier of the job to retrieve, as returned by the create-job request.",
+              "title": "Job Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "completed_at": {
+                      "description": "Present once the job is terminal.",
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "description": "Present once status is ``failed``.",
+                      "properties": {
+                        "code": {
+                          "description": "Stable error code (``internal_error`` when unmapped).",
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "job_id": {
+                      "description": "The unique identifier for this classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                      "type": "string"
+                    },
+                    "progress": {
+                      "description": "Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.",
+                      "maximum": 1,
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    "result": {
+                      "anyOf": [
+                        {
+                          "description": "Result returned by ``V1ClassifyOperationWorkflow`` — the\n``/v1/classify`` response body (VTRA's ``ClassifyResponse``).",
+                          "properties": {
+                            "classification": {
+                              "description": "One classification result per page, in page order.",
+                              "items": {
+                                "properties": {
+                                  "class": {
+                                    "description": "Predicted class label, or 'unknown'.",
+                                    "type": "string"
+                                  },
+                                  "page": {
+                                    "description": "Page number, zero-indexed (the first page is 0).",
+                                    "type": "integer"
+                                  },
+                                  "reason": {
+                                    "description": "Why the page was classified this way.",
+                                    "type": "string"
+                                  },
+                                  "suggested_class": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ],
+                                    "description": "A class the model proposes when the prediction is 'unknown'."
+                                  }
+                                },
+                                "required": [
+                                  "class",
+                                  "reason",
+                                  "page"
+                                ],
+                                "title": "ClassificationItem",
+                                "type": "object"
+                              },
+                              "title": "Classification",
+                              "type": "array"
+                            },
+                            "metadata": {
+                              "$ref": "#/components/schemas/V1ClassifyMetadata",
+                              "description": "Metadata for the classification request."
+                            }
+                          },
+                          "required": [
+                            "classification",
+                            "metadata"
+                          ],
+                          "title": "V1ClassifyResponse",
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Present once status is ``completed``."
+                    },
+                    "status": {
+                      "enum": [
+                        "pending",
+                        "processing",
+                        "completed",
+                        "failed"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Job status / result"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not found (e.g. no such job)."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Get Classify Jobs",
+        "tags": [
+          "Classify"
         ]
       }
     },
@@ -3912,9 +4819,13 @@
                     "description": "JSON-serialized string in form data.",
                     "title": "Custom Prompts"
                   },
-                  "document_ref": {
-                    "description": "File upload.",
+                  "document": {
+                    "description": "The file to process. Provide either `document` or `document_url`, not both.",
                     "format": "binary",
+                    "type": "string"
+                  },
+                  "document_url": {
+                    "description": "A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.",
                     "type": "string"
                   },
                   "filename": {
@@ -4015,7 +4926,6 @@
                   }
                 },
                 "required": [
-                  "document_ref",
                   "filename",
                   "content_type"
                 ],
@@ -4041,6 +4951,11 @@
                       "default": 0,
                       "title": "Billable Pages",
                       "type": "integer"
+                    },
+                    "billing_suppressed": {
+                      "default": false,
+                      "title": "Billing Suppressed",
+                      "type": "boolean"
                     },
                     "completion_tokens": {
                       "default": 0,
@@ -4481,9 +5396,13 @@
                     "description": "JSON-serialized string in form data.",
                     "title": "Custom Prompts"
                   },
-                  "document_ref": {
-                    "description": "File upload.",
+                  "document": {
+                    "description": "The file to process. Provide either `document` or `document_url`, not both.",
                     "format": "binary",
+                    "type": "string"
+                  },
+                  "document_url": {
+                    "description": "A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.",
                     "type": "string"
                   },
                   "filename": {
@@ -4612,7 +5531,6 @@
                   }
                 },
                 "required": [
-                  "document_ref",
                   "filename",
                   "content_type"
                 ],
@@ -4755,6 +5673,11 @@
                               "default": 0,
                               "title": "Billable Pages",
                               "type": "integer"
+                            },
+                            "billing_suppressed": {
+                              "default": false,
+                              "title": "Billing Suppressed",
+                              "type": "boolean"
                             },
                             "completion_tokens": {
                               "default": 0,
@@ -4907,6 +5830,77 @@
         "summary": "ADE Get Parse v1 Jobs",
         "tags": [
           "Parse v1"
+        ]
+      }
+    },
+    "/v1/split": {
+      "post": {
+        "description": "Split a Markdown document into segments and return the split response inline.",
+        "operationId": "v1-split_run_sync",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "markdown": {
+                    "anyOf": [
+                      {
+                        "format": "binary",
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "description": "Markdown content to split, as an inline string or an uploaded file. Provide either `markdown` or `markdown_url`, not both."
+                  },
+                  "markdown_url": {
+                    "description": "A publicly accessible URL to the Markdown file to split. Provide either `markdown` or `markdown_url`, not both.",
+                    "type": "string"
+                  },
+                  "model": {
+                    "description": "The split model version to use. Accepts a dated snapshot (`split-20251105`), `split-latest`, or `split` (both aliases resolve to the latest snapshot). Defaults to the latest snapshot. The resolved version is echoed back as `metadata.version`.",
+                    "type": "string"
+                  },
+                  "split_class": {
+                    "description": "The split classification entries, as a JSON-encoded array of objects with `name` (required), `description`, and `identifier` keys. At most 19 entries. Sent as a JSON-serialized string in form data.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "split_class"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SplitResponse"
+                }
+              }
+            },
+            "description": "The split response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Split",
+        "tags": [
+          "Split"
         ]
       }
     },

--- a/src/landingai_ade/resources/v2/_normalize.py
+++ b/src/landingai_ade/resources/v2/_normalize.py
@@ -12,12 +12,14 @@ from ...types.v2 import (
     JobStatus,
     V2ExtractResult,
     V2ParseResponse,
+    V2ClassifyResponse,
     V2BuildSchemaResponse,
 )
 
 __all__ = [
     "normalize_parse_job",
     "normalize_extract_job",
+    "normalize_classify_job",
     "normalize_build_schema_job",
 ]
 
@@ -117,6 +119,33 @@ def normalize_extract_job(raw: Mapping[str, Any]) -> Job:
         result=result,
         error=error,
         metadata=_metadata(raw.get("metadata")),
+        raw=dict(raw),
+    )
+
+
+def normalize_classify_job(raw: Mapping[str, Any]) -> Job:
+    status = _status(raw)
+    payload = raw.get("result")
+    # Build leniently (like the sync-response path) so unexpected upstream drift
+    # doesn't fail construction.
+    result = V2ClassifyResponse.construct(**cast(Dict[str, Any], payload)) if isinstance(payload, Mapping) else None
+
+    error = None
+    err = raw.get("error")
+    if isinstance(err, Mapping):
+        err = cast(Dict[str, Any], err)
+        error = JobError(code=err.get("code"), message=err.get("message"))
+    elif raw.get("failure_reason"):  # classify *list* uses failure_reason
+        error = JobError(message=str(raw["failure_reason"]))
+
+    return Job(
+        job_id=str(raw["job_id"]),
+        status=status,
+        created_at=_ts(raw.get("created_at")),
+        completed_at=_ts(raw.get("completed_at")),
+        progress=_progress(raw.get("progress")),
+        result=result,
+        error=error,
         raw=dict(raw),
     )
 

--- a/src/landingai_ade/resources/v2/classify.py
+++ b/src/landingai_ade/resources/v2/classify.py
@@ -1,0 +1,409 @@
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, Mapping, Callable, Iterable, Optional, cast
+from typing_extensions import Literal
+
+import httpx
+
+from ._base import DEFAULT_WAIT_TIMEOUT, JobList, V2ResourceMixin, poll_until_terminal, apoll_until_terminal
+from ..._files import deepcopy_with_paths
+from ..._types import Body, Omit, Query, Headers, NotGiven, FileTypes, omit, not_given
+from ..._utils import is_given, extract_files
+from ...types.v2 import Job, V2ClassifyResponse
+from ._normalize import normalize_classify_job
+from ..._resource import SyncAPIResource, AsyncAPIResource
+from ..._exceptions import APIStatusError
+from ..._base_client import make_request_options
+from ...lib.v2_errors import raise_if_sync_timeout
+
+__all__ = ["ClassifyResource", "AsyncClassifyResource", "ClassifyJobsResource", "AsyncClassifyJobsResource"]
+
+
+def _build_classify_body(
+    document: object,
+    document_url: object,
+    classes: Iterable[Mapping[str, object]],
+    model: object,
+) -> dict[str, Any]:
+    # `classes` is a JSON-encoded string form field per the contract: each entry
+    # is an object with a `class` name and an optional `description`.
+    body: dict[str, Any] = {"classes": json.dumps([dict(entry) for entry in classes])}
+    # Multipart requests aren't run through `maybe_transform`, so drop unset
+    # `omit`/`not_given` sentinels (and explicit `None`) here so they aren't
+    # serialized as form fields.
+    for key, value in (
+        ("document", document),
+        ("document_url", document_url),
+        ("model", model),
+    ):
+        if is_given(value) and value is not None:
+            body[key] = value
+    return body
+
+
+class ClassifyResource(V2ResourceMixin, SyncAPIResource):
+    def run(
+        self,
+        *,
+        classes: Iterable[Mapping[str, object]],
+        document: Optional[FileTypes] | Omit = omit,
+        document_url: Optional[str] | Omit = omit,
+        model: Optional[str] | Omit = omit,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> V2ClassifyResponse:
+        """Classify each page of a document into classes you define, synchronously
+        against the V2 (ADE) `/v1/classify` endpoint (multipart body).
+
+        Returns one predicted class per page. Raises `V2SyncTimeoutError` when the
+        server times out the synchronous request (HTTP 504); use the async jobs
+        route (`client.v2.classify_jobs`) for long-running documents in that case.
+
+        Args:
+          classes: The candidate classes for each page. Each entry is a mapping with a
+              `class` name and an optional `description`. Only one class is assigned per
+              page; unclassifiable pages receive `"unknown"`. Sent to the server as a
+              JSON-encoded string form field.
+
+          document: A file to be classified. Either this parameter or `document_url` must be
+              provided.
+
+          document_url: The URL to the file to be classified. Either this parameter or `document`
+              must be provided.
+
+          model: The classify pipeline version to use (e.g. `classify-latest`).
+
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        body = deepcopy_with_paths(
+            _build_classify_body(document, document_url, classes, model),
+            [["document"]],
+        )
+        files = extract_files(cast(Mapping[str, object], body), paths=[["document"]])
+        # It should be noted that the actual Content-Type header that will be
+        # sent to the server will contain a `boundary` parameter, e.g.
+        # multipart/form-data; boundary=---abc--
+        extra_headers = {"Content-Type": "multipart/form-data", **(extra_headers or {})}
+        try:
+            return self._post(
+                self._v2_url("/v1/classify"),
+                body=body,
+                files=files,
+                options=make_request_options(
+                    extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+                ),
+                cast_to=V2ClassifyResponse,
+            )
+        except APIStatusError as exc:
+            raise_if_sync_timeout(exc, jobs_resource="classify_jobs")
+            raise
+
+
+class AsyncClassifyResource(V2ResourceMixin, AsyncAPIResource):
+    async def run(
+        self,
+        *,
+        classes: Iterable[Mapping[str, object]],
+        document: Optional[FileTypes] | Omit = omit,
+        document_url: Optional[str] | Omit = omit,
+        model: Optional[str] | Omit = omit,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> V2ClassifyResponse:
+        """Async mirror of `ClassifyResource.run`. See there for full documentation."""
+        body = deepcopy_with_paths(
+            _build_classify_body(document, document_url, classes, model),
+            [["document"]],
+        )
+        files = extract_files(cast(Mapping[str, object], body), paths=[["document"]])
+        extra_headers = {"Content-Type": "multipart/form-data", **(extra_headers or {})}
+        try:
+            return await self._post(
+                self._v2_url("/v1/classify"),
+                body=body,
+                files=files,
+                options=make_request_options(
+                    extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+                ),
+                cast_to=V2ClassifyResponse,
+            )
+        except APIStatusError as exc:
+            raise_if_sync_timeout(exc, jobs_resource="classify_jobs")
+            raise
+
+
+class ClassifyJobsResource(V2ResourceMixin, SyncAPIResource):
+    def create(
+        self,
+        *,
+        classes: Iterable[Mapping[str, object]],
+        document: Optional[FileTypes] | Omit = omit,
+        document_url: Optional[str] | Omit = omit,
+        model: Optional[str] | Omit = omit,
+        service_tier: Optional[Literal["standard", "priority"]] | Omit = omit,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> Job:
+        """Create an asynchronous classify job against `/v1/classify/jobs`.
+
+        Returns a normalized `Job` immediately (typically `pending`). Poll for
+        completion via `.get(job_id)`, or block until the job is terminal with
+        `.wait(job_id)`.
+
+        Args:
+          classes: The candidate classes for each page. Each entry is a mapping with a
+              `class` name and an optional `description`. Sent to the server as a
+              JSON-encoded string form field.
+
+          document: A file to be classified. Either this parameter or `document_url` must be
+              provided.
+
+          document_url: The URL to the file to be classified. Either this parameter or `document`
+              must be provided.
+
+          model: The classify pipeline version to use (e.g. `classify-latest`).
+
+          service_tier: Service tier for the job: ``standard`` or ``priority``.
+
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        body = _build_classify_body(document, document_url, classes, model)
+        if is_given(service_tier) and service_tier is not None:
+            body["service_tier"] = service_tier
+        body = deepcopy_with_paths(body, [["document"]])
+        files = extract_files(cast(Mapping[str, object], body), paths=[["document"]])
+        extra_headers = {"Content-Type": "multipart/form-data", **(extra_headers or {})}
+        raw = self._post(
+            self._v2_url("/v1/classify/jobs"),
+            body=body,
+            files=files,
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=cast("type[Any]", object),
+        )
+        return normalize_classify_job(cast(Mapping[str, Any], raw))
+
+    def get(
+        self,
+        job_id: str,
+        *,
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> Job:
+        """Get the current status of an async classify job by `job_id`."""
+        if not job_id:
+            raise ValueError(f"Expected a non-empty value for `job_id` but received {job_id!r}")
+        raw = self._get(
+            self._v2_url(f"/v1/classify/jobs/{job_id}"),
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=cast("type[Any]", object),
+        )
+        return normalize_classify_job(cast(Mapping[str, Any], raw))
+
+    def list(
+        self,
+        *,
+        page: int | Omit = omit,
+        page_size: int | Omit = omit,
+        status: Optional[str] | Omit = omit,
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> JobList:
+        """List async classify jobs associated with your API key, newest first."""
+        query = {
+            key: value
+            for key, value in {"page": page, "page_size": page_size, "status": status}.items()
+            if is_given(value) and value is not None
+        }
+        raw = self._get(
+            self._v2_url("/v1/classify/jobs"),
+            options=make_request_options(
+                extra_headers=extra_headers,
+                extra_query=extra_query,
+                extra_body=extra_body,
+                timeout=timeout,
+                query=query,
+            ),
+            cast_to=cast("type[Any]", object),
+        )
+        env = cast(Mapping[str, Any], raw)
+        jobs = [normalize_classify_job(cast(Mapping[str, Any], item)) for item in env.get("jobs", [])]
+        return JobList.build(
+            jobs,
+            has_more=env.get("has_more"),
+            org_id=env.get("org_id"),
+            page=env.get("page"),
+            page_size=env.get("page_size"),
+        )
+
+    def wait(
+        self,
+        job_id: str,
+        *,
+        timeout: float = DEFAULT_WAIT_TIMEOUT,
+        poll_interval: Optional[float] = None,
+        raise_on_failure: bool = False,
+        _monotonic: Optional[Callable[[], float]] = None,
+    ) -> Job:
+        """Block, polling `.get(job_id)` with backoff, until the job is terminal.
+
+        Raises `JobWaitTimeoutError` if `timeout` seconds elapse before the job
+        reaches a terminal state, and `JobFailedError` if `raise_on_failure` is
+        set and the job ends failed with an error attached.
+
+        `_monotonic` is a test seam for injecting a fake clock; production
+        callers should leave it unset (defaults to `time.monotonic`).
+        """
+        return poll_until_terminal(
+            lambda: self.get(job_id),
+            monotonic=_monotonic or time.monotonic,
+            sleep=self._sleep,
+            timeout=timeout,
+            poll_interval=poll_interval,
+            raise_on_failure=raise_on_failure,
+        )
+
+
+class AsyncClassifyJobsResource(V2ResourceMixin, AsyncAPIResource):
+    async def create(
+        self,
+        *,
+        classes: Iterable[Mapping[str, object]],
+        document: Optional[FileTypes] | Omit = omit,
+        document_url: Optional[str] | Omit = omit,
+        model: Optional[str] | Omit = omit,
+        service_tier: Optional[Literal["standard", "priority"]] | Omit = omit,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> Job:
+        """Async mirror of `ClassifyJobsResource.create`. See there for full documentation."""
+        body = _build_classify_body(document, document_url, classes, model)
+        if is_given(service_tier) and service_tier is not None:
+            body["service_tier"] = service_tier
+        body = deepcopy_with_paths(body, [["document"]])
+        files = extract_files(cast(Mapping[str, object], body), paths=[["document"]])
+        extra_headers = {"Content-Type": "multipart/form-data", **(extra_headers or {})}
+        raw = await self._post(
+            self._v2_url("/v1/classify/jobs"),
+            body=body,
+            files=files,
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=cast("type[Any]", object),
+        )
+        return normalize_classify_job(cast(Mapping[str, Any], raw))
+
+    async def get(
+        self,
+        job_id: str,
+        *,
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> Job:
+        """Async mirror of `ClassifyJobsResource.get`. See there for full documentation."""
+        if not job_id:
+            raise ValueError(f"Expected a non-empty value for `job_id` but received {job_id!r}")
+        raw = await self._get(
+            self._v2_url(f"/v1/classify/jobs/{job_id}"),
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=cast("type[Any]", object),
+        )
+        return normalize_classify_job(cast(Mapping[str, Any], raw))
+
+    async def list(
+        self,
+        *,
+        page: int | Omit = omit,
+        page_size: int | Omit = omit,
+        status: Optional[str] | Omit = omit,
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> JobList:
+        """Async mirror of `ClassifyJobsResource.list`. See there for full documentation."""
+        query = {
+            key: value
+            for key, value in {"page": page, "page_size": page_size, "status": status}.items()
+            if is_given(value) and value is not None
+        }
+        raw = await self._get(
+            self._v2_url("/v1/classify/jobs"),
+            options=make_request_options(
+                extra_headers=extra_headers,
+                extra_query=extra_query,
+                extra_body=extra_body,
+                timeout=timeout,
+                query=query,
+            ),
+            cast_to=cast("type[Any]", object),
+        )
+        env = cast(Mapping[str, Any], raw)
+        jobs = [normalize_classify_job(cast(Mapping[str, Any], item)) for item in env.get("jobs", [])]
+        return JobList.build(
+            jobs,
+            has_more=env.get("has_more"),
+            org_id=env.get("org_id"),
+            page=env.get("page"),
+            page_size=env.get("page_size"),
+        )
+
+    async def wait(
+        self,
+        job_id: str,
+        *,
+        timeout: float = DEFAULT_WAIT_TIMEOUT,
+        poll_interval: Optional[float] = None,
+        raise_on_failure: bool = False,
+        _monotonic: Optional[Callable[[], float]] = None,
+    ) -> Job:
+        """Async mirror of `ClassifyJobsResource.wait`; sleeps via `anyio.sleep` instead of blocking."""
+        return await apoll_until_terminal(
+            lambda: self.get(job_id),
+            monotonic=_monotonic or time.monotonic,
+            timeout=timeout,
+            poll_interval=poll_interval,
+            raise_on_failure=raise_on_failure,
+        )

--- a/src/landingai_ade/resources/v2/split.py
+++ b/src/landingai_ade/resources/v2/split.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping, Iterable, Optional, cast
+
+import httpx
+
+from ._base import V2ResourceMixin
+from ..._files import deepcopy_with_paths
+from ..._types import Body, Omit, Query, Headers, NotGiven, FileTypes, omit, not_given
+from ..._utils import is_given, extract_files
+from ...types.v2 import V2SplitResponse
+from ..._resource import SyncAPIResource, AsyncAPIResource
+from ..._base_client import make_request_options
+
+__all__ = ["SplitResource", "AsyncSplitResource"]
+
+
+def _build_split_body(
+    markdown: object,
+    markdown_url: object,
+    split_class: Iterable[Mapping[str, object]],
+    model: object,
+) -> dict[str, Any]:
+    # `split_class` is a JSON-encoded string form field per the contract: an
+    # array of objects with `name` (required), `description`, and `identifier`.
+    body: dict[str, Any] = {"split_class": json.dumps([dict(entry) for entry in split_class])}
+    # Multipart requests aren't run through `maybe_transform`, so drop unset
+    # `omit`/`not_given` sentinels (and explicit `None`) here so they aren't
+    # serialized as form fields.
+    for key, value in (
+        ("markdown", markdown),
+        ("markdown_url", markdown_url),
+        ("model", model),
+    ):
+        if is_given(value) and value is not None:
+            body[key] = value
+    return body
+
+
+class SplitResource(V2ResourceMixin, SyncAPIResource):
+    def run(
+        self,
+        *,
+        split_class: Iterable[Mapping[str, object]],
+        markdown: Optional[FileTypes] | Omit = omit,
+        markdown_url: Optional[str] | Omit = omit,
+        model: Optional[str] | Omit = omit,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> V2SplitResponse:
+        """Split a Markdown document into segments synchronously against the V2 (ADE)
+        `/v1/split` endpoint (multipart body).
+
+        Consecutive pages with the same classification merge into one segment; an
+        identifier change starts a new segment. `/v1/split` is synchronous-only
+        (no async jobs route).
+
+        Args:
+          split_class: The split classification entries. Each entry is a mapping with a `name`
+              (required), and optional `description` / `identifier` keys. At most 19
+              entries. Sent to the server as a JSON-encoded string form field.
+
+          markdown: Markdown content to split, as an inline string or an uploaded file. Either
+              this parameter or `markdown_url` must be provided.
+
+          markdown_url: The URL to the Markdown file to split. Either this parameter or `markdown`
+              must be provided.
+
+          model: The split model version to use (e.g. `split-latest`). The resolved version
+              is echoed back as `metadata.version`.
+
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        body = deepcopy_with_paths(
+            _build_split_body(markdown, markdown_url, split_class, model),
+            [["markdown"]],
+        )
+        files = extract_files(cast(Mapping[str, object], body), paths=[["markdown"]])
+        # It should be noted that the actual Content-Type header that will be
+        # sent to the server will contain a `boundary` parameter, e.g.
+        # multipart/form-data; boundary=---abc--
+        extra_headers = {"Content-Type": "multipart/form-data", **(extra_headers or {})}
+        return self._post(
+            self._v2_url("/v1/split"),
+            body=body,
+            files=files,
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=V2SplitResponse,
+        )
+
+
+class AsyncSplitResource(V2ResourceMixin, AsyncAPIResource):
+    async def run(
+        self,
+        *,
+        split_class: Iterable[Mapping[str, object]],
+        markdown: Optional[FileTypes] | Omit = omit,
+        markdown_url: Optional[str] | Omit = omit,
+        model: Optional[str] | Omit = omit,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> V2SplitResponse:
+        """Async mirror of `SplitResource.run`. See there for full documentation."""
+        body = deepcopy_with_paths(
+            _build_split_body(markdown, markdown_url, split_class, model),
+            [["markdown"]],
+        )
+        files = extract_files(cast(Mapping[str, object], body), paths=[["markdown"]])
+        extra_headers = {"Content-Type": "multipart/form-data", **(extra_headers or {})}
+        return await self._post(
+            self._v2_url("/v1/split"),
+            body=body,
+            files=files,
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=V2SplitResponse,
+        )

--- a/src/landingai_ade/resources/v2/v2.py
+++ b/src/landingai_ade/resources/v2/v2.py
@@ -1,7 +1,7 @@
 # src/landingai_ade/resources/v2/v2.py
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Type, Union, Mapping, Optional
+from typing import TYPE_CHECKING, Type, Union, Mapping, Iterable, Optional
 from pathlib import Path
 
 import httpx
@@ -10,13 +10,20 @@ from pydantic import BaseModel
 from ._base import V2ResourceMixin
 from ..._types import Body, Omit, Query, Headers, NotGiven, FileTypes, omit, not_given
 from ..._compat import cached_property
-from ...types.v2 import V2GroundResult, V2ExtractResult, V2ParseResponse
+from ...types.v2 import V2GroundResult, V2ExtractResult, V2ParseResponse, V2SplitResponse, V2ClassifyResponse
 from ..._resource import SyncAPIResource, AsyncAPIResource
 
 if TYPE_CHECKING:
     from .parse import ParseResource, ParseJobsResource, AsyncParseResource, AsyncParseJobsResource
+    from .split import SplitResource, AsyncSplitResource
     from .ground import GroundResource, AsyncGroundResource
     from .extract import ExtractResource, ExtractJobsResource, AsyncExtractResource, AsyncExtractJobsResource
+    from .classify import (
+        ClassifyResource,
+        ClassifyJobsResource,
+        AsyncClassifyResource,
+        AsyncClassifyJobsResource,
+    )
 
 __all__ = ["V2Resource", "AsyncV2Resource"]
 
@@ -24,10 +31,10 @@ __all__ = ["V2Resource", "AsyncV2Resource"]
 class V2Resource(SyncAPIResource, V2ResourceMixin):
     """Container for the V2 (ADE) surface: ``client.v2.<resource>``.
 
-    ``parse``, ``extract``, and ``ground`` are wired up; each sub-resource
-    does its own lazy import inside its cached property body -- mirroring
-    ``LandingAIADE.parse_jobs`` -- so that this module keeps importing standalone
-    regardless of which sub-resources exist yet.
+    ``parse``, ``extract``, ``ground``, ``classify``, and ``split`` are wired up;
+    each sub-resource does its own lazy import inside its cached property body --
+    mirroring ``LandingAIADE.parse_jobs`` -- so that this module keeps importing
+    standalone regardless of which sub-resources exist yet.
     """
 
     @cached_property
@@ -136,6 +143,76 @@ class V2Resource(SyncAPIResource, V2ResourceMixin):
         return self._ground.run(
             extraction_metadata=extraction_metadata,
             structure=structure,
+            extra_headers=extra_headers,
+            extra_query=extra_query,
+            extra_body=extra_body,
+            timeout=timeout,
+        )
+
+    @cached_property
+    def _classify(self) -> ClassifyResource:
+        from .classify import ClassifyResource
+
+        return ClassifyResource(self._client)
+
+    @cached_property
+    def classify_jobs(self) -> ClassifyJobsResource:
+        from .classify import ClassifyJobsResource
+
+        return ClassifyJobsResource(self._client)
+
+    def classify(
+        self,
+        *,
+        classes: Iterable[Mapping[str, object]],
+        document: Optional[FileTypes] | Omit = omit,
+        document_url: Optional[str] | Omit = omit,
+        model: Optional[str] | Omit = omit,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> V2ClassifyResponse:
+        """Classify each page of a document synchronously. See ``ClassifyResource.run`` for full documentation."""
+        return self._classify.run(
+            classes=classes,
+            document=document,
+            document_url=document_url,
+            model=model,
+            extra_headers=extra_headers,
+            extra_query=extra_query,
+            extra_body=extra_body,
+            timeout=timeout,
+        )
+
+    @cached_property
+    def _split(self) -> SplitResource:
+        from .split import SplitResource
+
+        return SplitResource(self._client)
+
+    def split(
+        self,
+        *,
+        split_class: Iterable[Mapping[str, object]],
+        markdown: Optional[FileTypes] | Omit = omit,
+        markdown_url: Optional[str] | Omit = omit,
+        model: Optional[str] | Omit = omit,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> V2SplitResponse:
+        """Split a Markdown document into segments synchronously. See ``SplitResource.run`` for full documentation."""
+        return self._split.run(
+            split_class=split_class,
+            markdown=markdown,
+            markdown_url=markdown_url,
+            model=model,
             extra_headers=extra_headers,
             extra_query=extra_query,
             extra_body=extra_body,
@@ -252,6 +329,76 @@ class AsyncV2Resource(AsyncAPIResource, V2ResourceMixin):
         return await self._ground.run(
             extraction_metadata=extraction_metadata,
             structure=structure,
+            extra_headers=extra_headers,
+            extra_query=extra_query,
+            extra_body=extra_body,
+            timeout=timeout,
+        )
+
+    @cached_property
+    def _classify(self) -> AsyncClassifyResource:
+        from .classify import AsyncClassifyResource
+
+        return AsyncClassifyResource(self._client)
+
+    @cached_property
+    def classify_jobs(self) -> AsyncClassifyJobsResource:
+        from .classify import AsyncClassifyJobsResource
+
+        return AsyncClassifyJobsResource(self._client)
+
+    async def classify(
+        self,
+        *,
+        classes: Iterable[Mapping[str, object]],
+        document: Optional[FileTypes] | Omit = omit,
+        document_url: Optional[str] | Omit = omit,
+        model: Optional[str] | Omit = omit,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> V2ClassifyResponse:
+        """Async mirror of :meth:`V2Resource.classify`."""
+        return await self._classify.run(
+            classes=classes,
+            document=document,
+            document_url=document_url,
+            model=model,
+            extra_headers=extra_headers,
+            extra_query=extra_query,
+            extra_body=extra_body,
+            timeout=timeout,
+        )
+
+    @cached_property
+    def _split(self) -> AsyncSplitResource:
+        from .split import AsyncSplitResource
+
+        return AsyncSplitResource(self._client)
+
+    async def split(
+        self,
+        *,
+        split_class: Iterable[Mapping[str, object]],
+        markdown: Optional[FileTypes] | Omit = omit,
+        markdown_url: Optional[str] | Omit = omit,
+        model: Optional[str] | Omit = omit,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> V2SplitResponse:
+        """Async mirror of :meth:`V2Resource.split`."""
+        return await self._split.run(
+            split_class=split_class,
+            markdown=markdown,
+            markdown_url=markdown_url,
+            model=model,
             extra_headers=extra_headers,
             extra_query=extra_query,
             extra_body=extra_body,

--- a/src/landingai_ade/types/v2/__init__.py
+++ b/src/landingai_ade/types/v2/__init__.py
@@ -16,6 +16,11 @@ from .parse_response import (
     V2ParseGroundingEntry as V2ParseGroundingEntry,
     V2ParseGroundingElement as V2ParseGroundingElement,
 )
+from .split_response import (
+    V2Split as V2Split,
+    V2SplitMetadata as V2SplitMetadata,
+    V2SplitResponse as V2SplitResponse,
+)
 from .ground_response import (
     V2GroundResult as V2GroundResult,
     V2GroundBilling as V2GroundBilling,
@@ -25,6 +30,11 @@ from .extract_response import (
     V2ExtractResult as V2ExtractResult,
     V2ExtractBilling as V2ExtractBilling,
     V2ExtractMetadata as V2ExtractMetadata,
+)
+from .classify_response import (
+    V2ClassifyMetadata as V2ClassifyMetadata,
+    V2ClassifyResponse as V2ClassifyResponse,
+    V2ClassificationItem as V2ClassificationItem,
 )
 from .build_schema_response import (
     V2BuildSchemaBilling as V2BuildSchemaBilling,

--- a/src/landingai_ade/types/v2/classify_response.py
+++ b/src/landingai_ade/types/v2/classify_response.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import Field as FieldInfo
+
+from ..._models import BaseModel
+
+__all__ = ["V2ClassificationItem", "V2ClassifyMetadata", "V2ClassifyResponse"]
+
+
+class V2ClassificationItem(BaseModel):
+    """One page-level classification result."""
+
+    # Predicted class label, or "unknown". The wire key is `class` (a Python
+    # keyword), so the field is `class_` with the alias carrying the wire name.
+    class_: str = FieldInfo(alias="class")
+    # Page number, zero-indexed (the first page is 0).
+    page: int
+    # Why the page was classified this way.
+    reason: str
+    # A class the model proposes when the prediction is "unknown".
+    suggested_class: Optional[str] = None
+
+
+class V2ClassifyMetadata(BaseModel):
+    """Response metadata for a v2 classify call."""
+
+    # Number of pages classified. Required and non-null per the spec.
+    page_count: int
+    # End-to-end request duration in milliseconds. Required and non-null per the spec.
+    duration_ms: int
+    # URL of the OpenAPI spec covering this API. Required and non-null per the spec.
+    openapi_spec: str
+    # Credits billed for this request.
+    credit_usage: Optional[float] = None
+    # Name of the classified file.
+    filename: Optional[str] = None
+    # Gateway job id (workflow id). Matches the billing row id in vision-agent.
+    job_id: Optional[str] = None
+    org_id: Optional[str] = None
+    # Resolved classify pipeline version that produced this response.
+    version: Optional[str] = None
+
+
+class V2ClassifyResponse(BaseModel):
+    # One classification result per page, in page order.
+    classification: List[V2ClassificationItem]
+    metadata: V2ClassifyMetadata

--- a/src/landingai_ade/types/v2/split_response.py
+++ b/src/landingai_ade/types/v2/split_response.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from ..._models import BaseModel
+
+__all__ = ["V2Split", "V2SplitMetadata", "V2SplitResponse"]
+
+
+class V2Split(BaseModel):
+    """One split segment: consecutive pages of one classification.
+
+    An identifier change starts a new segment.
+    """
+
+    # The split classification name this segment was assigned.
+    classification: str
+    # The Markdown content of each page in this segment, in order.
+    markdowns: List[str]
+    # 0-indexed page numbers belonging to this segment, in order.
+    pages: List[int]
+    # The identifier value extracted for this segment, when the matching split
+    # classification requested one. Null otherwise (the key is always present per
+    # the spec, but may be null).
+    identifier: Optional[str] = None
+
+
+class V2SplitMetadata(BaseModel):
+    """Information about a split request."""
+
+    # Credits consumed by this request. Required and non-null per the spec.
+    credit_usage: float
+    # Total processing time in milliseconds. Required and non-null per the spec.
+    duration_ms: int
+    # Display name of the split document. Required and non-null per the spec.
+    filename: str
+    # The split job identifier -- server-minted and unique per request. Required
+    # and non-null per the spec.
+    job_id: str
+    # Total number of pages in the input Markdown. Required and non-null per the spec.
+    page_count: int
+    # The exact split model snapshot that processed the document, e.g.
+    # `split-20251105`. Required and non-null per the spec.
+    version: str
+    org_id: Optional[str] = None
+
+
+class V2SplitResponse(BaseModel):
+    # The split segments, in page order. Consecutive pages with the same
+    # classification merge into one segment; an identifier change starts a new one.
+    splits: List[V2Split]
+    metadata: V2SplitMetadata

--- a/tests/api_resources/v2/test_classify.py
+++ b/tests/api_resources/v2/test_classify.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import httpx
+import respx
+import pytest
+
+from landingai_ade import LandingAIADE
+from landingai_ade.types.v2 import Job, JobStatus, V2ClassifyResponse
+from landingai_ade.lib.v2_errors import V2SyncTimeoutError
+
+APIKEY = "My Apikey"
+
+CLASSES = [{"class": "invoice", "description": "A billing invoice"}, {"class": "receipt"}]
+
+CLASSIFY_BODY: Dict[str, Any] = {
+    "classification": [
+        {"class": "invoice", "page": 0, "reason": "Has an invoice number and totals."},
+        {"class": "unknown", "page": 1, "reason": "No signal.", "suggested_class": "cover_page"},
+    ],
+    "metadata": {
+        "page_count": 2,
+        "duration_ms": 42,
+        "openapi_spec": "https://api.ade.landing.ai/openapi.json",
+        "credit_usage": 0.2,
+        "job_id": "classify-1",
+        "version": "classify-20260420",
+    },
+}
+
+
+@respx.mock
+def test_classify_sync_routes_to_v1_and_sends_classes_json() -> None:
+    client = LandingAIADE(apikey=APIKEY, environment="production")
+    route = respx.post("https://api.ade.landing.ai/v1/classify").mock(
+        return_value=httpx.Response(200, json=CLASSIFY_BODY)
+    )
+    result = client.v2.classify(classes=CLASSES, document=b"pdf")
+    assert isinstance(result, V2ClassifyResponse)
+    assert result.classification[0].class_ == "invoice"
+    assert result.classification[0].page == 0
+    assert result.classification[1].suggested_class == "cover_page"
+    assert result.metadata.page_count == 2
+    assert result.metadata.version == "classify-20260420"
+    # `classes` must be sent as a JSON-encoded string form field.
+    sent = route.calls.last.request.content
+    assert b'name="classes"' in sent
+    assert b'"class": "invoice"' in sent
+
+
+@respx.mock
+def test_classify_sync_omits_unset_and_none_fields() -> None:
+    client = LandingAIADE(apikey=APIKEY, environment="production")
+    route = respx.post("https://api.ade.landing.ai/v1/classify").mock(
+        return_value=httpx.Response(200, json=CLASSIFY_BODY)
+    )
+    client.v2.classify(classes=CLASSES, document=b"pdf", document_url=None, model=None)
+    sent = route.calls.last.request.content
+    assert b"Omit object" not in sent
+    assert b"NOT_GIVEN" not in sent
+    assert b"document_url" not in sent
+    assert b'name="model"' not in sent
+
+
+@respx.mock
+def test_classify_sync_504_raises_v2_sync_timeout() -> None:
+    client = LandingAIADE(apikey=APIKEY, max_retries=0)
+    respx.post("https://api.ade.landing.ai/v1/classify").mock(return_value=httpx.Response(504, json={"detail": "x"}))
+    with pytest.raises(V2SyncTimeoutError, match="classify_jobs"):
+        client.v2.classify(classes=CLASSES, document=b"pdf")
+
+
+@respx.mock
+def test_classify_job_create_normalizes_envelope() -> None:
+    client = LandingAIADE(apikey=APIKEY)
+    respx.post("https://api.ade.landing.ai/v1/classify/jobs").mock(
+        return_value=httpx.Response(202, json={"job_id": "c1", "status": "pending"})
+    )
+    job = client.v2.classify_jobs.create(classes=CLASSES, document=b"pdf", service_tier="priority")
+    assert isinstance(job, Job)
+    assert job.job_id == "c1" and job.status is JobStatus.PENDING
+
+
+def test_classify_job_create_sends_service_tier(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = LandingAIADE(apikey=APIKEY)
+    captured: Dict[str, Any] = {}
+
+    def fake_post(path: str, *, cast_to: Any, body: Any = None, files: Any = None, options: Any = None) -> Any:  # noqa: ARG001
+        captured["body"] = body
+        return {"job_id": "c1", "status": "pending"}
+
+    monkeypatch.setattr(client.v2.classify_jobs, "_post", fake_post)
+    client.v2.classify_jobs.create(classes=CLASSES, document=b"x", service_tier="priority", model=None)
+    assert captured["body"]["service_tier"] == "priority"
+    assert "model" not in captured["body"]
+
+
+@respx.mock
+def test_classify_job_get_completed_has_typed_result() -> None:
+    client = LandingAIADE(apikey=APIKEY)
+    respx.get("https://api.ade.landing.ai/v1/classify/jobs/c1").mock(
+        return_value=httpx.Response(
+            200,
+            json={"job_id": "c1", "status": "completed", "created_at": 1700000000, "result": CLASSIFY_BODY},
+        )
+    )
+    job = client.v2.classify_jobs.get("c1")
+    assert job.status is JobStatus.COMPLETED
+    assert isinstance(job.result, V2ClassifyResponse)
+    assert job.result.classification[0].class_ == "invoice"
+
+
+@respx.mock
+def test_classify_job_get_failed_carries_error() -> None:
+    client = LandingAIADE(apikey=APIKEY)
+    respx.get("https://api.ade.landing.ai/v1/classify/jobs/c2").mock(
+        return_value=httpx.Response(
+            200,
+            json={"job_id": "c2", "status": "failed", "error": {"code": "bad_pdf", "message": "boom"}},
+        )
+    )
+    failed = client.v2.classify_jobs.get("c2")
+    assert failed.status is JobStatus.FAILED
+    assert failed.error is not None and failed.error.code == "bad_pdf"
+    assert failed.result is None
+
+
+@respx.mock
+def test_classify_job_get_empty_job_id_raises() -> None:
+    client = LandingAIADE(apikey=APIKEY)
+    with pytest.raises(ValueError):
+        client.v2.classify_jobs.get("")
+
+
+@respx.mock
+def test_classify_job_list_carries_envelope() -> None:
+    client = LandingAIADE(apikey=APIKEY)
+    respx.get("https://api.ade.landing.ai/v1/classify/jobs").mock(
+        return_value=httpx.Response(
+            200,
+            json={"jobs": [{"job_id": "c1", "status": "completed"}], "page": 0, "page_size": 10, "has_more": False},
+        )
+    )
+    jobs = client.v2.classify_jobs.list()
+    assert len(jobs) == 1 and jobs[0].job_id == "c1"
+    assert jobs.page == 0 and jobs.page_size == 10 and jobs.has_more is False
+
+
+@respx.mock
+def test_classify_job_wait_polls_until_completed() -> None:
+    client = LandingAIADE(apikey=APIKEY)
+    responses = [
+        httpx.Response(200, json={"job_id": "c1", "status": "processing", "progress": 0.5}),
+        httpx.Response(200, json={"job_id": "c1", "status": "completed", "result": CLASSIFY_BODY}),
+    ]
+    respx.get("https://api.ade.landing.ai/v1/classify/jobs/c1").mock(side_effect=responses)
+    ticks = iter([0.0, 0.0, 0.1, 0.2, 0.3])
+    job = client.v2.classify_jobs.wait("c1", timeout=30, poll_interval=0.01, _monotonic=lambda: next(ticks))
+    assert job.status is JobStatus.COMPLETED
+    assert isinstance(job.result, V2ClassifyResponse)
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_async_classify_and_jobs() -> None:
+    from landingai_ade import AsyncLandingAIADE
+
+    client = AsyncLandingAIADE(apikey=APIKEY, environment="production")
+    respx.post("https://api.ade.landing.ai/v1/classify").mock(return_value=httpx.Response(200, json=CLASSIFY_BODY))
+    result = await client.v2.classify(classes=CLASSES, document=b"pdf")
+    assert isinstance(result, V2ClassifyResponse)
+
+    respx.post("https://api.ade.landing.ai/v1/classify/jobs").mock(
+        return_value=httpx.Response(202, json={"job_id": "c1", "status": "pending"})
+    )
+    respx.get("https://api.ade.landing.ai/v1/classify/jobs/c1").mock(
+        return_value=httpx.Response(200, json={"job_id": "c1", "status": "completed", "result": CLASSIFY_BODY})
+    )
+    created = await client.v2.classify_jobs.create(classes=CLASSES, document=b"pdf")
+    assert created.status is JobStatus.PENDING
+    fetched = await client.v2.classify_jobs.get("c1")
+    assert fetched.status is JobStatus.COMPLETED
+    assert isinstance(fetched.result, V2ClassifyResponse)

--- a/tests/api_resources/v2/test_split.py
+++ b/tests/api_resources/v2/test_split.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import httpx
+import respx
+import pytest
+
+from landingai_ade import LandingAIADE
+from landingai_ade.types.v2 import V2SplitResponse
+
+APIKEY = "My Apikey"
+
+SPLIT_CLASS = [
+    {"name": "invoice", "description": "A billing invoice", "identifier": "invoice_number"},
+    {"name": "receipt"},
+]
+
+SPLIT_BODY: Dict[str, Any] = {
+    "splits": [
+        {
+            "classification": "invoice",
+            "identifier": "INV-042",
+            "markdowns": ["# Invoice\n", "line items\n"],
+            "pages": [0, 1],
+        },
+        {
+            "classification": "receipt",
+            "identifier": None,
+            "markdowns": ["# Receipt\n"],
+            "pages": [2],
+        },
+    ],
+    "metadata": {
+        "credit_usage": 0.1,
+        "duration_ms": 12,
+        "filename": "doc.md",
+        "job_id": "split-1",
+        "org_id": None,
+        "page_count": 3,
+        "version": "split-20251105",
+    },
+}
+
+
+@respx.mock
+def test_split_sync_routes_to_v1_and_sends_split_class_json() -> None:
+    client = LandingAIADE(apikey=APIKEY, environment="production")
+    route = respx.post("https://api.ade.landing.ai/v1/split").mock(return_value=httpx.Response(200, json=SPLIT_BODY))
+    result = client.v2.split(split_class=SPLIT_CLASS, markdown="# Invoice")
+    assert isinstance(result, V2SplitResponse)
+    assert len(result.splits) == 2
+    assert result.splits[0].classification == "invoice"
+    assert result.splits[0].identifier == "INV-042"
+    assert result.splits[0].pages == [0, 1]
+    # An identifier that is null on the wire deserializes to None.
+    assert result.splits[1].identifier is None
+    assert result.metadata.version == "split-20251105"
+    assert result.metadata.org_id is None
+    # `split_class` must be sent as a JSON-encoded string form field.
+    sent = route.calls.last.request.content
+    assert b'name="split_class"' in sent
+    assert b'"name": "invoice"' in sent
+
+
+@respx.mock
+def test_split_sync_omits_unset_and_none_fields() -> None:
+    client = LandingAIADE(apikey=APIKEY, environment="production")
+    route = respx.post("https://api.ade.landing.ai/v1/split").mock(return_value=httpx.Response(200, json=SPLIT_BODY))
+    client.v2.split(split_class=SPLIT_CLASS, markdown_url="https://example.com/doc.md", model=None)
+    sent = route.calls.last.request.content
+    assert b"Omit object" not in sent
+    assert b"NOT_GIVEN" not in sent
+    assert b'name="markdown"' not in sent
+    assert b'name="model"' not in sent
+    assert b'name="markdown_url"' in sent
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_async_split_sync_ok() -> None:
+    from landingai_ade import AsyncLandingAIADE
+
+    client = AsyncLandingAIADE(apikey=APIKEY, environment="production")
+    respx.post("https://api.ade.landing.ai/v1/split").mock(return_value=httpx.Response(200, json=SPLIT_BODY))
+    result = await client.v2.split(split_class=SPLIT_CLASS, markdown="# Invoice")
+    assert isinstance(result, V2SplitResponse)
+    assert result.splits[0].markdowns == ["# Invoice\n", "line items\n"]

--- a/tests/contract/test_v2_smoke.py
+++ b/tests/contract/test_v2_smoke.py
@@ -14,6 +14,8 @@ from landingai_ade.types.v2 import (
     V2ParseElement,
     V2ExtractResult,
     V2ParseResponse,
+    V2SplitResponse,
+    V2ClassifyResponse,
     V2ParseNodeGrounding,
 )
 
@@ -152,6 +154,52 @@ def test_parse_atomic_grounding_confidence(staging_client: LandingAIADE) -> None
     for page in resp.structure.children:
         _check_node(page.grounding)
         _walk(page.children)
+
+
+def test_classify_sync(staging_client: LandingAIADE) -> None:
+    # Do not pin `model=`: the default classify pipeline is what staging is
+    # guaranteed to serve. Assert only the response contract, not a specific
+    # predicted class (that depends on the document and model).
+    pdf = Path(__file__).parent / "sample.pdf"
+    res = staging_client.v2.classify(
+        classes=[
+            {"class": "report", "description": "A business or financial report"},
+            {"class": "invoice", "description": "A billing invoice"},
+        ],
+        document=pdf,
+    )
+    assert isinstance(res, V2ClassifyResponse)
+    assert res.classification, "expected at least one page classification"
+    for item in res.classification:
+        assert isinstance(item.class_, str) and item.class_
+        assert isinstance(item.page, int)
+        # Optional field: absent-or-valid.
+        if item.suggested_class is not None:
+            assert isinstance(item.suggested_class, str)
+    assert res.metadata.page_count >= 1
+    # Optional metadata field: assert absent-or-valid, never that it is populated.
+    if res.metadata.credit_usage is not None:
+        assert res.metadata.credit_usage >= 0
+
+
+def test_split_sync(staging_client: LandingAIADE) -> None:
+    # Split takes Markdown; use the inline sample so no file is needed. Do not
+    # pin `model=` -- the default split snapshot is what staging serves.
+    res = staging_client.v2.split(
+        split_class=[{"name": "report", "description": "The report body"}],
+        markdown=SAMPLE_MARKDOWN,
+    )
+    assert isinstance(res, V2SplitResponse)
+    assert isinstance(res.splits, list)
+    for seg in res.splits:
+        assert isinstance(seg.classification, str)
+        assert isinstance(seg.pages, list)
+        assert isinstance(seg.markdowns, list)
+        # Optional field: absent-or-valid.
+        if seg.identifier is not None:
+            assert isinstance(seg.identifier, str)
+    assert res.metadata.job_id
+    assert res.metadata.page_count >= 1
 
 
 def test_ground_sync(staging_client: LandingAIADE) -> None:

--- a/tests/test_v2_normalize.py
+++ b/tests/test_v2_normalize.py
@@ -8,11 +8,13 @@ from landingai_ade.types.v2 import (
     JobStatus,
     V2ExtractResult,
     V2ParseResponse,
+    V2ClassifyResponse,
     V2BuildSchemaResponse,
 )
 from landingai_ade.resources.v2._normalize import (
     normalize_parse_job,
     normalize_extract_job,
+    normalize_classify_job,
     normalize_build_schema_job,
 )
 
@@ -194,6 +196,40 @@ def test_normalize_extract_job_unknown_status_defaults_to_pending() -> None:
     job = normalize_extract_job(raw)
     assert job.status is JobStatus.PENDING
     assert job.raw["status"] == "some_brand_new_status"
+
+
+def test_normalize_classify_job_iso_and_result() -> None:
+    raw: Dict[str, Any] = {
+        "job_id": "classify-1",
+        "status": "completed",
+        "created_at": "2026-01-02T03:04:05Z",
+        "completed_at": "2026-01-02T03:04:09Z",
+        "result": {
+            "classification": [{"class": "invoice", "page": 0, "reason": "totals present"}],
+            "metadata": {"page_count": 1, "duration_ms": 10, "openapi_spec": "https://x/openapi.json"},
+        },
+    }
+    job = normalize_classify_job(raw)
+    assert job.status is JobStatus.COMPLETED
+    assert job.created_at is not None and job.created_at.year == 2026
+    assert isinstance(job.result, V2ClassifyResponse)
+    assert job.result.classification[0].class_ == "invoice"
+
+
+def test_normalize_classify_job_error_object() -> None:
+    raw = {"job_id": "classify-2", "status": "failed", "error": {"code": "internal_error", "message": "boom"}}
+    job = normalize_classify_job(raw)
+    assert job.status is JobStatus.FAILED
+    assert job.error is not None and job.error.code == "internal_error"
+    assert job.result is None
+
+
+def test_normalize_classify_job_minimal_create_envelope_defaults_to_pending() -> None:
+    raw = {"job_id": "classify-x"}
+    job = normalize_classify_job(raw)
+    assert job.job_id == "classify-x"
+    assert job.status is JobStatus.PENDING
+    assert job.result is None
 
 
 def test_normalize_build_schema_job_iso_and_result() -> None:

--- a/tests/test_v2_types.py
+++ b/tests/test_v2_types.py
@@ -10,6 +10,8 @@ from landingai_ade.types.v2 import (
     V2GroundResult,
     V2ExtractResult,
     V2ParseResponse,
+    V2SplitResponse,
+    V2ClassifyResponse,
     V2BuildSchemaResponse,
 )
 
@@ -66,6 +68,51 @@ def test_job_raw_default_is_independent_per_instance() -> None:
     job_a.raw["org_id"] = "o1"
     assert job_b.raw == {}
     assert job_a.raw is not job_b.raw
+
+
+def test_classify_response_deserializes_with_class_alias_and_optionals() -> None:
+    resp = V2ClassifyResponse.model_validate(
+        {
+            "classification": [
+                {"class": "invoice", "page": 0, "reason": "totals present"},
+                {"class": "unknown", "page": 1, "reason": "no signal", "suggested_class": "cover"},
+            ],
+            "metadata": {"page_count": 2, "duration_ms": 5, "openapi_spec": "https://x/openapi.json"},
+        }
+    )
+    # `class` is a Python keyword, so it deserializes onto `class_` via its alias.
+    assert resp.classification[0].class_ == "invoice"
+    assert resp.classification[0].suggested_class is None
+    assert resp.classification[1].suggested_class == "cover"
+    # Optional metadata absent from the payload defaults to None.
+    assert resp.metadata.page_count == 2
+    assert resp.metadata.credit_usage is None
+    assert resp.metadata.version is None
+
+
+def test_split_response_deserializes_and_treats_null_identifier_as_none() -> None:
+    resp = V2SplitResponse.model_validate(
+        {
+            "splits": [
+                {"classification": "invoice", "identifier": "INV-1", "markdowns": ["a"], "pages": [0]},
+                {"classification": "receipt", "identifier": None, "markdowns": ["b"], "pages": [1]},
+            ],
+            "metadata": {
+                "credit_usage": 0.1,
+                "duration_ms": 3,
+                "filename": "d.md",
+                "job_id": "split-1",
+                "org_id": None,
+                "page_count": 2,
+                "version": "split-20251105",
+            },
+        }
+    )
+    assert resp.splits[0].identifier == "INV-1"
+    # A null identifier and an absent one are the same state (None).
+    assert resp.splits[1].identifier is None
+    assert resp.metadata.org_id is None
+    assert resp.metadata.version == "split-20251105"
 
 
 def test_job_raw_default_is_independent_per_instance_via_construct() -> None:


### PR DESCRIPTION
Automated V2 spec-sync PR (`client.v2`).

- **Commit 1 (mechanical):** normalized V2 spec snapshot + regenerated reference models.
- **Commit 2 (AI, only if the spec diff needs SDK changes):** client.v2 resources/methods/tests/docs wired from the diff, added after this PR opened. Workflow-only drift is excluded and an AI no-op is skipped, so some drifts produce a **mechanical-only PR with no second commit**.

Gates (surface-lock, V2 contract tests, lint/test/typecheck) must pass. When present, the AI commit is a **draft a human finishes** (the V2 ergonomic layer — unified Job, dual-host, schema coercion — is not in the spec). **Human review required before merge.**

<!-- what-changed:start -->
## What changed
_AI-generated from the PR diff — verify against the actual changes._

This PR adds new synchronous and asynchronous Classify and Split endpoints to the V2 (ADE) client surface, plus their response types; the workflow-related spec changes are not part of this SDK's client surface and introduce no client-facing change.

**Changes:**
- Add `client.v2.classify(...)` (sync `POST /v1/classify`) returning `V2ClassifyResponse`, with `V2SyncTimeoutError` on 504 pointing at `classify_jobs`.
- Add `client.v2.classify_jobs` (`create`/`get`/`list`/`wait` against `/v1/classify/jobs*`) mirroring `parse_jobs`, with completed jobs carrying `V2ClassifyResponse` on `result`.
- Add `client.v2.split(...)` (sync-only `POST /v1/split`) returning `V2SplitResponse`; no async jobs route.
- Add new response types `V2ClassificationItem`, `V2ClassifyMetadata`, `V2ClassifyResponse`, `V2Split`, `V2SplitMetadata`, `V2SplitResponse`.
- Extend the unified `Job.result` union to include `V2ClassifyResponse` for classify jobs.
<!-- what-changed:end -->
<!-- spec-sync-nudged: 20702 -->
