### PR TITLE
spec-sync(v2): track spec drift

### DIFF
--- a/api.md
+++ b/api.md
@@ -64,7 +64,7 @@ Methods:
 
 The `client.v2` sub-client targets LandingAI's next-generation ADE gateway, which lives on its own host (`api.ade.[env].landing.ai`) rather than the V1 host (`api.va.[env].landing.ai`). It is **additive**: `client.v2.*` is a separate surface from the top-level `client.*` (V1) methods documented above, and using it does not change any V1 behavior. See the [README](README.md#environments) for environment selection and usage examples.
 
-`client.v2.parse_jobs` and `client.v2.extract_jobs` both return a single, unified <a href="./src/landingai_ade/types/v2/job.py">`Job`</a> shape, even though the underlying parse/extract job envelopes differ upstream -- `Job.raw` retains the full original envelope as an escape hatch for any field not surfaced on the typed model.
+`client.v2.parse_jobs`, `client.v2.extract_jobs`, and `client.v2.classify_jobs` all return a single, unified <a href="./src/landingai_ade/types/v2/job.py">`Job`</a> shape, even though the underlying job envelopes differ upstream -- `Job.raw` retains the full original envelope as an escape hatch for any field not surfaced on the typed model.
 
 Types:
 
@@ -77,6 +77,9 @@ from landingai_ade.types.v2 import (
     V2BuildSchemaMetadata,
     V2BuildSchemaResponse,
     V2BuildSchemaWarning,
+    V2Classification,
+    V2ClassifyMetadata,
+    V2ClassifyResponse,
     V2ExtractBilling,
     V2ExtractMetadata,
     V2ExtractResult,
@@ -96,14 +99,19 @@ from landingai_ade.types.v2 import (
     V2ParseRange,
     V2ParseResponse,
     V2ParseStructure,
+    V2Split,
+    V2SplitMetadata,
+    V2SplitResponse,
 )
 ```
 
-- <code><a href="./src/landingai_ade/types/v2/job.py">Job</a></code> -- unified job shape: `job_id`, `status` (<code><a href="./src/landingai_ade/types/v2/job.py">JobStatus</a></code>: `pending` / `processing` / `completed` / `failed` / `cancelled`), `created_at`, `completed_at`, `progress`, `result` (a `V2ParseResponse` for parse jobs, a `V2ExtractResult` for extract jobs, a `V2BuildSchemaResponse` for build-schema jobs, or `None` until completion), `error` (<code><a href="./src/landingai_ade/types/v2/job.py">JobError</a></code>), `metadata` (the result's metadata receipt as a `dict`, populated top-level only when `output_save_url` was set and the result was delivered to `output_url` instead of inline; `None` otherwise, since inline jobs carry it on `result.metadata`), `raw` (the full original envelope as a `dict`), and the `.is_terminal` property.
+- <code><a href="./src/landingai_ade/types/v2/job.py">Job</a></code> -- unified job shape: `job_id`, `status` (<code><a href="./src/landingai_ade/types/v2/job.py">JobStatus</a></code>: `pending` / `processing` / `completed` / `failed` / `cancelled`), `created_at`, `completed_at`, `progress`, `result` (a `V2ParseResponse` for parse jobs, a `V2ExtractResult` for extract jobs, a `V2ClassifyResponse` for classify jobs, a `V2BuildSchemaResponse` for build-schema jobs, or `None` until completion), `error` (<code><a href="./src/landingai_ade/types/v2/job.py">JobError</a></code>), `metadata` (the result's metadata receipt as a `dict`, populated top-level only when `output_save_url` was set and the result was delivered to `output_url` instead of inline; `None` otherwise, since inline jobs carry it on `result.metadata`), `raw` (the full original envelope as a `dict`), and the `.is_terminal` property.
 - <code><a href="./src/landingai_ade/types/v2/parse_response.py">V2ParseResponse</a></code> -- `markdown`, `structure`, `grounding`, `metadata` (<code><a href="./src/landingai_ade/types/v2/parse_response.py">V2ParseMetadata</a></code>, which nests <code><a href="./src/landingai_ade/types/v2/parse_response.py">V2ParseBilling</a></code> and carries `output_markdown_chars`, `range_units`, and `openapi_spec`). `structure` is a typed <code><a href="./src/landingai_ade/types/v2/parse_response.py">V2ParseStructure</a></code> tree (`document` → <code><a href="./src/landingai_ade/types/v2/parse_response.py">V2ParsePage</a></code> → <code><a href="./src/landingai_ade/types/v2/parse_response.py">V2ParseElement</a></code>); each node below the root carries its spatial data inline in a <code><a href="./src/landingai_ade/types/v2/parse_response.py">V2ParseNodeGrounding</a></code> (`page`, <code><a href="./src/landingai_ade/types/v2/parse_response.py">V2ParseRange</a></code>, <code><a href="./src/landingai_ade/types/v2/parse_response.py">V2ParseBox</a></code>, normalized page coordinates, and an optional `confidence` in `[0, 1]` that is present only on word-granularity `atomic_grounding` segments (`dpt-3-verity`), where it is the lowest per-character OCR confidence in the word, and that is `None` on node-level grounding and on line-granularity models (`dpt-3-pro`)), and leaf elements additionally carry an `atomic_grounding` list. With `options.inline_markdown`, each node also carries its `markdown` slice. The legacy top-level `grounding` tree (<code><a href="./src/landingai_ade/types/v2/parse_response.py">V2ParseGrounding</a></code> → `V2ParseGroundingPage` → `V2ParseGroundingElement` → `V2ParseGroundingEntry`) is retained for older gateway responses. Element `type`/page `status` are permissive strings and unknown keys are retained.
 - <code><a href="./src/landingai_ade/types/v2/extract_response.py">V2ExtractResult</a></code> -- `extraction`, `extraction_metadata`, `markdown`, `output_ref`, `schema_violation_error` (set when `strict=False` and the schema had unextractable fields), `warnings`, and `metadata` (<code><a href="./src/landingai_ade/types/v2/extract_response.py">V2ExtractMetadata</a></code>, which carries `model_version`, `input_markdown_chars`, `output_extraction_chars`, `range_units`, `openapi_spec`, and nests <code><a href="./src/landingai_ade/types/v2/extract_response.py">V2ExtractBilling</a></code>).
 - <code><a href="./src/landingai_ade/types/v2/build_schema_response.py">V2BuildSchemaResponse</a></code> -- `extraction_schema` (the generated JSON Schema serialized as a string) and `metadata` (<code><a href="./src/landingai_ade/types/v2/build_schema_response.py">V2BuildSchemaMetadata</a></code>: `job_id`, `duration_ms`, `openapi_spec`, `filename`/`org_id`/`version` (retained for compatibility), a `warnings` list of <code><a href="./src/landingai_ade/types/v2/build_schema_response.py">V2BuildSchemaWarning</a></code> (`code`, `msg`), and nested <code><a href="./src/landingai_ade/types/v2/build_schema_response.py">V2BuildSchemaBilling</a></code>).
 - <code><a href="./src/landingai_ade/types/v2/ground_response.py">V2GroundResult</a></code> -- `grounding` (a tree mirroring the input `extraction_metadata`, each `{value, ranges}` leaf replaced by the list of `structure` blocks its ranges overlap) and `metadata` (<code><a href="./src/landingai_ade/types/v2/ground_response.py">V2GroundMetadata</a></code>: `job_id`, `duration_ms`, `openapi_spec`, and nested <code><a href="./src/landingai_ade/types/v2/ground_response.py">V2GroundBilling</a></code>).
+- <code><a href="./src/landingai_ade/types/v2/classify_response.py">V2ClassifyResponse</a></code> -- `classification` (one <code><a href="./src/landingai_ade/types/v2/classify_response.py">V2Classification</a></code> per page, in page order: `class_` (aliased from the wire `class`), `page` (0-indexed), `reason`, and optional `suggested_class`) and `metadata` (<code><a href="./src/landingai_ade/types/v2/classify_response.py">V2ClassifyMetadata</a></code>: required `page_count`, `duration_ms`, `openapi_spec`, plus optional `credit_usage`, `filename`, `job_id`, `org_id`, `version`).
+- <code><a href="./src/landingai_ade/types/v2/split_response.py">V2SplitResponse</a></code> -- `splits` (the merged segments, in page order: each <code><a href="./src/landingai_ade/types/v2/split_response.py">V2Split</a></code> carries `classification`, a required-but-nullable `identifier`, `markdowns`, and `pages`) and `metadata` (<code><a href="./src/landingai_ade/types/v2/split_response.py">V2SplitMetadata</a></code>: `filename`, `org_id` (nullable), `page_count`, `duration_ms`, `credit_usage`, `job_id`, `version`).
 
 Methods:
 
@@ -133,7 +141,22 @@ Methods:
 
   Synchronous ground. Maps each extracted field back to the `structure` blocks it was quoted from by overlapping `extraction_metadata` ranges against every block's inline `grounding.range`. Both `extraction_metadata` (e.g. `client.v2.extract(...).extraction_metadata`) and `structure` (e.g. `client.v2.parse(...).structure`) accept a `dict` or a pydantic model. Block ids resolve only against the `structure` supplied here, so pass the parse result the extraction actually came from. `/v2/ground` is synchronous-only (no async jobs route).
 
+- <code title="post /v2/classify">client.v2.<a href="./src/landingai_ade/resources/v2/v2.py">classify</a>(\*, classes, document=..., document_url=..., model=...) -> <a href="./src/landingai_ade/types/v2/classify_response.py">V2ClassifyResponse</a></code>
+
+  Synchronous classify. Provide exactly one of `document` (file) or `document_url`, plus `classes` (an iterable of mappings, each with a `class` name and optional `description`), and get one predicted class per page. `classes` is JSON-encoded onto the multipart body automatically. Raises `V2SyncTimeoutError` on a 504; use `classify_jobs` for long-running documents.
+
+- <code title="post /v2/classify/jobs">client.v2.classify_jobs.<a href="./src/landingai_ade/resources/v2/classify.py">create</a>(\*, classes, document=..., document_url=..., model=..., service_tier=...) -> <a href="./src/landingai_ade/types/v2/job.py">Job</a></code>
+- <code title="get /v2/classify/jobs/{job_id}">client.v2.classify_jobs.<a href="./src/landingai_ade/resources/v2/classify.py">get</a>(job_id) -> <a href="./src/landingai_ade/types/v2/job.py">Job</a></code>
+- <code title="get /v2/classify/jobs">client.v2.classify_jobs.<a href="./src/landingai_ade/resources/v2/classify.py">list</a>(\*, page=..., page_size=..., status=...) -> JobList[<a href="./src/landingai_ade/types/v2/job.py">Job</a>]</code>
+- <code>client.v2.classify_jobs.<a href="./src/landingai_ade/resources/v2/classify.py">wait</a>(job_id, \*, timeout=600, poll_interval=None, raise_on_failure=False) -> <a href="./src/landingai_ade/types/v2/job.py">Job</a></code>
+
+  Same polling/timeout semantics as `parse_jobs.wait`. Classify jobs have no `cancelled` status, so `raise_on_failure` only ever triggers on `failed`.
+
+- <code title="post /v2/split">client.v2.<a href="./src/landingai_ade/resources/v2/v2.py">split</a>(\*, split_class, markdown=..., markdown_url=..., model=..., save_to=...) -> <a href="./src/landingai_ade/types/v2/split_response.py">V2SplitResponse</a></code>
+
+  Synchronous split. Provide exactly one of `markdown` (inline string or file) or `markdown_url`, plus `split_class` (an iterable of mappings, each with a `name` and optional `description`/`identifier`; at most 19 entries), and get the Markdown split into segments. `split_class` is JSON-encoded onto the multipart body automatically. `/v2/split` is synchronous-only (no async jobs route).
+
 Notes:
 
-- `parse_jobs.list` and `extract_jobs.list` both return a `JobList` (a `list[Job]` subclass) carrying pagination metadata: `.has_more`, `.org_id`, `.page`, `.page_size`.
-- All `client.v2.*` methods accept the usual `extra_headers`, `extra_query`, `extra_body`, and `timeout` overrides; sync methods additionally accept `save_to` (parse/extract only, not the job-creation methods) to write the response to disk, mirroring V1's `save_to`.
+- `parse_jobs.list`, `extract_jobs.list`, and `classify_jobs.list` all return a `JobList` (a `list[Job]` subclass) carrying pagination metadata: `.has_more`, `.org_id`, `.page`, `.page_size`.
+- All `client.v2.*` methods accept the usual `extra_headers`, `extra_query`, `extra_body`, and `timeout` overrides; the sync `parse`, `extract`, and `split` methods additionally accept `save_to` (not the job-creation methods) to write the response to disk, mirroring V1's `save_to`.

--- a/docs/v2-testing.md
+++ b/docs/v2-testing.md
@@ -8,9 +8,9 @@ what to check when the upstream spec (`specs/v2-aide.json`) changes.
 
 | Layer | Location | What it covers |
 | --- | --- | --- |
-| Response models | `tests/test_v2_types.py` | Deserialization of `V2ParseResponse` / `V2ExtractResult` / `V2BuildSchemaResponse` / `V2GroundResult` and their nested models from plain dicts, including unknown-key tolerance. |
-| Job normalization | `tests/test_v2_normalize.py` | `normalize_parse_job` / `normalize_extract_job` / `normalize_build_schema_job`: envelope → unified `Job` (status, timestamps, `result`, `error`). |
-| Resource wiring | `tests/api_resources/v2/` | `respx`-mocked HTTP: host routing, multipart/JSON bodies, options serialization, job polling. No network. |
+| Response models | `tests/test_v2_types.py` | Deserialization of `V2ParseResponse` / `V2ExtractResult` / `V2ClassifyResponse` / `V2SplitResponse` / `V2BuildSchemaResponse` / `V2GroundResult` and their nested models from plain dicts, including unknown-key tolerance. |
+| Job normalization | `tests/test_v2_normalize.py` | `normalize_parse_job` / `normalize_extract_job` / `normalize_classify_job` / `normalize_build_schema_job`: envelope → unified `Job` (status, timestamps, `result`, `error`). |
+| Resource wiring | `tests/api_resources/v2/` | `respx`-mocked HTTP (incl. `test_classify.py` / `test_split.py`): host routing, multipart/JSON bodies, options serialization, job polling. No network. |
 | Live smoke | `tests/contract/test_v2_smoke.py` | End-to-end calls against staging (marked `contract`; skipped unless `LANDINGAI_ADE_STAGING_APIKEY` is set). |
 
 Run the offline suites with `rye run pytest tests/test_v2_types.py
@@ -96,6 +96,44 @@ its `normalize_build_schema_job` handling are retained internally, so a build-sc
   this version), a `warnings` list of `V2BuildSchemaWarning` (`{code, msg}`, e.g.
   code `nonconformant_schema`), and `billing` (`V2BuildSchemaBilling`).
 
+## Current classify-response shape
+
+`POST /v2/classify` (and the completed `classify_jobs` result) returns a
+`V2ClassifyResponse` with:
+
+- `classification` — one `V2Classification` per page, in page order: `class_`
+  (aliased from the reserved wire key `class`), `page` (0-indexed), `reason`, and
+  an optional `suggested_class` (proposed only when the prediction is `'unknown'`).
+- `metadata` (`V2ClassifyMetadata`) — required `page_count`, `duration_ms`,
+  `openapi_spec`; optional `credit_usage`, `filename`, `job_id`, `org_id`,
+  `version` (each `None` when the gateway omits it).
+
+`client.v2.classify(...)` takes `classes` (an iterable of mappings, each with a
+`class` name and optional `description`) plus exactly one of `document` (file) or
+`document_url`. `classes` is JSON-encoded onto the multipart body. The async
+`client.v2.classify_jobs` surface (`create` / `get` / `list` / `wait`) mirrors
+`parse_jobs`; `create` additionally accepts `service_tier` (there is no
+`output_save_url` on classify). Classify jobs have no `cancelled` status.
+
+## Current split-response shape
+
+`POST /v2/split` returns a `V2SplitResponse` with:
+
+- `splits` — the merged segments, in page order. Consecutive pages with the same
+  classification merge into one segment; an identifier change starts a new one.
+  Each `V2Split` carries `classification`, a required-but-nullable `identifier`
+  (`None` when the matching split class requested none), `markdowns` (one string
+  per page in the segment), and `pages` (0-indexed).
+- `metadata` (`V2SplitMetadata`) — `filename`, `org_id` (nullable), `page_count`,
+  `duration_ms`, `credit_usage`, `job_id`, `version`. Every field is required by
+  the spec.
+
+`client.v2.split(...)` takes `split_class` (an iterable of mappings, each with a
+`name` and optional `description`/`identifier`; at most 19 entries) plus exactly
+one of `markdown` (inline string or file) or `markdown_url`. `split_class` is
+JSON-encoded onto the multipart body. `/v2/split` is synchronous-only (no async
+jobs route).
+
 ## Current ground-response shape
 
 `POST /v2/ground` returns a `V2GroundResult` — a pure, stateless join that maps
@@ -114,9 +152,9 @@ be passed directly). `/v2/ground` is synchronous-only (no async jobs route).
 
 ## Async job envelopes
 
-`normalize_parse_job`, `normalize_extract_job`, and `normalize_build_schema_job`
-fold the upstream job envelopes into the unified `Job`. All are tolerant of
-field-name drift:
+`normalize_parse_job`, `normalize_extract_job`, `normalize_classify_job`, and
+`normalize_build_schema_job` fold the upstream job envelopes into the unified
+`Job`. All are tolerant of field-name drift:
 
 - The parse response lives under `result` (older envelopes used `data`).
 - Failures arrive as a structured `error` object (`{code, message}`); older parse

--- a/specs/_generated/v2_models.py
+++ b/specs/_generated/v2_models.py
@@ -68,6 +68,29 @@ class BuildSchemaWarning(BaseModel):
     )
 
 
+class ClassifyClass(BaseModel):
+    """
+    One classification option: a class name plus an optional description.
+
+    Wire key ``class`` (VTRA's ``ClassifyClass``); the field is ``class_name``
+    because ``class`` is a Python keyword, with the alias carrying the wire
+    name. ``populate_by_name`` lets the Temporal round-trip (which serializes by
+    FIELD name) rebuild the object on the worker side.
+    """
+
+    class_: str = Field(
+        ...,
+        alias='class',
+        description='Class name assigned to a page when it matches.',
+        title='Class',
+    )
+    description: Optional[str] = Field(
+        None,
+        description='What this class represents. Improves classification.',
+        title='Description',
+    )
+
+
 class CreditUsage(BaseModel):
     """
     The standard credit-usage shape a billable WORK result carries.
@@ -219,6 +242,86 @@ class Range(BaseModel):
     )
 
 
+class Split(BaseModel):
+    """
+    One split segment: consecutive pages of one classification (an
+    identifier change starts a new segment).
+    """
+
+    classification: str = Field(
+        ...,
+        description='The split classification name this segment was assigned.',
+        title='Classification',
+    )
+    identifier: Optional[str] = Field(
+        ...,
+        description='The identifier value extracted for this segment, when the matching split classification requested one. Null otherwise.',
+        title='Identifier',
+    )
+    markdowns: list[str] = Field(
+        ...,
+        description='The Markdown content of each page in this segment, in order.',
+        title='Markdowns',
+    )
+    pages: list[int] = Field(
+        ...,
+        description='0-indexed page numbers belonging to this segment, in order.',
+        title='Pages',
+    )
+
+
+class SplitMetadata(BaseModel):
+    """
+    Information about a split request.
+    """
+
+    credit_usage: float = Field(
+        ...,
+        description='Credits consumed by this request: the input Markdown length in characters divided by 5000. Billed usage rounds this up to the next 0.1 credit.',
+        title='Credit Usage',
+    )
+    duration_ms: int = Field(
+        ..., description='Total processing time in milliseconds.', title='Duration Ms'
+    )
+    filename: str = Field(
+        ...,
+        description="Display name of the split document: the URL path's file name for `markdown_url` inputs, or a generated name for inline and uploaded Markdown.",
+        title='Filename',
+    )
+    job_id: str = Field(
+        ...,
+        description="The split job identifier — server-minted and unique per request. Correlates with the request's entry in your billing dashboard.",
+        title='Job Id',
+    )
+    org_id: Optional[str] = Field(..., description='Organization ID.', title='Org Id')
+    page_count: int = Field(
+        ...,
+        description='Total number of pages in the input Markdown.',
+        title='Page Count',
+    )
+    version: str = Field(
+        ...,
+        description='The exact split model snapshot that processed the document, e.g. `split-20251105`.',
+        title='Version',
+    )
+
+
+class SplitResponse(BaseModel):
+    """
+    The split result: the merged `splits` segments and request `metadata`.
+    """
+
+    metadata: SplitMetadata = Field(
+        ...,
+        description='Information about the request: file name, page count, duration, credits, and the resolved model version.',
+    )
+    splits: list[Split] = Field(
+        ...,
+        description='The split segments, in page order. Consecutive pages with the same classification merge into one segment; an identifier change starts a new segment.',
+        title='Splits',
+    )
+
+
 class Format(Enum):
     markdown = 'markdown'
     html = 'html'
@@ -278,6 +381,42 @@ class V1BuildSchemaMetadata(BaseModel):
         None,
         description='Structured warnings from the schema-generation process. Each is a ``{code, msg}`` object (e.g. code ``nonconformant_schema``).',
         title='Warnings',
+    )
+
+
+class V1ClassifyMetadata(BaseModel):
+    """
+    Response metadata for a classify call — VTRA's ``ClassifyMetadata``.
+    """
+
+    credit_usage: Optional[float] = Field(
+        0.0, description='Credits billed for this request.', title='Credit Usage'
+    )
+    duration_ms: int = Field(
+        ...,
+        description='End-to-end request duration in milliseconds.',
+        title='Duration Ms',
+    )
+    filename: Optional[str] = Field(
+        '', description='Name of the classified file.', title='Filename'
+    )
+    job_id: Optional[str] = Field(
+        '',
+        description='Gateway job id (workflow id). Matches the billing row id in vision-agent.',
+        title='Job Id',
+    )
+    openapi_spec: str = Field(
+        ...,
+        description='URL of the OpenAPI spec covering this API, for inspection and client generation.',
+    )
+    org_id: Optional[str] = Field(None, description='Organization ID.', title='Org Id')
+    page_count: int = Field(
+        ..., description='Number of pages classified.', title='Page Count'
+    )
+    version: Optional[str] = Field(
+        None,
+        description='Resolved classify pipeline version that produced this response.',
+        title='Version',
     )
 
 
@@ -525,6 +664,422 @@ class WorkflowStepOptions(BaseModel):
     )
 
 
+class V1AdeClassifyPostRequest(BaseModel):
+    """
+    Input to ``V1ClassifyOperationWorkflow`` (gateway) and, threaded
+    unchanged, to ``ClassifyWorkflow`` (work) — the ``/v1/classify`` request
+    body. Mirrors VTRA's ``ClassifyRequest``.
+    """
+
+    classes: list[ClassifyClass] = Field(
+        ...,
+        description="The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string.",
+        title='Classes',
+    )
+    content_type: Optional[str] = Field('', title='Content Type')
+    document_ref: str = Field(..., title='Document Ref')
+    filename: Optional[str] = Field('', title='Filename')
+    model: Optional[str] = Field(
+        None,
+        description='Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version.',
+        title='Model',
+    )
+
+
+class V1AdeClassifyPostRequest1(BaseModel):
+    classes: list[ClassifyClass] = Field(
+        ...,
+        description="The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string. JSON-serialized string in form data.",
+        title='Classes',
+    )
+    content_type: Optional[str] = Field('', title='Content Type')
+    document: Optional[bytes] = Field(
+        None,
+        description='The file to process. Provide either `document` or `document_url`, not both.',
+    )
+    document_url: Optional[str] = Field(
+        None,
+        description='A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.',
+    )
+    filename: Optional[str] = Field('', title='Filename')
+    model: Optional[str] = Field(
+        None,
+        description='Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version. JSON-serialized string in form data.',
+        title='Model',
+    )
+
+
+class ClassificationItem(BaseModel):
+    class_: str = Field(
+        ..., alias='class', description="Predicted class label, or 'unknown'."
+    )
+    page: int = Field(
+        ..., description='Page number, zero-indexed (the first page is 0).'
+    )
+    reason: str = Field(..., description='Why the page was classified this way.')
+    suggested_class: Optional[str] = Field(
+        None, description="A class the model proposes when the prediction is 'unknown'."
+    )
+
+
+class V1AdeClassifyPostResponse(BaseModel):
+    """
+    Result returned by ``V1ClassifyOperationWorkflow`` — the
+    ``/v1/classify`` response body (VTRA's ``ClassifyResponse``).
+    """
+
+    classification: list[ClassificationItem] = Field(
+        ...,
+        description='One classification result per page, in page order.',
+        title='Classification',
+    )
+    metadata: V1ClassifyMetadata = Field(
+        ..., description='Metadata for the classification request.'
+    )
+
+
+class V1AdeClassifyJobsGetParametersQuery(BaseModel):
+    page: Optional[int] = Field(
+        0, description='Page number (0-indexed).', ge=0, title='Page'
+    )
+    page_size: Optional[int] = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    )
+    status: Optional[str] = Field(
+        None, description='Filter by job status.', title='Status'
+    )
+
+
+class Status1(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+
+
+class Job(BaseModel):
+    completed_at: Optional[str] = None
+    created_at: Optional[str] = None
+    failure_reason: Optional[str] = None
+    job_id: Optional[str] = Field(
+        None,
+        description='The unique identifier for this v1-ade-classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    model_version: Optional[str] = None
+    status: Optional[Status1] = None
+
+
+class V1AdeClassifyJobsGetResponse(BaseModel):
+    has_more: Optional[bool] = None
+    jobs: Optional[list[Job]] = None
+    page: Optional[int] = None
+    page_size: Optional[int] = None
+
+
+class ServiceTier2(Enum):
+    """
+    Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.
+    """
+
+    standard = 'standard'
+    priority = 'priority'
+
+
+class V1AdeClassifyJobsPostRequest(BaseModel):
+    """
+    Input to ``V1ClassifyOperationWorkflow`` (gateway) and, threaded
+    unchanged, to ``ClassifyWorkflow`` (work) — the ``/v1/classify`` request
+    body. Mirrors VTRA's ``ClassifyRequest``.
+    """
+
+    classes: list[ClassifyClass] = Field(
+        ...,
+        description="The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string.",
+        title='Classes',
+    )
+    content_type: Optional[str] = Field('', title='Content Type')
+    document_ref: str = Field(..., title='Document Ref')
+    filename: Optional[str] = Field('', title='Filename')
+    model: Optional[str] = Field(
+        None,
+        description='Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version.',
+        title='Model',
+    )
+    service_tier: Optional[ServiceTier2] = Field(
+        None,
+        description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
+    )
+
+
+class V1AdeClassifyJobsPostRequest1(BaseModel):
+    classes: list[ClassifyClass] = Field(
+        ...,
+        description="The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string. JSON-serialized string in form data.",
+        title='Classes',
+    )
+    content_type: Optional[str] = Field('', title='Content Type')
+    document: Optional[bytes] = Field(
+        None,
+        description='The file to process. Provide either `document` or `document_url`, not both.',
+    )
+    document_url: Optional[str] = Field(
+        None,
+        description='A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.',
+    )
+    filename: Optional[str] = Field('', title='Filename')
+    model: Optional[str] = Field(
+        None,
+        description='Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version. JSON-serialized string in form data.',
+        title='Model',
+    )
+    service_tier: Optional[ServiceTier2] = Field(
+        None,
+        description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
+    )
+
+
+class V1AdeClassifyJobsPostResponse(BaseModel):
+    created_at: Optional[str] = None
+    job_id: Optional[str] = Field(
+        None,
+        description='The unique identifier for this v1-ade-classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    status: Optional[Status1] = None
+
+
+class Error(BaseModel):
+    """
+    Present once status is ``failed``.
+    """
+
+    code: Optional[str] = Field(
+        None, description='Stable error code (``internal_error`` when unmapped).'
+    )
+    message: Optional[str] = None
+
+
+class Result(BaseModel):
+    """
+    Result returned by ``V1ClassifyOperationWorkflow`` — the
+    ``/v1/classify`` response body (VTRA's ``ClassifyResponse``).
+    """
+
+    classification: list[ClassificationItem] = Field(
+        ...,
+        description='One classification result per page, in page order.',
+        title='Classification',
+    )
+    metadata: V1ClassifyMetadata = Field(
+        ..., description='Metadata for the classification request.'
+    )
+
+
+class V1AdeClassifyJobsJobIdGetResponse(BaseModel):
+    completed_at: Optional[str] = Field(
+        None, description='Present once the job is terminal.'
+    )
+    created_at: Optional[str] = None
+    error: Optional[Error] = Field(
+        None, description='Present once status is ``failed``.'
+    )
+    job_id: Optional[str] = Field(
+        None,
+        description='The unique identifier for this v1-ade-classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    progress: Optional[float] = Field(
+        None,
+        description='Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.',
+        ge=0.0,
+        le=1.0,
+    )
+    result: Optional[Result] = Field(
+        None, description='Present once status is ``completed``.'
+    )
+    status: Optional[Status1] = None
+
+
+class V1AdeExtractPostRequest(BaseModel):
+    """
+    Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.
+
+    VTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline
+    string), ``markdown_url``, ``schema``, ``strict``. Nothing else — AIDE's own
+    extras (``return_reasoning``, ``fallback_model``, ``output_save_url``) stay on
+    the R&D ``/api/extract`` contract, so the customer surface publishes the VTRA
+    contract and only that.
+    """
+
+    markdown: Optional[str] = Field(None, title='Markdown')
+    markdown_url: Optional[str] = Field(None, title='Markdown Url')
+    model: Optional[str] = Field(None, title='Model')
+    schema_: Optional[str] = Field(None, alias='schema', title='Schema')
+    strict: Optional[bool] = Field(False, title='Strict')
+
+
+class V1AdeExtractPostRequest1(BaseModel):
+    markdown: Optional[bytes] = Field(None, description='File upload.')
+    markdown_url: Optional[str] = Field(
+        None, description='JSON-serialized string in form data.', title='Markdown Url'
+    )
+    model: Optional[str] = Field(
+        None, description='JSON-serialized string in form data.', title='Model'
+    )
+    schema_: Optional[str] = Field(
+        None,
+        alias='schema',
+        description='JSON-serialized string in form data.',
+        title='Schema',
+    )
+    strict: Optional[bool] = Field(
+        False, description='JSON-serialized string in form data.', title='Strict'
+    )
+
+
+class V1AdeExtractPostResponse(BaseModel):
+    """
+    VTRA's ``ExtractResponse`` — the ``/v1/extract`` response body.
+
+    ``extraction`` is ALWAYS inline. The internal ``ExtractResult`` returns an
+    ``output_ref`` instead when the payload is too large for the Temporal wire; on
+    this route that pointer is resolved back to inline content at the render
+    boundary, because VTRA always inlines and a client migrating off it has no
+    ``output_ref`` handling at all.
+    """
+
+    extraction: Optional[dict[str, Any]] = Field(None, title='Extraction')
+    extraction_metadata: Optional[dict[str, Any]] = Field(
+        None, title='Extraction Metadata'
+    )
+    metadata: Optional[V1ExtractMetadata] = None
+
+
+class V1AdeExtractJobsGetParametersQuery(BaseModel):
+    page: Optional[int] = Field(
+        0, description='Page number (0-indexed).', ge=0, title='Page'
+    )
+    page_size: Optional[int] = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    )
+    status: Optional[str] = Field(
+        None, description='Filter by job status.', title='Status'
+    )
+
+
+class Job1(BaseModel):
+    completed_at: Optional[str] = None
+    created_at: Optional[str] = None
+    failure_reason: Optional[str] = None
+    job_id: Optional[str] = Field(
+        None,
+        description='The unique identifier for this v1-ade-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    model_version: Optional[str] = None
+    status: Optional[Status1] = None
+
+
+class V1AdeExtractJobsGetResponse(BaseModel):
+    has_more: Optional[bool] = None
+    jobs: Optional[list[Job1]] = None
+    page: Optional[int] = None
+    page_size: Optional[int] = None
+
+
+class V1AdeExtractJobsPostRequest(BaseModel):
+    """
+    Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.
+
+    VTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline
+    string), ``markdown_url``, ``schema``, ``strict``. Nothing else — AIDE's own
+    extras (``return_reasoning``, ``fallback_model``, ``output_save_url``) stay on
+    the R&D ``/api/extract`` contract, so the customer surface publishes the VTRA
+    contract and only that.
+    """
+
+    markdown: Optional[str] = Field(None, title='Markdown')
+    markdown_url: Optional[str] = Field(None, title='Markdown Url')
+    model: Optional[str] = Field(None, title='Model')
+    schema_: Optional[str] = Field(None, alias='schema', title='Schema')
+    service_tier: Optional[ServiceTier2] = Field(
+        None,
+        description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
+    )
+    strict: Optional[bool] = Field(False, title='Strict')
+
+
+class V1AdeExtractJobsPostRequest1(BaseModel):
+    markdown: Optional[bytes] = Field(None, description='File upload.')
+    markdown_url: Optional[str] = Field(
+        None, description='JSON-serialized string in form data.', title='Markdown Url'
+    )
+    model: Optional[str] = Field(
+        None, description='JSON-serialized string in form data.', title='Model'
+    )
+    schema_: Optional[str] = Field(
+        None,
+        alias='schema',
+        description='JSON-serialized string in form data.',
+        title='Schema',
+    )
+    service_tier: Optional[ServiceTier2] = Field(
+        None,
+        description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
+    )
+    strict: Optional[bool] = Field(
+        False, description='JSON-serialized string in form data.', title='Strict'
+    )
+
+
+class V1AdeExtractJobsPostResponse(BaseModel):
+    created_at: Optional[str] = None
+    job_id: Optional[str] = Field(
+        None,
+        description='The unique identifier for this v1-ade-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    status: Optional[Status1] = None
+
+
+class Result1(BaseModel):
+    """
+    VTRA's ``ExtractResponse`` — the ``/v1/extract`` response body.
+
+    ``extraction`` is ALWAYS inline. The internal ``ExtractResult`` returns an
+    ``output_ref`` instead when the payload is too large for the Temporal wire; on
+    this route that pointer is resolved back to inline content at the render
+    boundary, because VTRA always inlines and a client migrating off it has no
+    ``output_ref`` handling at all.
+    """
+
+    extraction: Optional[dict[str, Any]] = Field(None, title='Extraction')
+    extraction_metadata: Optional[dict[str, Any]] = Field(
+        None, title='Extraction Metadata'
+    )
+    metadata: Optional[V1ExtractMetadata] = None
+
+
+class V1AdeExtractJobsJobIdGetResponse(BaseModel):
+    completed_at: Optional[str] = Field(
+        None, description='Present once the job is terminal.'
+    )
+    created_at: Optional[str] = None
+    error: Optional[Error] = Field(
+        None, description='Present once status is ``failed``.'
+    )
+    job_id: Optional[str] = Field(
+        None,
+        description='The unique identifier for this v1-ade-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    progress: Optional[float] = Field(
+        None,
+        description='Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.',
+        ge=0.0,
+        le=1.0,
+    )
+    result: Optional[Result1] = Field(
+        None, description='Present once status is ``completed``.'
+    )
+    status: Optional[Status1] = None
+
+
 class V1AdeParsePostRequest(BaseModel):
     """
     Input to ``Parse2OperationWorkflow`` (gateway) and ``Parse2DocumentWorkflow``
@@ -552,7 +1107,14 @@ class V1AdeParsePostRequest1(BaseModel):
     custom_prompts: Optional[dict[str, str]] = Field(
         None, description='JSON-serialized string in form data.', title='Custom Prompts'
     )
-    document_ref: bytes = Field(..., description='File upload.')
+    document: Optional[bytes] = Field(
+        None,
+        description='The file to process. Provide either `document` or `document_url`, not both.',
+    )
+    document_url: Optional[str] = Field(
+        None,
+        description='A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.',
+    )
     filename: str = Field(..., title='Filename')
     job_id: Optional[str] = Field(
         None, description='JSON-serialized string in form data.', title='Job Id'
@@ -596,6 +1158,7 @@ class V1AdeParsePostResponse(BaseModel):
 
     base_credit: Optional[float] = Field(0.0, title='Base Credit')
     billable_pages: Optional[int] = Field(0, title='Billable Pages')
+    billing_suppressed: Optional[bool] = Field(False, title='Billing Suppressed')
     completion_tokens: Optional[int] = Field(0, title='Completion Tokens')
     credit_usage: Optional[CreditUsage] = None
     duration_ms: Optional[int] = Field(0, title='Duration Ms')
@@ -623,14 +1186,7 @@ class V1AdeParseJobsGetParametersQuery(BaseModel):
     )
 
 
-class Status1(Enum):
-    pending = 'pending'
-    processing = 'processing'
-    completed = 'completed'
-    failed = 'failed'
-
-
-class Job(BaseModel):
+class Job2(BaseModel):
     completed_at: Optional[str] = None
     created_at: Optional[str] = None
     failure_reason: Optional[str] = None
@@ -644,18 +1200,9 @@ class Job(BaseModel):
 
 class V1AdeParseJobsGetResponse(BaseModel):
     has_more: Optional[bool] = None
-    jobs: Optional[list[Job]] = None
+    jobs: Optional[list[Job2]] = None
     page: Optional[int] = None
     page_size: Optional[int] = None
-
-
-class ServiceTier2(Enum):
-    """
-    Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.
-    """
-
-    standard = 'standard'
-    priority = 'priority'
 
 
 class V1AdeParseJobsPostRequest(BaseModel):
@@ -690,7 +1237,14 @@ class V1AdeParseJobsPostRequest1(BaseModel):
     custom_prompts: Optional[dict[str, str]] = Field(
         None, description='JSON-serialized string in form data.', title='Custom Prompts'
     )
-    document_ref: bytes = Field(..., description='File upload.')
+    document: Optional[bytes] = Field(
+        None,
+        description='The file to process. Provide either `document` or `document_url`, not both.',
+    )
+    document_url: Optional[str] = Field(
+        None,
+        description='A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.',
+    )
     filename: str = Field(..., title='Filename')
     job_id: Optional[str] = Field(
         None, description='JSON-serialized string in form data.', title='Job Id'
@@ -736,18 +1290,7 @@ class V1AdeParseJobsPostResponse(BaseModel):
     status: Optional[Status1] = None
 
 
-class Error(BaseModel):
-    """
-    Present once status is ``failed``.
-    """
-
-    code: Optional[str] = Field(
-        None, description='Stable error code (``internal_error`` when unmapped).'
-    )
-    message: Optional[str] = None
-
-
-class Result(BaseModel):
+class Result2(BaseModel):
     """
     Output of ``Parse2DocumentWorkflow``. Carries the customer response plus the
     billing inputs hoisted to the top level so the gateway operation reads them
@@ -763,6 +1306,7 @@ class Result(BaseModel):
 
     base_credit: Optional[float] = Field(0.0, title='Base Credit')
     billable_pages: Optional[int] = Field(0, title='Billable Pages')
+    billing_suppressed: Optional[bool] = Field(False, title='Billing Suppressed')
     completion_tokens: Optional[int] = Field(0, title='Completion Tokens')
     credit_usage: Optional[CreditUsage] = None
     duration_ms: Optional[int] = Field(0, title='Duration Ms')
@@ -804,66 +1348,205 @@ class V1AdeParseJobsJobIdGetResponse(BaseModel):
         ge=0.0,
         le=1.0,
     )
-    result: Optional[Result] = Field(
+    result: Optional[Result2] = Field(
         None,
         description='Present once status is ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead.',
     )
     status: Optional[Status1] = None
 
 
-class V1ExtractPostRequest(BaseModel):
+class V1ClassifyPostRequest(BaseModel):
     """
-    Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.
-
-    VTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline
-    string), ``markdown_url``, ``schema``, ``strict``. Nothing else — AIDE's own
-    extras (``return_reasoning``, ``fallback_model``, ``output_save_url``) stay on
-    the R&D ``/api/extract`` contract, so the customer surface publishes the VTRA
-    contract and only that.
+    Input to ``V1ClassifyOperationWorkflow`` (gateway) and, threaded
+    unchanged, to ``ClassifyWorkflow`` (work) — the ``/v1/classify`` request
+    body. Mirrors VTRA's ``ClassifyRequest``.
     """
 
-    markdown: Optional[str] = Field(None, title='Markdown')
-    markdown_url: Optional[str] = Field(None, title='Markdown Url')
-    model: Optional[str] = Field(None, title='Model')
-    schema_: Optional[str] = Field(None, alias='schema', title='Schema')
-    strict: Optional[bool] = Field(False, title='Strict')
-
-
-class V1ExtractPostRequest1(BaseModel):
-    markdown: Optional[bytes] = Field(None, description='File upload.')
-    markdown_url: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='Markdown Url'
+    classes: list[ClassifyClass] = Field(
+        ...,
+        description="The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string.",
+        title='Classes',
     )
+    content_type: Optional[str] = Field('', title='Content Type')
+    document_ref: str = Field(..., title='Document Ref')
+    filename: Optional[str] = Field('', title='Filename')
     model: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='Model'
-    )
-    schema_: Optional[str] = Field(
         None,
-        alias='schema',
-        description='JSON-serialized string in form data.',
-        title='Schema',
-    )
-    strict: Optional[bool] = Field(
-        False, description='JSON-serialized string in form data.', title='Strict'
+        description='Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version.',
+        title='Model',
     )
 
 
-class V1ExtractPostResponse(BaseModel):
+class V1ClassifyPostRequest1(BaseModel):
+    classes: list[ClassifyClass] = Field(
+        ...,
+        description="The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string. JSON-serialized string in form data.",
+        title='Classes',
+    )
+    content_type: Optional[str] = Field('', title='Content Type')
+    document: Optional[bytes] = Field(
+        None,
+        description='The file to process. Provide either `document` or `document_url`, not both.',
+    )
+    document_url: Optional[str] = Field(
+        None,
+        description='A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.',
+    )
+    filename: Optional[str] = Field('', title='Filename')
+    model: Optional[str] = Field(
+        None,
+        description='Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version. JSON-serialized string in form data.',
+        title='Model',
+    )
+
+
+class V1ClassifyPostResponse(BaseModel):
     """
-    VTRA's ``ExtractResponse`` — the ``/v1/extract`` response body.
-
-    ``extraction`` is ALWAYS inline. The internal ``ExtractResult`` returns an
-    ``output_ref`` instead when the payload is too large for the Temporal wire; on
-    this route that pointer is resolved back to inline content at the render
-    boundary, because VTRA always inlines and a client migrating off it has no
-    ``output_ref`` handling at all.
+    Result returned by ``V1ClassifyOperationWorkflow`` — the
+    ``/v1/classify`` response body (VTRA's ``ClassifyResponse``).
     """
 
-    extraction: Optional[dict[str, Any]] = Field(None, title='Extraction')
-    extraction_metadata: Optional[dict[str, Any]] = Field(
-        None, title='Extraction Metadata'
+    classification: list[ClassificationItem] = Field(
+        ...,
+        description='One classification result per page, in page order.',
+        title='Classification',
     )
-    metadata: Optional[V1ExtractMetadata] = None
+    metadata: V1ClassifyMetadata = Field(
+        ..., description='Metadata for the classification request.'
+    )
+
+
+class V1ClassifyJobsGetParametersQuery(BaseModel):
+    page: Optional[int] = Field(
+        0, description='Page number (0-indexed).', ge=0, title='Page'
+    )
+    page_size: Optional[int] = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    )
+    status: Optional[str] = Field(
+        None, description='Filter by job status.', title='Status'
+    )
+
+
+class Job3(BaseModel):
+    completed_at: Optional[str] = None
+    created_at: Optional[str] = None
+    failure_reason: Optional[str] = None
+    job_id: Optional[str] = Field(
+        None,
+        description='The unique identifier for this classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    model_version: Optional[str] = None
+    status: Optional[Status1] = None
+
+
+class V1ClassifyJobsGetResponse(BaseModel):
+    has_more: Optional[bool] = None
+    jobs: Optional[list[Job3]] = None
+    page: Optional[int] = None
+    page_size: Optional[int] = None
+
+
+class V1ClassifyJobsPostRequest(BaseModel):
+    """
+    Input to ``V1ClassifyOperationWorkflow`` (gateway) and, threaded
+    unchanged, to ``ClassifyWorkflow`` (work) — the ``/v1/classify`` request
+    body. Mirrors VTRA's ``ClassifyRequest``.
+    """
+
+    classes: list[ClassifyClass] = Field(
+        ...,
+        description="The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string.",
+        title='Classes',
+    )
+    content_type: Optional[str] = Field('', title='Content Type')
+    document_ref: str = Field(..., title='Document Ref')
+    filename: Optional[str] = Field('', title='Filename')
+    model: Optional[str] = Field(
+        None,
+        description='Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version.',
+        title='Model',
+    )
+    service_tier: Optional[ServiceTier2] = Field(
+        None,
+        description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
+    )
+
+
+class V1ClassifyJobsPostRequest1(BaseModel):
+    classes: list[ClassifyClass] = Field(
+        ...,
+        description="The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string. JSON-serialized string in form data.",
+        title='Classes',
+    )
+    content_type: Optional[str] = Field('', title='Content Type')
+    document: Optional[bytes] = Field(
+        None,
+        description='The file to process. Provide either `document` or `document_url`, not both.',
+    )
+    document_url: Optional[str] = Field(
+        None,
+        description='A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.',
+    )
+    filename: Optional[str] = Field('', title='Filename')
+    model: Optional[str] = Field(
+        None,
+        description='Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version. JSON-serialized string in form data.',
+        title='Model',
+    )
+    service_tier: Optional[ServiceTier2] = Field(
+        None,
+        description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
+    )
+
+
+class V1ClassifyJobsPostResponse(BaseModel):
+    created_at: Optional[str] = None
+    job_id: Optional[str] = Field(
+        None,
+        description='The unique identifier for this classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    status: Optional[Status1] = None
+
+
+class Result3(BaseModel):
+    """
+    Result returned by ``V1ClassifyOperationWorkflow`` — the
+    ``/v1/classify`` response body (VTRA's ``ClassifyResponse``).
+    """
+
+    classification: list[ClassificationItem] = Field(
+        ...,
+        description='One classification result per page, in page order.',
+        title='Classification',
+    )
+    metadata: V1ClassifyMetadata = Field(
+        ..., description='Metadata for the classification request.'
+    )
+
+
+class V1ClassifyJobsJobIdGetResponse(BaseModel):
+    completed_at: Optional[str] = Field(
+        None, description='Present once the job is terminal.'
+    )
+    created_at: Optional[str] = None
+    error: Optional[Error] = Field(
+        None, description='Present once status is ``failed``.'
+    )
+    job_id: Optional[str] = Field(
+        None,
+        description='The unique identifier for this classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    progress: Optional[float] = Field(
+        None,
+        description='Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.',
+        ge=0.0,
+        le=1.0,
+    )
+    result: Optional[Result3] = Field(
+        None, description='Present once status is ``completed``.'
+    )
+    status: Optional[Status1] = None
 
 
 class V1ExtractBuildSchemaPostRequest(BaseModel):
@@ -975,7 +1658,7 @@ class V1ExtractBuildSchemaJobsGetParametersQuery(BaseModel):
     )
 
 
-class Job1(BaseModel):
+class Job4(BaseModel):
     completed_at: Optional[str] = None
     created_at: Optional[str] = None
     failure_reason: Optional[str] = None
@@ -989,7 +1672,7 @@ class Job1(BaseModel):
 
 class V1ExtractBuildSchemaJobsGetResponse(BaseModel):
     has_more: Optional[bool] = None
-    jobs: Optional[list[Job1]] = None
+    jobs: Optional[list[Job4]] = None
     page: Optional[int] = None
     page_size: Optional[int] = None
 
@@ -1090,7 +1773,7 @@ class V1ExtractBuildSchemaJobsPostResponse(BaseModel):
     status: Optional[Status1] = None
 
 
-class Result1(BaseModel):
+class Result4(BaseModel):
     """
     Result of a **v1** build-schema call — VTRA's ``BuildSchemaResponse``.
 
@@ -1126,396 +1809,29 @@ class V1ExtractBuildSchemaJobsJobIdGetResponse(BaseModel):
         ge=0.0,
         le=1.0,
     )
-    result: Optional[Result1] = Field(
+    result: Optional[Result4] = Field(
         None, description='Present once status is ``completed``.'
     )
     status: Optional[Status1] = None
 
 
-class V1ExtractJobsGetParametersQuery(BaseModel):
-    page: Optional[int] = Field(
-        0, description='Page number (0-indexed).', ge=0, title='Page'
-    )
-    page_size: Optional[int] = Field(
-        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
-    )
-    status: Optional[str] = Field(
-        None, description='Filter by job status.', title='Status'
-    )
-
-
-class Job2(BaseModel):
-    completed_at: Optional[str] = None
-    created_at: Optional[str] = None
-    failure_reason: Optional[str] = None
-    job_id: Optional[str] = Field(
+class V1SplitPostRequest(BaseModel):
+    markdown: Optional[Union[bytes, str]] = Field(
         None,
-        description='The unique identifier for this v1-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+        description='Markdown content to split, as an inline string or an uploaded file. Provide either `markdown` or `markdown_url`, not both.',
     )
-    model_version: Optional[str] = None
-    status: Optional[Status1] = None
-
-
-class V1ExtractJobsGetResponse(BaseModel):
-    has_more: Optional[bool] = None
-    jobs: Optional[list[Job2]] = None
-    page: Optional[int] = None
-    page_size: Optional[int] = None
-
-
-class V1ExtractJobsPostRequest(BaseModel):
-    """
-    Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.
-
-    VTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline
-    string), ``markdown_url``, ``schema``, ``strict``. Nothing else — AIDE's own
-    extras (``return_reasoning``, ``fallback_model``, ``output_save_url``) stay on
-    the R&D ``/api/extract`` contract, so the customer surface publishes the VTRA
-    contract and only that.
-    """
-
-    markdown: Optional[str] = Field(None, title='Markdown')
-    markdown_url: Optional[str] = Field(None, title='Markdown Url')
-    model: Optional[str] = Field(None, title='Model')
-    schema_: Optional[str] = Field(None, alias='schema', title='Schema')
-    service_tier: Optional[ServiceTier2] = Field(
-        None,
-        description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
-    )
-    strict: Optional[bool] = Field(False, title='Strict')
-
-
-class V1ExtractJobsPostRequest1(BaseModel):
-    markdown: Optional[bytes] = Field(None, description='File upload.')
     markdown_url: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='Markdown Url'
+        None,
+        description='A publicly accessible URL to the Markdown file to split. Provide either `markdown` or `markdown_url`, not both.',
     )
     model: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='Model'
-    )
-    schema_: Optional[str] = Field(
         None,
-        alias='schema',
-        description='JSON-serialized string in form data.',
-        title='Schema',
+        description='The split model version to use. Accepts a dated snapshot (`split-20251105`), `split-latest`, or `split` (both aliases resolve to the latest snapshot). Defaults to the latest snapshot. The resolved version is echoed back as `metadata.version`.',
     )
-    service_tier: Optional[ServiceTier2] = Field(
-        None,
-        description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
+    split_class: str = Field(
+        ...,
+        description='The split classification entries, as a JSON-encoded array of objects with `name` (required), `description`, and `identifier` keys. At most 19 entries. Sent as a JSON-serialized string in form data.',
     )
-    strict: Optional[bool] = Field(
-        False, description='JSON-serialized string in form data.', title='Strict'
-    )
-
-
-class V1ExtractJobsPostResponse(BaseModel):
-    created_at: Optional[str] = None
-    job_id: Optional[str] = Field(
-        None,
-        description='The unique identifier for this v1-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
-    )
-    status: Optional[Status1] = None
-
-
-class Result2(BaseModel):
-    """
-    VTRA's ``ExtractResponse`` — the ``/v1/extract`` response body.
-
-    ``extraction`` is ALWAYS inline. The internal ``ExtractResult`` returns an
-    ``output_ref`` instead when the payload is too large for the Temporal wire; on
-    this route that pointer is resolved back to inline content at the render
-    boundary, because VTRA always inlines and a client migrating off it has no
-    ``output_ref`` handling at all.
-    """
-
-    extraction: Optional[dict[str, Any]] = Field(None, title='Extraction')
-    extraction_metadata: Optional[dict[str, Any]] = Field(
-        None, title='Extraction Metadata'
-    )
-    metadata: Optional[V1ExtractMetadata] = None
-
-
-class V1ExtractJobsJobIdGetResponse(BaseModel):
-    completed_at: Optional[str] = Field(
-        None, description='Present once the job is terminal.'
-    )
-    created_at: Optional[str] = None
-    error: Optional[Error] = Field(
-        None, description='Present once status is ``failed``.'
-    )
-    job_id: Optional[str] = Field(
-        None,
-        description='The unique identifier for this v1-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
-    )
-    progress: Optional[float] = Field(
-        None,
-        description='Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.',
-        ge=0.0,
-        le=1.0,
-    )
-    result: Optional[Result2] = Field(
-        None, description='Present once status is ``completed``.'
-    )
-    status: Optional[Status1] = None
-
-
-class V1ParsePostRequest(BaseModel):
-    """
-    Input to ``Parse2OperationWorkflow`` (gateway) and ``Parse2DocumentWorkflow``
-    (work). The document rides as ``document_ref`` (the gateway's multipart adapter
-    stages the upload / fetches ``document_url`` → data store, runs the pdf_pages
-    pre-flight, then starts the operation).
-    """
-
-    content_type: str = Field(..., title='Content Type')
-    custom_prompts: Optional[dict[str, str]] = Field(None, title='Custom Prompts')
-    document_ref: str = Field(..., title='Document Ref')
-    filename: str = Field(..., title='Filename')
-    job_id: Optional[str] = Field(None, title='Job Id')
-    model_versions: Optional[dict[str, str]] = Field(None, title='Model Versions')
-    password: Optional[str] = Field(None, title='Password')
-    pricing_multiplier: Optional[float] = Field(1.0, title='Pricing Multiplier')
-    processing_mode: Optional[str] = Field('sync', title='Processing Mode')
-    split: Optional[str] = Field(None, title='Split')
-    version: Optional[str] = Field(None, title='Version')
-    x_request_id: Optional[str] = Field(None, title='X Request Id')
-
-
-class V1ParsePostRequest1(BaseModel):
-    content_type: str = Field(..., title='Content Type')
-    custom_prompts: Optional[dict[str, str]] = Field(
-        None, description='JSON-serialized string in form data.', title='Custom Prompts'
-    )
-    document_ref: bytes = Field(..., description='File upload.')
-    filename: str = Field(..., title='Filename')
-    job_id: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='Job Id'
-    )
-    model_versions: Optional[dict[str, str]] = Field(
-        None, description='JSON-serialized string in form data.', title='Model Versions'
-    )
-    password: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='Password'
-    )
-    pricing_multiplier: Optional[float] = Field(
-        1.0,
-        description='JSON-serialized string in form data.',
-        title='Pricing Multiplier',
-    )
-    processing_mode: Optional[str] = Field('sync', title='Processing Mode')
-    split: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='Split'
-    )
-    version: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='Version'
-    )
-    x_request_id: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='X Request Id'
-    )
-
-
-class V1ParsePostResponse(BaseModel):
-    """
-    Output of ``Parse2DocumentWorkflow``. Carries the customer response plus the
-    billing inputs hoisted to the top level so the gateway operation reads them
-    without re-parsing the nested tree.
-
-    Billing is worker-owned (parse-api parity): the worker finalizes the price and
-    reports it on the standard ``credit_usage: CreditUsage`` shape (``credits`` =
-    FINAL billed value, ``charge_unit`` = billable pages, ``breakdown`` = itemized),
-    plus the record-inference enrichment (``usage`` + ``model_family``). The
-    gateway's default biller reads ``credit_usage`` verbatim (a ``JobContract.billed()``
-    op — no gateway recomputation).
-    """
-
-    base_credit: Optional[float] = Field(0.0, title='Base Credit')
-    billable_pages: Optional[int] = Field(0, title='Billable Pages')
-    completion_tokens: Optional[int] = Field(0, title='Completion Tokens')
-    credit_usage: Optional[CreditUsage] = None
-    duration_ms: Optional[int] = Field(0, title='Duration Ms')
-    failed_pages: Optional[list[int]] = Field(None, title='Failed Pages')
-    model_family: Optional[str] = Field(None, title='Model Family')
-    output_ref: Optional[str] = Field(None, title='Output Ref')
-    page_count: Optional[int] = Field(0, title='Page Count')
-    prompt_tokens: Optional[int] = Field(0, title='Prompt Tokens')
-    response: dict[str, Any] = Field(..., title='Response')
-    status_code: Optional[int] = Field(200, title='Status Code')
-    token_steps: Optional[list[dict[str, Any]]] = Field(None, title='Token Steps')
-    total_tokens: Optional[int] = Field(0, title='Total Tokens')
-    usage: Optional[dict[str, Any]] = Field(None, title='Usage')
-
-
-class V1ParseJobsGetParametersQuery(BaseModel):
-    page: Optional[int] = Field(
-        0, description='Page number (0-indexed).', ge=0, title='Page'
-    )
-    page_size: Optional[int] = Field(
-        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
-    )
-    status: Optional[str] = Field(
-        None, description='Filter by job status.', title='Status'
-    )
-
-
-class Job3(BaseModel):
-    completed_at: Optional[str] = None
-    created_at: Optional[str] = None
-    failure_reason: Optional[str] = None
-    job_id: Optional[str] = Field(
-        None,
-        description='The unique identifier for this parse2 job. Format: ``parse2-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
-    )
-    model_version: Optional[str] = None
-    status: Optional[Status1] = None
-
-
-class V1ParseJobsGetResponse(BaseModel):
-    has_more: Optional[bool] = None
-    jobs: Optional[list[Job3]] = None
-    page: Optional[int] = None
-    page_size: Optional[int] = None
-
-
-class V1ParseJobsPostRequest(BaseModel):
-    """
-    Input to ``Parse2OperationWorkflow`` (gateway) and ``Parse2DocumentWorkflow``
-    (work). The document rides as ``document_ref`` (the gateway's multipart adapter
-    stages the upload / fetches ``document_url`` → data store, runs the pdf_pages
-    pre-flight, then starts the operation).
-    """
-
-    content_type: str = Field(..., title='Content Type')
-    custom_prompts: Optional[dict[str, str]] = Field(None, title='Custom Prompts')
-    document_ref: str = Field(..., title='Document Ref')
-    filename: str = Field(..., title='Filename')
-    job_id: Optional[str] = Field(None, title='Job Id')
-    model_versions: Optional[dict[str, str]] = Field(None, title='Model Versions')
-    output_save_url: Optional[str] = Field(None, title='Output Save Url')
-    password: Optional[str] = Field(None, title='Password')
-    pricing_multiplier: Optional[float] = Field(1.0, title='Pricing Multiplier')
-    processing_mode: Optional[str] = Field('sync', title='Processing Mode')
-    service_tier: Optional[ServiceTier2] = Field(
-        None,
-        description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
-    )
-    split: Optional[str] = Field(None, title='Split')
-    version: Optional[str] = Field(None, title='Version')
-    x_request_id: Optional[str] = Field(None, title='X Request Id')
-
-
-class V1ParseJobsPostRequest1(BaseModel):
-    content_type: str = Field(..., title='Content Type')
-    custom_prompts: Optional[dict[str, str]] = Field(
-        None, description='JSON-serialized string in form data.', title='Custom Prompts'
-    )
-    document_ref: bytes = Field(..., description='File upload.')
-    filename: str = Field(..., title='Filename')
-    job_id: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='Job Id'
-    )
-    model_versions: Optional[dict[str, str]] = Field(
-        None, description='JSON-serialized string in form data.', title='Model Versions'
-    )
-    output_save_url: Optional[str] = Field(
-        None,
-        description='JSON-serialized string in form data.',
-        title='Output Save Url',
-    )
-    password: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='Password'
-    )
-    pricing_multiplier: Optional[float] = Field(
-        1.0,
-        description='JSON-serialized string in form data.',
-        title='Pricing Multiplier',
-    )
-    processing_mode: Optional[str] = Field('sync', title='Processing Mode')
-    service_tier: Optional[ServiceTier2] = Field(
-        None,
-        description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
-    )
-    split: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='Split'
-    )
-    version: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='Version'
-    )
-    x_request_id: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='X Request Id'
-    )
-
-
-class V1ParseJobsPostResponse(BaseModel):
-    created_at: Optional[str] = None
-    job_id: Optional[str] = Field(
-        None,
-        description='The unique identifier for this parse2 job. Format: ``parse2-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
-    )
-    status: Optional[Status1] = None
-
-
-class Result3(BaseModel):
-    """
-    Output of ``Parse2DocumentWorkflow``. Carries the customer response plus the
-    billing inputs hoisted to the top level so the gateway operation reads them
-    without re-parsing the nested tree.
-
-    Billing is worker-owned (parse-api parity): the worker finalizes the price and
-    reports it on the standard ``credit_usage: CreditUsage`` shape (``credits`` =
-    FINAL billed value, ``charge_unit`` = billable pages, ``breakdown`` = itemized),
-    plus the record-inference enrichment (``usage`` + ``model_family``). The
-    gateway's default biller reads ``credit_usage`` verbatim (a ``JobContract.billed()``
-    op — no gateway recomputation).
-    """
-
-    base_credit: Optional[float] = Field(0.0, title='Base Credit')
-    billable_pages: Optional[int] = Field(0, title='Billable Pages')
-    completion_tokens: Optional[int] = Field(0, title='Completion Tokens')
-    credit_usage: Optional[CreditUsage] = None
-    duration_ms: Optional[int] = Field(0, title='Duration Ms')
-    failed_pages: Optional[list[int]] = Field(None, title='Failed Pages')
-    model_family: Optional[str] = Field(None, title='Model Family')
-    output_ref: Optional[str] = Field(None, title='Output Ref')
-    page_count: Optional[int] = Field(0, title='Page Count')
-    prompt_tokens: Optional[int] = Field(0, title='Prompt Tokens')
-    response: dict[str, Any] = Field(..., title='Response')
-    status_code: Optional[int] = Field(200, title='Status Code')
-    token_steps: Optional[list[dict[str, Any]]] = Field(None, title='Token Steps')
-    total_tokens: Optional[int] = Field(0, title='Total Tokens')
-    usage: Optional[dict[str, Any]] = Field(None, title='Usage')
-
-
-class V1ParseJobsJobIdGetResponse(BaseModel):
-    completed_at: Optional[str] = Field(
-        None, description='Present once the job is terminal.'
-    )
-    created_at: Optional[str] = None
-    error: Optional[Error] = Field(
-        None, description='Present once status is ``failed``.'
-    )
-    job_id: Optional[str] = Field(
-        None,
-        description='The unique identifier for this parse2 job. Format: ``parse2-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
-    )
-    metadata: Optional[dict[str, Any]] = Field(
-        None,
-        description="The result's metadata block (billing included), present alongside ``output_url`` once a job with ``output_save_url`` has ``completed`` — the delivery moves the content, not the receipt. Same shape as the inline ``result``'s ``metadata``; inline jobs carry it there instead.",
-    )
-    output_url: Optional[str] = Field(
-        None,
-        description='The URL the result was delivered to. Present once the job has ``completed`` and ``output_save_url`` was set, instead of inline ``result``.',
-    )
-    progress: Optional[float] = Field(
-        None,
-        description='Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.',
-        ge=0.0,
-        le=1.0,
-    )
-    result: Optional[Result3] = Field(
-        None,
-        description='Present once status is ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead.',
-    )
-    status: Optional[Status1] = None
 
 
 class V2ExtractPostRequest(BaseModel):
@@ -1645,7 +1961,7 @@ class V2ExtractJobsGetParametersQuery(BaseModel):
     )
 
 
-class Job4(BaseModel):
+class Job5(BaseModel):
     completed_at: Optional[str] = None
     created_at: Optional[str] = None
     failure_reason: Optional[str] = None
@@ -1659,7 +1975,7 @@ class Job4(BaseModel):
 
 class V2ExtractJobsGetResponse(BaseModel):
     has_more: Optional[bool] = None
-    jobs: Optional[list[Job4]] = None
+    jobs: Optional[list[Job5]] = None
     page: Optional[int] = None
     page_size: Optional[int] = None
 
@@ -1769,7 +2085,7 @@ class V2ExtractJobsPostResponse(BaseModel):
     status: Optional[Status1] = None
 
 
-class Result4(BaseModel):
+class Result5(BaseModel):
     """
     Result returned by V2ExtractOperationWorkflow — the ``/v2/extract``
     response body (``docs/extract-v2-contract.md`` → Response).
@@ -1832,7 +2148,7 @@ class V2ExtractJobsJobIdGetResponse(BaseModel):
         ge=0.0,
         le=1.0,
     )
-    result: Optional[Result4] = Field(
+    result: Optional[Result5] = Field(
         None,
         description='Present once status is ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead.',
     )
@@ -1948,7 +2264,7 @@ class V2ParseJobsGetParametersQuery(BaseModel):
     )
 
 
-class Status16(Enum):
+class Status19(Enum):
     """
     The job's current status: ``pending``, ``processing``, ``completed``, or ``failed``.
     """
@@ -1959,7 +2275,7 @@ class Status16(Enum):
     failed = 'failed'
 
 
-class Job5(BaseModel):
+class Job6(BaseModel):
     completed_at: Optional[str] = Field(
         None, description='ISO-8601 timestamp for when the job finished, if terminal.'
     )
@@ -1977,7 +2293,7 @@ class Job5(BaseModel):
     model_version: Optional[str] = Field(
         None, description='The model snapshot used to parse the document.'
     )
-    status: Optional[Status16] = Field(
+    status: Optional[Status19] = Field(
         None,
         description="The job's current status: ``pending``, ``processing``, ``completed``, or ``failed``.",
     )
@@ -1988,14 +2304,14 @@ class V2ParseJobsGetResponse(BaseModel):
         None,
         description='Whether more jobs exist beyond this page; request the next ``page`` to fetch them.',
     )
-    jobs: Optional[list[Job5]] = Field(
+    jobs: Optional[list[Job6]] = Field(
         None, description="The caller's parse jobs for this page, newest first."
     )
     page: Optional[int] = Field(None, description='The 0-indexed page number.')
     page_size: Optional[int] = Field(None, description='Items per page.')
 
 
-class ServiceTier12(Enum):
+class ServiceTier14(Enum):
     """
     Async service tier (``POST /jobs`` only). ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.
     """
@@ -2004,7 +2320,7 @@ class ServiceTier12(Enum):
     priority = 'priority'
 
 
-class Status17(Enum):
+class Status20(Enum):
     """
     The job's status at creation — normally ``pending`` (a just-created job that is still running is reported as ``pending``), but may already be a terminal ``completed`` / ``failed`` if the job finished before the create response was rendered.
     """
@@ -2023,13 +2339,13 @@ class V2ParseJobsPostResponse(BaseModel):
         ...,
         description='The unique identifier for the created parse job. Poll ``GET /v2/parse/jobs/{job_id}`` for its status and result. Format: ``<service>-<26-character Crockford base32 ULID>`` matching ``^(parse|extract)-[0-9a-hjkmnp-tv-z]{26}$``. Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
-    status: Status17 = Field(
+    status: Status20 = Field(
         ...,
         description="The job's status at creation — normally ``pending`` (a just-created job that is still running is reported as ``pending``), but may already be a terminal ``completed`` / ``failed`` if the job finished before the create response was rendered.",
     )
 
 
-class Error5(BaseModel):
+class Error6(BaseModel):
     """
     Present once the job has ``failed`` — the failure code + message.
     """
@@ -2038,7 +2354,7 @@ class Error5(BaseModel):
     message: Optional[str] = None
 
 
-class Status18(Enum):
+class Status21(Enum):
     """
     The job's current status: ``pending``, ``processing``, ``completed``, or ``failed``.
     """
@@ -2097,14 +2413,14 @@ class V2WorkflowJobsGetParametersQuery(BaseModel):
     )
 
 
-class Status19(Enum):
+class Status22(Enum):
     pending = 'pending'
     processing = 'processing'
     completed = 'completed'
     failed = 'failed'
 
 
-class Job6(BaseModel):
+class Job7(BaseModel):
     completed_at: Optional[str] = None
     created_at: Optional[str] = None
     failure_reason: Optional[str] = None
@@ -2113,17 +2429,17 @@ class Job6(BaseModel):
         description='The unique identifier for this v2-workflow job. Format: ``v2-workflow-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
     model_version: Optional[str] = None
-    status: Optional[Status19] = None
+    status: Optional[Status22] = None
 
 
 class V2WorkflowJobsGetResponse(BaseModel):
     has_more: Optional[bool] = None
-    jobs: Optional[list[Job6]] = None
+    jobs: Optional[list[Job7]] = None
     page: Optional[int] = None
     page_size: Optional[int] = None
 
 
-class ServiceTier13(Enum):
+class ServiceTier15(Enum):
     """
     Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.
     """
@@ -2138,10 +2454,10 @@ class V2WorkflowJobsPostResponse(BaseModel):
         None,
         description='The unique identifier for this v2-workflow job. Format: ``v2-workflow-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
-    status: Optional[Status19] = None
+    status: Optional[Status22] = None
 
 
-class Error6(BaseModel):
+class Error7(BaseModel):
     """
     Present once status is ``failed``.
     """
@@ -2152,7 +2468,7 @@ class Error6(BaseModel):
     message: Optional[str] = None
 
 
-class Result5(BaseModel):
+class Result6(BaseModel):
     """
     Result returned by V2WorkflowOperationWorkflow.
 
@@ -2193,7 +2509,7 @@ class V2WorkflowJobsJobIdGetResponse(BaseModel):
         None, description='Present once the job is terminal.'
     )
     created_at: Optional[str] = None
-    error: Optional[Error6] = Field(
+    error: Optional[Error7] = Field(
         None, description='Present once status is ``failed``.'
     )
     job_id: Optional[str] = Field(
@@ -2206,10 +2522,10 @@ class V2WorkflowJobsJobIdGetResponse(BaseModel):
         ge=0.0,
         le=1.0,
     )
-    result: Optional[Result5] = Field(
+    result: Optional[Result6] = Field(
         None, description='Present once status is ``completed``.'
     )
-    status: Optional[Status19] = None
+    status: Optional[Status22] = None
 
 
 class BlocksOptions(BaseModel):
@@ -2309,7 +2625,7 @@ class Options(BaseModel):
     pages: Optional[list[int]] = Field(None, title='Pages')
     password: Optional[str] = Field(
         None,
-        description='Password for encrypted PDFs. Not currently supported — providing a value returns a 422 error; decrypt the file before uploading.',
+        description='Password for an encrypted PDF. The document is decrypted once at the start of processing; the password is not retained with the result. PDFs only — supplying one for an image or Office document returns a 422 (`password_unsupported_content_type`). A wrong password returns a 422 (`encrypted_pdf_wrong_password`); omitting it for a locked PDF returns a 422 (`encrypted_pdf_password_required`).',
         title='Password',
     )
 
@@ -2356,7 +2672,7 @@ class V2ParseJobsPostRequest(BaseModel):
         None,
         description="Public URL the full response is delivered to; the API response then carries ``output_url`` instead of inline data. A presigned URL must stay valid until the job COMPLETES, not just past submit: an already-expired URL, or one whose remaining validity is too short for the document's page count, is rejected at submit (422). By default the URL must retain at least 15 minutes of validity at submit, plus 3 seconds per document page; the 422 message names the exact window required. Sign with credentials that outlive the expected job duration — a URL signed with temporary (assumed-role/session) credentials dies when that session expires, regardless of the URL's stated expiry.",
     )
-    service_tier: Optional[ServiceTier12] = Field(
+    service_tier: Optional[ServiceTier14] = Field(
         None,
         description='Async service tier (``POST /jobs`` only). ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
     )
@@ -2506,7 +2822,7 @@ class V2WorkflowJobsPostRequest(BaseModel):
         ],
         title='Output',
     )
-    service_tier: Optional[ServiceTier13] = Field(
+    service_tier: Optional[ServiceTier15] = Field(
         None,
         description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
     )
@@ -2547,7 +2863,7 @@ class V2WorkflowJobsPostRequest1(BaseModel):
         ],
         title='Output',
     )
-    service_tier: Optional[ServiceTier13] = Field(
+    service_tier: Optional[ServiceTier15] = Field(
         None,
         description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
     )
@@ -2708,7 +3024,7 @@ class V2ParseJobsJobIdGetResponse(BaseModel):
     created_at: Optional[str] = Field(
         None, description='ISO-8601 timestamp for when the job was created.'
     )
-    error: Optional[Error5] = Field(
+    error: Optional[Error6] = Field(
         None,
         description='Present once the job has ``failed`` — the failure code + message.',
     )
@@ -2732,7 +3048,7 @@ class V2ParseJobsJobIdGetResponse(BaseModel):
         None,
         description='The parse response, present once the job has ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead.',
     )
-    status: Optional[Status18] = Field(
+    status: Optional[Status21] = Field(
         None,
         description="The job's current status: ``pending``, ``processing``, ``completed``, or ``failed``.",
     )

--- a/specs/v2-aide.json
+++ b/specs/v2-aide.json
@@ -98,6 +98,34 @@
         "title": "BuildSchemaWarning",
         "type": "object"
       },
+      "ClassifyClass": {
+        "description": "One classification option: a class name plus an optional description.\n\nWire key ``class`` (VTRA's ``ClassifyClass``); the field is ``class_name``\nbecause ``class`` is a Python keyword, with the alias carrying the wire\nname. ``populate_by_name`` lets the Temporal round-trip (which serializes by\nFIELD name) rebuild the object on the worker side.",
+        "properties": {
+          "class": {
+            "description": "Class name assigned to a page when it matches.",
+            "title": "Class",
+            "type": "string"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "What this class represents. Improves classification.",
+            "title": "Description"
+          }
+        },
+        "required": [
+          "class"
+        ],
+        "title": "ClassifyClass",
+        "type": "object"
+      },
       "CreditUsage": {
         "description": "The standard credit-usage shape a billable WORK result carries.\n\nA billed passthrough operation's work result declares\n``credit_usage: CreditUsage`` and the gateway's default\n``build_success_record`` bills it verbatim — no per-op billing code\n(operations/base.py requires it: a result carrying anything else raises).\n\nStdlib result modules embedding CreditUsage should follow the pdf.py posture\n(no ``from __future__ import annotations``) or use pydantic dataclasses (the\nextract_v2 posture).",
         "properties": {
@@ -675,6 +703,133 @@
         "title": "Range",
         "type": "object"
       },
+      "Split": {
+        "description": "One split segment: consecutive pages of one classification (an\nidentifier change starts a new segment).",
+        "properties": {
+          "classification": {
+            "description": "The split classification name this segment was assigned.",
+            "title": "Classification",
+            "type": "string"
+          },
+          "identifier": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The identifier value extracted for this segment, when the matching split classification requested one. Null otherwise.",
+            "title": "Identifier"
+          },
+          "markdowns": {
+            "description": "The Markdown content of each page in this segment, in order.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Markdowns",
+            "type": "array"
+          },
+          "pages": {
+            "description": "0-indexed page numbers belonging to this segment, in order.",
+            "items": {
+              "type": "integer"
+            },
+            "title": "Pages",
+            "type": "array"
+          }
+        },
+        "required": [
+          "classification",
+          "identifier",
+          "pages",
+          "markdowns"
+        ],
+        "title": "Split",
+        "type": "object"
+      },
+      "SplitMetadata": {
+        "description": "Information about a split request.",
+        "properties": {
+          "credit_usage": {
+            "description": "Credits consumed by this request: the input Markdown length in characters divided by 5000. Billed usage rounds this up to the next 0.1 credit.",
+            "title": "Credit Usage",
+            "type": "number"
+          },
+          "duration_ms": {
+            "description": "Total processing time in milliseconds.",
+            "title": "Duration Ms",
+            "type": "integer"
+          },
+          "filename": {
+            "description": "Display name of the split document: the URL path's file name for `markdown_url` inputs, or a generated name for inline and uploaded Markdown.",
+            "title": "Filename",
+            "type": "string"
+          },
+          "job_id": {
+            "description": "The split job identifier — server-minted and unique per request. Correlates with the request's entry in your billing dashboard.",
+            "title": "Job Id",
+            "type": "string"
+          },
+          "org_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Organization ID.",
+            "title": "Org Id"
+          },
+          "page_count": {
+            "description": "Total number of pages in the input Markdown.",
+            "title": "Page Count",
+            "type": "integer"
+          },
+          "version": {
+            "description": "The exact split model snapshot that processed the document, e.g. `split-20251105`.",
+            "title": "Version",
+            "type": "string"
+          }
+        },
+        "required": [
+          "filename",
+          "org_id",
+          "page_count",
+          "duration_ms",
+          "credit_usage",
+          "job_id",
+          "version"
+        ],
+        "title": "SplitMetadata",
+        "type": "object"
+      },
+      "SplitResponse": {
+        "description": "The split result: the merged `splits` segments and request `metadata`.",
+        "properties": {
+          "metadata": {
+            "$ref": "#/components/schemas/SplitMetadata",
+            "description": "Information about the request: file name, page count, duration, credits, and the resolved model version."
+          },
+          "splits": {
+            "description": "The split segments, in page order. Consecutive pages with the same classification merge into one segment; an identifier change starts a new segment.",
+            "items": {
+              "$ref": "#/components/schemas/Split"
+            },
+            "title": "Splits",
+            "type": "array"
+          }
+        },
+        "required": [
+          "splits",
+          "metadata"
+        ],
+        "title": "SplitResponse",
+        "type": "object"
+      },
       "TableOptions": {
         "additionalProperties": false,
         "properties": {
@@ -773,6 +928,76 @@
           "openapi_spec"
         ],
         "title": "V1BuildSchemaMetadata",
+        "type": "object"
+      },
+      "V1ClassifyMetadata": {
+        "description": "Response metadata for a classify call — VTRA's ``ClassifyMetadata``.",
+        "properties": {
+          "credit_usage": {
+            "default": 0.0,
+            "description": "Credits billed for this request.",
+            "title": "Credit Usage",
+            "type": "number"
+          },
+          "duration_ms": {
+            "description": "End-to-end request duration in milliseconds.",
+            "title": "Duration Ms",
+            "type": "integer"
+          },
+          "filename": {
+            "default": "",
+            "description": "Name of the classified file.",
+            "title": "Filename",
+            "type": "string"
+          },
+          "job_id": {
+            "default": "",
+            "description": "Gateway job id (workflow id). Matches the billing row id in vision-agent.",
+            "title": "Job Id",
+            "type": "string"
+          },
+          "openapi_spec": {
+            "description": "URL of the OpenAPI spec covering this API, for inspection and client generation.",
+            "type": "string"
+          },
+          "org_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Organization ID.",
+            "title": "Org Id"
+          },
+          "page_count": {
+            "description": "Number of pages classified.",
+            "title": "Page Count",
+            "type": "integer"
+          },
+          "version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Resolved classify pipeline version that produced this response.",
+            "title": "Version"
+          }
+        },
+        "required": [
+          "page_count",
+          "duration_ms",
+          "openapi_spec"
+        ],
+        "title": "V1ClassifyMetadata",
         "type": "object"
       },
       "V1ExtractMetadata": {
@@ -1244,6 +1469,1312 @@
   },
   "openapi": "3.1.0",
   "paths": {
+    "/v1/ade/classify": {
+      "post": {
+        "description": "Classify each page of a document into classes you define. Accepts a PDF, an image, or an Office document, plus the list of candidate classes; returns one predicted class per page. Runs synchronously and returns the result inline.",
+        "operationId": "v1-ade-classify_run_sync",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Input to ``V1ClassifyOperationWorkflow`` (gateway) and, threaded\nunchanged, to ``ClassifyWorkflow`` (work) — the ``/v1/classify`` request\nbody. Mirrors VTRA's ``ClassifyRequest``.",
+                "properties": {
+                  "classes": {
+                    "description": "The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string.",
+                    "items": {
+                      "$ref": "#/components/schemas/ClassifyClass"
+                    },
+                    "title": "Classes",
+                    "type": "array"
+                  },
+                  "content_type": {
+                    "default": "",
+                    "title": "Content Type",
+                    "type": "string"
+                  },
+                  "document_ref": {
+                    "title": "Document Ref",
+                    "type": "string"
+                  },
+                  "filename": {
+                    "default": "",
+                    "title": "Filename",
+                    "type": "string"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version.",
+                    "title": "Model"
+                  }
+                },
+                "required": [
+                  "document_ref",
+                  "classes"
+                ],
+                "title": "ClassifyRequest",
+                "type": "object"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "classes": {
+                    "description": "The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string. JSON-serialized string in form data.",
+                    "items": {
+                      "$ref": "#/components/schemas/ClassifyClass"
+                    },
+                    "title": "Classes",
+                    "type": "array"
+                  },
+                  "content_type": {
+                    "default": "",
+                    "title": "Content Type",
+                    "type": "string"
+                  },
+                  "document": {
+                    "description": "The file to process. Provide either `document` or `document_url`, not both.",
+                    "format": "binary",
+                    "type": "string"
+                  },
+                  "document_url": {
+                    "description": "A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.",
+                    "type": "string"
+                  },
+                  "filename": {
+                    "default": "",
+                    "title": "Filename",
+                    "type": "string"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version. JSON-serialized string in form data.",
+                    "title": "Model"
+                  }
+                },
+                "required": [
+                  "classes"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Result returned by ``V1ClassifyOperationWorkflow`` — the\n``/v1/classify`` response body (VTRA's ``ClassifyResponse``).",
+                  "properties": {
+                    "classification": {
+                      "description": "One classification result per page, in page order.",
+                      "items": {
+                        "properties": {
+                          "class": {
+                            "description": "Predicted class label, or 'unknown'.",
+                            "type": "string"
+                          },
+                          "page": {
+                            "description": "Page number, zero-indexed (the first page is 0).",
+                            "type": "integer"
+                          },
+                          "reason": {
+                            "description": "Why the page was classified this way.",
+                            "type": "string"
+                          },
+                          "suggested_class": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "description": "A class the model proposes when the prediction is 'unknown'."
+                          }
+                        },
+                        "required": [
+                          "class",
+                          "reason",
+                          "page"
+                        ],
+                        "title": "ClassificationItem",
+                        "type": "object"
+                      },
+                      "title": "Classification",
+                      "type": "array"
+                    },
+                    "metadata": {
+                      "$ref": "#/components/schemas/V1ClassifyMetadata",
+                      "description": "Metadata for the classification request."
+                    }
+                  },
+                  "required": [
+                    "classification",
+                    "metadata"
+                  ],
+                  "title": "V1ClassifyResponse",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "v1-ade-classify result"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Classify",
+        "tags": [
+          "Classify"
+        ]
+      }
+    },
+    "/v1/ade/classify/jobs": {
+      "get": {
+        "description": "List your Classify jobs, newest first.",
+        "operationId": "v1-ade-classify_list_jobs",
+        "parameters": [
+          {
+            "description": "Page number (0-indexed).",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Page number (0-indexed).",
+              "minimum": 0,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of items per page.",
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "description": "Number of items per page.",
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Page Size",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Filter by job status.",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by job status.",
+              "title": "Status"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "has_more": {
+                      "type": "boolean"
+                    },
+                    "jobs": {
+                      "items": {
+                        "properties": {
+                          "completed_at": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "created_at": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "failure_reason": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "job_id": {
+                            "description": "The unique identifier for this v1-ade-classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                            "type": "string"
+                          },
+                          "model_version": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "status": {
+                            "enum": [
+                              "pending",
+                              "processing",
+                              "completed",
+                              "failed"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "page": {
+                      "type": "integer"
+                    },
+                    "page_size": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "The caller's jobs, newest first"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE List Classify Jobs",
+        "tags": [
+          "Classify"
+        ]
+      },
+      "post": {
+        "description": "Classify each page of a document into classes you define. Accepts a PDF, an image, or an Office document, plus the list of candidate classes; returns one predicted class per page. Runs asynchronously and returns a job ID; use it to poll for status and retrieve the result once processing completes.",
+        "operationId": "v1-ade-classify_create_job",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Input to ``V1ClassifyOperationWorkflow`` (gateway) and, threaded\nunchanged, to ``ClassifyWorkflow`` (work) — the ``/v1/classify`` request\nbody. Mirrors VTRA's ``ClassifyRequest``.",
+                "properties": {
+                  "classes": {
+                    "description": "The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string.",
+                    "items": {
+                      "$ref": "#/components/schemas/ClassifyClass"
+                    },
+                    "title": "Classes",
+                    "type": "array"
+                  },
+                  "content_type": {
+                    "default": "",
+                    "title": "Content Type",
+                    "type": "string"
+                  },
+                  "document_ref": {
+                    "title": "Document Ref",
+                    "type": "string"
+                  },
+                  "filename": {
+                    "default": "",
+                    "title": "Filename",
+                    "type": "string"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version.",
+                    "title": "Model"
+                  },
+                  "service_tier": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "standard",
+                          "priority"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
+                  }
+                },
+                "required": [
+                  "document_ref",
+                  "classes"
+                ],
+                "title": "ClassifyRequest",
+                "type": "object"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "classes": {
+                    "description": "The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string. JSON-serialized string in form data.",
+                    "items": {
+                      "$ref": "#/components/schemas/ClassifyClass"
+                    },
+                    "title": "Classes",
+                    "type": "array"
+                  },
+                  "content_type": {
+                    "default": "",
+                    "title": "Content Type",
+                    "type": "string"
+                  },
+                  "document": {
+                    "description": "The file to process. Provide either `document` or `document_url`, not both.",
+                    "format": "binary",
+                    "type": "string"
+                  },
+                  "document_url": {
+                    "description": "A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.",
+                    "type": "string"
+                  },
+                  "filename": {
+                    "default": "",
+                    "title": "Filename",
+                    "type": "string"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version. JSON-serialized string in form data.",
+                    "title": "Model"
+                  },
+                  "service_tier": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "standard",
+                          "priority"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
+                  }
+                },
+                "required": [
+                  "classes"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "created_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "job_id": {
+                      "description": "The unique identifier for this v1-ade-classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                      "type": "string"
+                    },
+                    "status": {
+                      "enum": [
+                        "pending",
+                        "processing",
+                        "completed",
+                        "failed"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Job created"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Classify Jobs",
+        "tags": [
+          "Classify"
+        ]
+      }
+    },
+    "/v1/ade/classify/jobs/{job_id}": {
+      "get": {
+        "description": "Get the status of an async Classify job, including its result once the job has completed.",
+        "operationId": "v1-ade-classify_get_job",
+        "parameters": [
+          {
+            "description": "The identifier of the job to retrieve, as returned by the create-job request.",
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "description": "The identifier of the job to retrieve, as returned by the create-job request.",
+              "title": "Job Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "completed_at": {
+                      "description": "Present once the job is terminal.",
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "description": "Present once status is ``failed``.",
+                      "properties": {
+                        "code": {
+                          "description": "Stable error code (``internal_error`` when unmapped).",
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "job_id": {
+                      "description": "The unique identifier for this v1-ade-classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                      "type": "string"
+                    },
+                    "progress": {
+                      "description": "Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.",
+                      "maximum": 1,
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    "result": {
+                      "anyOf": [
+                        {
+                          "description": "Result returned by ``V1ClassifyOperationWorkflow`` — the\n``/v1/classify`` response body (VTRA's ``ClassifyResponse``).",
+                          "properties": {
+                            "classification": {
+                              "description": "One classification result per page, in page order.",
+                              "items": {
+                                "properties": {
+                                  "class": {
+                                    "description": "Predicted class label, or 'unknown'.",
+                                    "type": "string"
+                                  },
+                                  "page": {
+                                    "description": "Page number, zero-indexed (the first page is 0).",
+                                    "type": "integer"
+                                  },
+                                  "reason": {
+                                    "description": "Why the page was classified this way.",
+                                    "type": "string"
+                                  },
+                                  "suggested_class": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ],
+                                    "description": "A class the model proposes when the prediction is 'unknown'."
+                                  }
+                                },
+                                "required": [
+                                  "class",
+                                  "reason",
+                                  "page"
+                                ],
+                                "title": "ClassificationItem",
+                                "type": "object"
+                              },
+                              "title": "Classification",
+                              "type": "array"
+                            },
+                            "metadata": {
+                              "$ref": "#/components/schemas/V1ClassifyMetadata",
+                              "description": "Metadata for the classification request."
+                            }
+                          },
+                          "required": [
+                            "classification",
+                            "metadata"
+                          ],
+                          "title": "V1ClassifyResponse",
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Present once status is ``completed``."
+                    },
+                    "status": {
+                      "enum": [
+                        "pending",
+                        "processing",
+                        "completed",
+                        "failed"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Job status / result"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not found (e.g. no such job)."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Get Classify Jobs",
+        "tags": [
+          "Classify"
+        ]
+      }
+    },
+    "/v1/ade/extract": {
+      "post": {
+        "description": "Extract structured data from a Markdown document using a JSON Schema. v1-compatible wire, running the same extraction engine as `/v2/extract`. Runs synchronously and returns the result inline.",
+        "operationId": "v1-ade-extract_run_sync",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.\n\nVTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline\nstring), ``markdown_url``, ``schema``, ``strict``. Nothing else — AIDE's own\nextras (``return_reasoning``, ``fallback_model``, ``output_save_url``) stay on\nthe R&D ``/api/extract`` contract, so the customer surface publishes the VTRA\ncontract and only that.",
+                "properties": {
+                  "markdown": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Markdown"
+                  },
+                  "markdown_url": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Markdown Url"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Model"
+                  },
+                  "schema": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Schema"
+                  },
+                  "strict": {
+                    "default": false,
+                    "title": "Strict",
+                    "type": "boolean"
+                  }
+                },
+                "title": "V1ExtractRequest",
+                "type": "object"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "markdown": {
+                    "description": "File upload.",
+                    "format": "binary",
+                    "type": "string"
+                  },
+                  "markdown_url": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "JSON-serialized string in form data.",
+                    "title": "Markdown Url"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "JSON-serialized string in form data.",
+                    "title": "Model"
+                  },
+                  "schema": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "JSON-serialized string in form data.",
+                    "title": "Schema"
+                  },
+                  "strict": {
+                    "default": false,
+                    "description": "JSON-serialized string in form data.",
+                    "title": "Strict",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "VTRA's ``ExtractResponse`` — the ``/v1/extract`` response body.\n\n``extraction`` is ALWAYS inline. The internal ``ExtractResult`` returns an\n``output_ref`` instead when the payload is too large for the Temporal wire; on\nthis route that pointer is resolved back to inline content at the render\nboundary, because VTRA always inlines and a client migrating off it has no\n``output_ref`` handling at all.",
+                  "properties": {
+                    "extraction": {
+                      "additionalProperties": true,
+                      "title": "Extraction",
+                      "type": "object"
+                    },
+                    "extraction_metadata": {
+                      "additionalProperties": true,
+                      "title": "Extraction Metadata",
+                      "type": "object"
+                    },
+                    "metadata": {
+                      "$ref": "#/components/schemas/V1ExtractMetadata"
+                    }
+                  },
+                  "title": "V1ExtractResponse",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "v1-ade-extract result"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Extract",
+        "tags": [
+          "Extract"
+        ]
+      }
+    },
+    "/v1/ade/extract/jobs": {
+      "get": {
+        "description": "List your Extract jobs, newest first.",
+        "operationId": "v1-ade-extract_list_jobs",
+        "parameters": [
+          {
+            "description": "Page number (0-indexed).",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Page number (0-indexed).",
+              "minimum": 0,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of items per page.",
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "description": "Number of items per page.",
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Page Size",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Filter by job status.",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by job status.",
+              "title": "Status"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "has_more": {
+                      "type": "boolean"
+                    },
+                    "jobs": {
+                      "items": {
+                        "properties": {
+                          "completed_at": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "created_at": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "failure_reason": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "job_id": {
+                            "description": "The unique identifier for this v1-ade-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                            "type": "string"
+                          },
+                          "model_version": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "status": {
+                            "enum": [
+                              "pending",
+                              "processing",
+                              "completed",
+                              "failed"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "page": {
+                      "type": "integer"
+                    },
+                    "page_size": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "The caller's jobs, newest first"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE List Extract Jobs",
+        "tags": [
+          "Extract"
+        ]
+      },
+      "post": {
+        "description": "Extract structured data from a Markdown document using a JSON Schema. v1-compatible wire, running the same extraction engine as `/v2/extract`. Runs asynchronously and returns a job ID; use it to poll for status and retrieve the result once processing completes.",
+        "operationId": "v1-ade-extract_create_job",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.\n\nVTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline\nstring), ``markdown_url``, ``schema``, ``strict``. Nothing else — AIDE's own\nextras (``return_reasoning``, ``fallback_model``, ``output_save_url``) stay on\nthe R&D ``/api/extract`` contract, so the customer surface publishes the VTRA\ncontract and only that.",
+                "properties": {
+                  "markdown": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Markdown"
+                  },
+                  "markdown_url": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Markdown Url"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Model"
+                  },
+                  "schema": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Schema"
+                  },
+                  "service_tier": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "standard",
+                          "priority"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
+                  },
+                  "strict": {
+                    "default": false,
+                    "title": "Strict",
+                    "type": "boolean"
+                  }
+                },
+                "title": "V1ExtractRequest",
+                "type": "object"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "markdown": {
+                    "description": "File upload.",
+                    "format": "binary",
+                    "type": "string"
+                  },
+                  "markdown_url": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "JSON-serialized string in form data.",
+                    "title": "Markdown Url"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "JSON-serialized string in form data.",
+                    "title": "Model"
+                  },
+                  "schema": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "JSON-serialized string in form data.",
+                    "title": "Schema"
+                  },
+                  "service_tier": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "standard",
+                          "priority"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
+                  },
+                  "strict": {
+                    "default": false,
+                    "description": "JSON-serialized string in form data.",
+                    "title": "Strict",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "created_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "job_id": {
+                      "description": "The unique identifier for this v1-ade-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                      "type": "string"
+                    },
+                    "status": {
+                      "enum": [
+                        "pending",
+                        "processing",
+                        "completed",
+                        "failed"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Job created"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Extract Jobs",
+        "tags": [
+          "Extract"
+        ]
+      }
+    },
+    "/v1/ade/extract/jobs/{job_id}": {
+      "get": {
+        "description": "Get the status of an async Extract job, including its result once the job has completed.",
+        "operationId": "v1-ade-extract_get_job",
+        "parameters": [
+          {
+            "description": "The identifier of the job to retrieve, as returned by the create-job request.",
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "description": "The identifier of the job to retrieve, as returned by the create-job request.",
+              "title": "Job Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "completed_at": {
+                      "description": "Present once the job is terminal.",
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "description": "Present once status is ``failed``.",
+                      "properties": {
+                        "code": {
+                          "description": "Stable error code (``internal_error`` when unmapped).",
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "job_id": {
+                      "description": "The unique identifier for this v1-ade-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                      "type": "string"
+                    },
+                    "progress": {
+                      "description": "Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.",
+                      "maximum": 1,
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    "result": {
+                      "anyOf": [
+                        {
+                          "description": "VTRA's ``ExtractResponse`` — the ``/v1/extract`` response body.\n\n``extraction`` is ALWAYS inline. The internal ``ExtractResult`` returns an\n``output_ref`` instead when the payload is too large for the Temporal wire; on\nthis route that pointer is resolved back to inline content at the render\nboundary, because VTRA always inlines and a client migrating off it has no\n``output_ref`` handling at all.",
+                          "properties": {
+                            "extraction": {
+                              "additionalProperties": true,
+                              "title": "Extraction",
+                              "type": "object"
+                            },
+                            "extraction_metadata": {
+                              "additionalProperties": true,
+                              "title": "Extraction Metadata",
+                              "type": "object"
+                            },
+                            "metadata": {
+                              "$ref": "#/components/schemas/V1ExtractMetadata"
+                            }
+                          },
+                          "title": "V1ExtractResponse",
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Present once status is ``completed``."
+                    },
+                    "status": {
+                      "enum": [
+                        "pending",
+                        "processing",
+                        "completed",
+                        "failed"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Job status / result"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not found (e.g. no such job)."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Get Extract Jobs",
+        "tags": [
+          "Extract"
+        ]
+      }
+    },
     "/v1/ade/parse": {
       "post": {
         "description": "Run synchronously and return the result inline.\n\nAccepts ``application/json`` (the request fields as the body),\n``multipart/form-data`` (file fields are staged automatically),\nor ``application/x-www-form-urlencoded`` (text fields only).\n\nReturns **504** if the work does not finish within the wait\nwindow — long-running work belongs on the async ``POST\n{path}/jobs`` route, which returns 202 immediately and is polled\nvia ``GET {path}/jobs/{job_id}``. On a 504 the workflow is\nCANCELLED (a sync caller can never collect the result); a retry\nstarts the work over as a fresh job.",
@@ -1399,9 +2930,13 @@
                     "description": "JSON-serialized string in form data.",
                     "title": "Custom Prompts"
                   },
-                  "document_ref": {
-                    "description": "File upload.",
+                  "document": {
+                    "description": "The file to process. Provide either `document` or `document_url`, not both.",
                     "format": "binary",
+                    "type": "string"
+                  },
+                  "document_url": {
+                    "description": "A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.",
                     "type": "string"
                   },
                   "filename": {
@@ -1502,7 +3037,6 @@
                   }
                 },
                 "required": [
-                  "document_ref",
                   "filename",
                   "content_type"
                 ],
@@ -1528,6 +3062,11 @@
                       "default": 0,
                       "title": "Billable Pages",
                       "type": "integer"
+                    },
+                    "billing_suppressed": {
+                      "default": false,
+                      "title": "Billing Suppressed",
+                      "type": "boolean"
                     },
                     "completion_tokens": {
                       "default": 0,
@@ -1968,9 +3507,13 @@
                     "description": "JSON-serialized string in form data.",
                     "title": "Custom Prompts"
                   },
-                  "document_ref": {
-                    "description": "File upload.",
+                  "document": {
+                    "description": "The file to process. Provide either `document` or `document_url`, not both.",
                     "format": "binary",
+                    "type": "string"
+                  },
+                  "document_url": {
+                    "description": "A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.",
                     "type": "string"
                   },
                   "filename": {
@@ -2099,7 +3642,6 @@
                   }
                 },
                 "required": [
-                  "document_ref",
                   "filename",
                   "content_type"
                 ],
@@ -2242,6 +3784,11 @@
                               "default": 0,
                               "title": "Billable Pages",
                               "type": "integer"
+                            },
+                            "billing_suppressed": {
+                              "default": false,
+                              "title": "Billing Suppressed",
+                              "type": "boolean"
                             },
                             "completion_tokens": {
                               "default": 0,
@@ -2397,39 +3944,37 @@
         ]
       }
     },
-    "/v1/extract": {
+    "/v1/classify": {
       "post": {
-        "description": "Extract structured data from a Markdown document using a JSON Schema. v1-compatible wire, running the same extraction engine as `/v2/extract`. Runs synchronously and returns the result inline.",
-        "operationId": "v1-extract_run_sync",
+        "description": "Classify each page of a document into classes you define. Accepts a PDF, an image, or an Office document, plus the list of candidate classes; returns one predicted class per page. Runs synchronously and returns the result inline.",
+        "operationId": "classify_run_sync",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "description": "Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.\n\nVTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline\nstring), ``markdown_url``, ``schema``, ``strict``. Nothing else — AIDE's own\nextras (``return_reasoning``, ``fallback_model``, ``output_save_url``) stay on\nthe R&D ``/api/extract`` contract, so the customer surface publishes the VTRA\ncontract and only that.",
+                "description": "Input to ``V1ClassifyOperationWorkflow`` (gateway) and, threaded\nunchanged, to ``ClassifyWorkflow`` (work) — the ``/v1/classify`` request\nbody. Mirrors VTRA's ``ClassifyRequest``.",
                 "properties": {
-                  "markdown": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Markdown"
+                  "classes": {
+                    "description": "The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string.",
+                    "items": {
+                      "$ref": "#/components/schemas/ClassifyClass"
+                    },
+                    "title": "Classes",
+                    "type": "array"
                   },
-                  "markdown_url": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Markdown Url"
+                  "content_type": {
+                    "default": "",
+                    "title": "Content Type",
+                    "type": "string"
+                  },
+                  "document_ref": {
+                    "title": "Document Ref",
+                    "type": "string"
+                  },
+                  "filename": {
+                    "default": "",
+                    "title": "Filename",
+                    "type": "string"
                   },
                   "model": {
                     "anyOf": [
@@ -2441,50 +3986,47 @@
                       }
                     ],
                     "default": null,
+                    "description": "Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version.",
                     "title": "Model"
-                  },
-                  "schema": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Schema"
-                  },
-                  "strict": {
-                    "default": false,
-                    "title": "Strict",
-                    "type": "boolean"
                   }
                 },
-                "title": "V1ExtractRequest",
+                "required": [
+                  "document_ref",
+                  "classes"
+                ],
+                "title": "ClassifyRequest",
                 "type": "object"
               }
             },
             "multipart/form-data": {
               "schema": {
                 "properties": {
-                  "markdown": {
-                    "description": "File upload.",
+                  "classes": {
+                    "description": "The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string. JSON-serialized string in form data.",
+                    "items": {
+                      "$ref": "#/components/schemas/ClassifyClass"
+                    },
+                    "title": "Classes",
+                    "type": "array"
+                  },
+                  "content_type": {
+                    "default": "",
+                    "title": "Content Type",
+                    "type": "string"
+                  },
+                  "document": {
+                    "description": "The file to process. Provide either `document` or `document_url`, not both.",
                     "format": "binary",
                     "type": "string"
                   },
-                  "markdown_url": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Markdown Url"
+                  "document_url": {
+                    "description": "A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.",
+                    "type": "string"
+                  },
+                  "filename": {
+                    "default": "",
+                    "title": "Filename",
+                    "type": "string"
                   },
                   "model": {
                     "anyOf": [
@@ -2496,29 +4038,13 @@
                       }
                     ],
                     "default": null,
-                    "description": "JSON-serialized string in form data.",
+                    "description": "Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version. JSON-serialized string in form data.",
                     "title": "Model"
-                  },
-                  "schema": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Schema"
-                  },
-                  "strict": {
-                    "default": false,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Strict",
-                    "type": "boolean"
                   }
                 },
+                "required": [
+                  "classes"
+                ],
                 "type": "object"
               }
             }
@@ -2530,28 +4056,62 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "description": "VTRA's ``ExtractResponse`` — the ``/v1/extract`` response body.\n\n``extraction`` is ALWAYS inline. The internal ``ExtractResult`` returns an\n``output_ref`` instead when the payload is too large for the Temporal wire; on\nthis route that pointer is resolved back to inline content at the render\nboundary, because VTRA always inlines and a client migrating off it has no\n``output_ref`` handling at all.",
+                  "description": "Result returned by ``V1ClassifyOperationWorkflow`` — the\n``/v1/classify`` response body (VTRA's ``ClassifyResponse``).",
                   "properties": {
-                    "extraction": {
-                      "additionalProperties": true,
-                      "title": "Extraction",
-                      "type": "object"
-                    },
-                    "extraction_metadata": {
-                      "additionalProperties": true,
-                      "title": "Extraction Metadata",
-                      "type": "object"
+                    "classification": {
+                      "description": "One classification result per page, in page order.",
+                      "items": {
+                        "properties": {
+                          "class": {
+                            "description": "Predicted class label, or 'unknown'.",
+                            "type": "string"
+                          },
+                          "page": {
+                            "description": "Page number, zero-indexed (the first page is 0).",
+                            "type": "integer"
+                          },
+                          "reason": {
+                            "description": "Why the page was classified this way.",
+                            "type": "string"
+                          },
+                          "suggested_class": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "description": "A class the model proposes when the prediction is 'unknown'."
+                          }
+                        },
+                        "required": [
+                          "class",
+                          "reason",
+                          "page"
+                        ],
+                        "title": "ClassificationItem",
+                        "type": "object"
+                      },
+                      "title": "Classification",
+                      "type": "array"
                     },
                     "metadata": {
-                      "$ref": "#/components/schemas/V1ExtractMetadata"
+                      "$ref": "#/components/schemas/V1ClassifyMetadata",
+                      "description": "Metadata for the classification request."
                     }
                   },
-                  "title": "V1ExtractResponse",
+                  "required": [
+                    "classification",
+                    "metadata"
+                  ],
+                  "title": "V1ClassifyResponse",
                   "type": "object"
                 }
               }
             },
-            "description": "v1-extract result"
+            "description": "classify result"
           },
           "422": {
             "content": {
@@ -2564,9 +4124,489 @@
             "description": "Request validation failed."
           }
         },
-        "summary": "ADE Extract",
+        "summary": "ADE Classify",
         "tags": [
-          "Extract"
+          "Classify"
+        ]
+      }
+    },
+    "/v1/classify/jobs": {
+      "get": {
+        "description": "List your Classify jobs, newest first.",
+        "operationId": "classify_list_jobs",
+        "parameters": [
+          {
+            "description": "Page number (0-indexed).",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Page number (0-indexed).",
+              "minimum": 0,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of items per page.",
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "description": "Number of items per page.",
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Page Size",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Filter by job status.",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by job status.",
+              "title": "Status"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "has_more": {
+                      "type": "boolean"
+                    },
+                    "jobs": {
+                      "items": {
+                        "properties": {
+                          "completed_at": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "created_at": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "failure_reason": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "job_id": {
+                            "description": "The unique identifier for this classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                            "type": "string"
+                          },
+                          "model_version": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "status": {
+                            "enum": [
+                              "pending",
+                              "processing",
+                              "completed",
+                              "failed"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "page": {
+                      "type": "integer"
+                    },
+                    "page_size": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "The caller's jobs, newest first"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE List Classify Jobs",
+        "tags": [
+          "Classify"
+        ]
+      },
+      "post": {
+        "description": "Classify each page of a document into classes you define. Accepts a PDF, an image, or an Office document, plus the list of candidate classes; returns one predicted class per page. Runs asynchronously and returns a job ID; use it to poll for status and retrieve the result once processing completes.",
+        "operationId": "classify_create_job",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Input to ``V1ClassifyOperationWorkflow`` (gateway) and, threaded\nunchanged, to ``ClassifyWorkflow`` (work) — the ``/v1/classify`` request\nbody. Mirrors VTRA's ``ClassifyRequest``.",
+                "properties": {
+                  "classes": {
+                    "description": "The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string.",
+                    "items": {
+                      "$ref": "#/components/schemas/ClassifyClass"
+                    },
+                    "title": "Classes",
+                    "type": "array"
+                  },
+                  "content_type": {
+                    "default": "",
+                    "title": "Content Type",
+                    "type": "string"
+                  },
+                  "document_ref": {
+                    "title": "Document Ref",
+                    "type": "string"
+                  },
+                  "filename": {
+                    "default": "",
+                    "title": "Filename",
+                    "type": "string"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version.",
+                    "title": "Model"
+                  },
+                  "service_tier": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "standard",
+                          "priority"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
+                  }
+                },
+                "required": [
+                  "document_ref",
+                  "classes"
+                ],
+                "title": "ClassifyRequest",
+                "type": "object"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "classes": {
+                    "description": "The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string. JSON-serialized string in form data.",
+                    "items": {
+                      "$ref": "#/components/schemas/ClassifyClass"
+                    },
+                    "title": "Classes",
+                    "type": "array"
+                  },
+                  "content_type": {
+                    "default": "",
+                    "title": "Content Type",
+                    "type": "string"
+                  },
+                  "document": {
+                    "description": "The file to process. Provide either `document` or `document_url`, not both.",
+                    "format": "binary",
+                    "type": "string"
+                  },
+                  "document_url": {
+                    "description": "A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.",
+                    "type": "string"
+                  },
+                  "filename": {
+                    "default": "",
+                    "title": "Filename",
+                    "type": "string"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version. JSON-serialized string in form data.",
+                    "title": "Model"
+                  },
+                  "service_tier": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "standard",
+                          "priority"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
+                  }
+                },
+                "required": [
+                  "classes"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "created_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "job_id": {
+                      "description": "The unique identifier for this classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                      "type": "string"
+                    },
+                    "status": {
+                      "enum": [
+                        "pending",
+                        "processing",
+                        "completed",
+                        "failed"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Job created"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Classify Jobs",
+        "tags": [
+          "Classify"
+        ]
+      }
+    },
+    "/v1/classify/jobs/{job_id}": {
+      "get": {
+        "description": "Get the status of an async Classify job, including its result once the job has completed.",
+        "operationId": "classify_get_job",
+        "parameters": [
+          {
+            "description": "The identifier of the job to retrieve, as returned by the create-job request.",
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "description": "The identifier of the job to retrieve, as returned by the create-job request.",
+              "title": "Job Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "completed_at": {
+                      "description": "Present once the job is terminal.",
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "description": "Present once status is ``failed``.",
+                      "properties": {
+                        "code": {
+                          "description": "Stable error code (``internal_error`` when unmapped).",
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "job_id": {
+                      "description": "The unique identifier for this classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                      "type": "string"
+                    },
+                    "progress": {
+                      "description": "Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.",
+                      "maximum": 1,
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    "result": {
+                      "anyOf": [
+                        {
+                          "description": "Result returned by ``V1ClassifyOperationWorkflow`` — the\n``/v1/classify`` response body (VTRA's ``ClassifyResponse``).",
+                          "properties": {
+                            "classification": {
+                              "description": "One classification result per page, in page order.",
+                              "items": {
+                                "properties": {
+                                  "class": {
+                                    "description": "Predicted class label, or 'unknown'.",
+                                    "type": "string"
+                                  },
+                                  "page": {
+                                    "description": "Page number, zero-indexed (the first page is 0).",
+                                    "type": "integer"
+                                  },
+                                  "reason": {
+                                    "description": "Why the page was classified this way.",
+                                    "type": "string"
+                                  },
+                                  "suggested_class": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ],
+                                    "description": "A class the model proposes when the prediction is 'unknown'."
+                                  }
+                                },
+                                "required": [
+                                  "class",
+                                  "reason",
+                                  "page"
+                                ],
+                                "title": "ClassificationItem",
+                                "type": "object"
+                              },
+                              "title": "Classification",
+                              "type": "array"
+                            },
+                            "metadata": {
+                              "$ref": "#/components/schemas/V1ClassifyMetadata",
+                              "description": "Metadata for the classification request."
+                            }
+                          },
+                          "required": [
+                            "classification",
+                            "metadata"
+                          ],
+                          "title": "V1ClassifyResponse",
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Present once status is ``completed``."
+                    },
+                    "status": {
+                      "enum": [
+                        "pending",
+                        "processing",
+                        "completed",
+                        "failed"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Job status / result"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not found (e.g. no such job)."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Get Classify Jobs",
+        "tags": [
+          "Classify"
         ]
       }
     },
@@ -3290,734 +5330,42 @@
         ]
       }
     },
-    "/v1/extract/jobs": {
-      "get": {
-        "description": "List your Extract jobs, newest first.",
-        "operationId": "v1-extract_list_jobs",
-        "parameters": [
-          {
-            "description": "Page number (0-indexed).",
-            "in": "query",
-            "name": "page",
-            "required": false,
-            "schema": {
-              "default": 0,
-              "description": "Page number (0-indexed).",
-              "minimum": 0,
-              "title": "Page",
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Number of items per page.",
-            "in": "query",
-            "name": "page_size",
-            "required": false,
-            "schema": {
-              "default": 10,
-              "description": "Number of items per page.",
-              "maximum": 100,
-              "minimum": 1,
-              "title": "Page Size",
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Filter by job status.",
-            "in": "query",
-            "name": "status",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Filter by job status.",
-              "title": "Status"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "has_more": {
-                      "type": "boolean"
-                    },
-                    "jobs": {
-                      "items": {
-                        "properties": {
-                          "completed_at": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "created_at": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "failure_reason": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "job_id": {
-                            "description": "The unique identifier for this v1-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
-                            "type": "string"
-                          },
-                          "model_version": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "status": {
-                            "enum": [
-                              "pending",
-                              "processing",
-                              "completed",
-                              "failed"
-                            ],
-                            "type": "string"
-                          }
-                        },
-                        "type": "object"
-                      },
-                      "type": "array"
-                    },
-                    "page": {
-                      "type": "integer"
-                    },
-                    "page_size": {
-                      "type": "integer"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "The caller's jobs, newest first"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Request validation failed."
-          }
-        },
-        "summary": "ADE List Extract Jobs",
-        "tags": [
-          "Extract"
-        ]
-      },
+    "/v1/split": {
       "post": {
-        "description": "Extract structured data from a Markdown document using a JSON Schema. v1-compatible wire, running the same extraction engine as `/v2/extract`. Runs asynchronously and returns a job ID; use it to poll for status and retrieve the result once processing completes.",
-        "operationId": "v1-extract_create_job",
+        "description": "Split a Markdown document into segments and return the split response inline.",
+        "operationId": "v1-split_run_sync",
         "requestBody": {
           "content": {
-            "application/json": {
-              "schema": {
-                "description": "Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.\n\nVTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline\nstring), ``markdown_url``, ``schema``, ``strict``. Nothing else — AIDE's own\nextras (``return_reasoning``, ``fallback_model``, ``output_save_url``) stay on\nthe R&D ``/api/extract`` contract, so the customer surface publishes the VTRA\ncontract and only that.",
-                "properties": {
-                  "markdown": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Markdown"
-                  },
-                  "markdown_url": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Markdown Url"
-                  },
-                  "model": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Model"
-                  },
-                  "schema": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Schema"
-                  },
-                  "service_tier": {
-                    "anyOf": [
-                      {
-                        "enum": [
-                          "standard",
-                          "priority"
-                        ],
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
-                  },
-                  "strict": {
-                    "default": false,
-                    "title": "Strict",
-                    "type": "boolean"
-                  }
-                },
-                "title": "V1ExtractRequest",
-                "type": "object"
-              }
-            },
             "multipart/form-data": {
               "schema": {
                 "properties": {
                   "markdown": {
-                    "description": "File upload.",
-                    "format": "binary",
-                    "type": "string"
+                    "anyOf": [
+                      {
+                        "format": "binary",
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "description": "Markdown content to split, as an inline string or an uploaded file. Provide either `markdown` or `markdown_url`, not both."
                   },
                   "markdown_url": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Markdown Url"
+                    "description": "A publicly accessible URL to the Markdown file to split. Provide either `markdown` or `markdown_url`, not both.",
+                    "type": "string"
                   },
                   "model": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Model"
-                  },
-                  "schema": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Schema"
-                  },
-                  "service_tier": {
-                    "anyOf": [
-                      {
-                        "enum": [
-                          "standard",
-                          "priority"
-                        ],
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
-                  },
-                  "strict": {
-                    "default": false,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Strict",
-                    "type": "boolean"
-                  }
-                },
-                "type": "object"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "202": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "created_at": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "job_id": {
-                      "description": "The unique identifier for this v1-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
-                      "type": "string"
-                    },
-                    "status": {
-                      "enum": [
-                        "pending",
-                        "processing",
-                        "completed",
-                        "failed"
-                      ],
-                      "type": "string"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Job created"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Request validation failed."
-          }
-        },
-        "summary": "ADE Extract Jobs",
-        "tags": [
-          "Extract"
-        ]
-      }
-    },
-    "/v1/extract/jobs/{job_id}": {
-      "get": {
-        "description": "Get the status of an async Extract job, including its result once the job has completed.",
-        "operationId": "v1-extract_get_job",
-        "parameters": [
-          {
-            "description": "The identifier of the job to retrieve, as returned by the create-job request.",
-            "in": "path",
-            "name": "job_id",
-            "required": true,
-            "schema": {
-              "description": "The identifier of the job to retrieve, as returned by the create-job request.",
-              "title": "Job Id",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "completed_at": {
-                      "description": "Present once the job is terminal.",
-                      "type": "string"
-                    },
-                    "created_at": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "error": {
-                      "description": "Present once status is ``failed``.",
-                      "properties": {
-                        "code": {
-                          "description": "Stable error code (``internal_error`` when unmapped).",
-                          "type": "string"
-                        },
-                        "message": {
-                          "type": "string"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    "job_id": {
-                      "description": "The unique identifier for this v1-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
-                      "type": "string"
-                    },
-                    "progress": {
-                      "description": "Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.",
-                      "maximum": 1,
-                      "minimum": 0,
-                      "type": "number"
-                    },
-                    "result": {
-                      "anyOf": [
-                        {
-                          "description": "VTRA's ``ExtractResponse`` — the ``/v1/extract`` response body.\n\n``extraction`` is ALWAYS inline. The internal ``ExtractResult`` returns an\n``output_ref`` instead when the payload is too large for the Temporal wire; on\nthis route that pointer is resolved back to inline content at the render\nboundary, because VTRA always inlines and a client migrating off it has no\n``output_ref`` handling at all.",
-                          "properties": {
-                            "extraction": {
-                              "additionalProperties": true,
-                              "title": "Extraction",
-                              "type": "object"
-                            },
-                            "extraction_metadata": {
-                              "additionalProperties": true,
-                              "title": "Extraction Metadata",
-                              "type": "object"
-                            },
-                            "metadata": {
-                              "$ref": "#/components/schemas/V1ExtractMetadata"
-                            }
-                          },
-                          "title": "V1ExtractResponse",
-                          "type": "object"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "description": "Present once status is ``completed``."
-                    },
-                    "status": {
-                      "enum": [
-                        "pending",
-                        "processing",
-                        "completed",
-                        "failed"
-                      ],
-                      "type": "string"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Job status / result"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Not found (e.g. no such job)."
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Request validation failed."
-          }
-        },
-        "summary": "ADE Get Extract Jobs",
-        "tags": [
-          "Extract"
-        ]
-      }
-    },
-    "/v1/parse": {
-      "post": {
-        "description": "Run synchronously and return the result inline.\n\nAccepts ``application/json`` (the request fields as the body),\n``multipart/form-data`` (file fields are staged automatically),\nor ``application/x-www-form-urlencoded`` (text fields only).\n\nReturns **504** if the work does not finish within the wait\nwindow — long-running work belongs on the async ``POST\n{path}/jobs`` route, which returns 202 immediately and is polled\nvia ``GET {path}/jobs/{job_id}``. On a 504 the workflow is\nCANCELLED (a sync caller can never collect the result); a retry\nstarts the work over as a fresh job.",
-        "operationId": "parse2_run_sync",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "description": "Input to ``Parse2OperationWorkflow`` (gateway) and ``Parse2DocumentWorkflow``\n(work). The document rides as ``document_ref`` (the gateway's multipart adapter\nstages the upload / fetches ``document_url`` → data store, runs the pdf_pages\npre-flight, then starts the operation).",
-                "properties": {
-                  "content_type": {
-                    "title": "Content Type",
+                    "description": "The split model version to use. Accepts a dated snapshot (`split-20251105`), `split-latest`, or `split` (both aliases resolve to the latest snapshot). Defaults to the latest snapshot. The resolved version is echoed back as `metadata.version`.",
                     "type": "string"
                   },
-                  "custom_prompts": {
-                    "anyOf": [
-                      {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Custom Prompts"
-                  },
-                  "document_ref": {
-                    "title": "Document Ref",
+                  "split_class": {
+                    "description": "The split classification entries, as a JSON-encoded array of objects with `name` (required), `description`, and `identifier` keys. At most 19 entries. Sent as a JSON-serialized string in form data.",
                     "type": "string"
-                  },
-                  "filename": {
-                    "title": "Filename",
-                    "type": "string"
-                  },
-                  "job_id": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Job Id"
-                  },
-                  "model_versions": {
-                    "anyOf": [
-                      {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Model Versions"
-                  },
-                  "password": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Password"
-                  },
-                  "pricing_multiplier": {
-                    "default": 1.0,
-                    "title": "Pricing Multiplier",
-                    "type": "number"
-                  },
-                  "processing_mode": {
-                    "default": "sync",
-                    "title": "Processing Mode",
-                    "type": "string"
-                  },
-                  "split": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Split"
-                  },
-                  "version": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Version"
-                  },
-                  "x_request_id": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "X Request Id"
                   }
                 },
                 "required": [
-                  "document_ref",
-                  "filename",
-                  "content_type"
-                ],
-                "title": "Parse2Request",
-                "type": "object"
-              }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "properties": {
-                  "content_type": {
-                    "title": "Content Type",
-                    "type": "string"
-                  },
-                  "custom_prompts": {
-                    "anyOf": [
-                      {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Custom Prompts"
-                  },
-                  "document_ref": {
-                    "description": "File upload.",
-                    "format": "binary",
-                    "type": "string"
-                  },
-                  "filename": {
-                    "title": "Filename",
-                    "type": "string"
-                  },
-                  "job_id": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Job Id"
-                  },
-                  "model_versions": {
-                    "anyOf": [
-                      {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Model Versions"
-                  },
-                  "password": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Password"
-                  },
-                  "pricing_multiplier": {
-                    "default": 1.0,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Pricing Multiplier",
-                    "type": "number"
-                  },
-                  "processing_mode": {
-                    "default": "sync",
-                    "title": "Processing Mode",
-                    "type": "string"
-                  },
-                  "split": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Split"
-                  },
-                  "version": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Version"
-                  },
-                  "x_request_id": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "X Request Id"
-                  }
-                },
-                "required": [
-                  "document_ref",
-                  "filename",
-                  "content_type"
+                  "split_class"
                 ],
                 "type": "object"
               }
@@ -4030,126 +5378,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "description": "Output of ``Parse2DocumentWorkflow``. Carries the customer response plus the\nbilling inputs hoisted to the top level so the gateway operation reads them\nwithout re-parsing the nested tree.\n\nBilling is worker-owned (parse-api parity): the worker finalizes the price and\nreports it on the standard ``credit_usage: CreditUsage`` shape (``credits`` =\nFINAL billed value, ``charge_unit`` = billable pages, ``breakdown`` = itemized),\nplus the record-inference enrichment (``usage`` + ``model_family``). The\ngateway's default biller reads ``credit_usage`` verbatim (a ``JobContract.billed()``\nop — no gateway recomputation).",
-                  "properties": {
-                    "base_credit": {
-                      "default": 0.0,
-                      "title": "Base Credit",
-                      "type": "number"
-                    },
-                    "billable_pages": {
-                      "default": 0,
-                      "title": "Billable Pages",
-                      "type": "integer"
-                    },
-                    "completion_tokens": {
-                      "default": 0,
-                      "title": "Completion Tokens",
-                      "type": "integer"
-                    },
-                    "credit_usage": {
-                      "$ref": "#/components/schemas/CreditUsage"
-                    },
-                    "duration_ms": {
-                      "default": 0,
-                      "title": "Duration Ms",
-                      "type": "integer"
-                    },
-                    "failed_pages": {
-                      "items": {
-                        "type": "integer"
-                      },
-                      "title": "Failed Pages",
-                      "type": "array"
-                    },
-                    "model_family": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Model Family"
-                    },
-                    "output_ref": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Output Ref"
-                    },
-                    "page_count": {
-                      "default": 0,
-                      "title": "Page Count",
-                      "type": "integer"
-                    },
-                    "prompt_tokens": {
-                      "default": 0,
-                      "title": "Prompt Tokens",
-                      "type": "integer"
-                    },
-                    "response": {
-                      "additionalProperties": true,
-                      "title": "Response",
-                      "type": "object"
-                    },
-                    "status_code": {
-                      "default": 200,
-                      "title": "Status Code",
-                      "type": "integer"
-                    },
-                    "token_steps": {
-                      "anyOf": [
-                        {
-                          "items": {
-                            "additionalProperties": true,
-                            "type": "object"
-                          },
-                          "type": "array"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Token Steps"
-                    },
-                    "total_tokens": {
-                      "default": 0,
-                      "title": "Total Tokens",
-                      "type": "integer"
-                    },
-                    "usage": {
-                      "anyOf": [
-                        {
-                          "additionalProperties": true,
-                          "type": "object"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Usage"
-                    }
-                  },
-                  "required": [
-                    "response"
-                  ],
-                  "title": "Parse2Result",
-                  "type": "object"
+                  "$ref": "#/components/schemas/SplitResponse"
                 }
               }
             },
-            "description": "parse2 result"
+            "description": "The split response"
           },
           "422": {
             "content": {
@@ -4162,751 +5395,9 @@
             "description": "Request validation failed."
           }
         },
-        "summary": "ADE Parse v1",
+        "summary": "ADE Split",
         "tags": [
-          "Parse v1"
-        ]
-      }
-    },
-    "/v1/parse/jobs": {
-      "get": {
-        "operationId": "parse2_list_jobs",
-        "parameters": [
-          {
-            "description": "Page number (0-indexed).",
-            "in": "query",
-            "name": "page",
-            "required": false,
-            "schema": {
-              "default": 0,
-              "description": "Page number (0-indexed).",
-              "minimum": 0,
-              "title": "Page",
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Number of items per page.",
-            "in": "query",
-            "name": "page_size",
-            "required": false,
-            "schema": {
-              "default": 10,
-              "description": "Number of items per page.",
-              "maximum": 100,
-              "minimum": 1,
-              "title": "Page Size",
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Filter by job status.",
-            "in": "query",
-            "name": "status",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Filter by job status.",
-              "title": "Status"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "has_more": {
-                      "type": "boolean"
-                    },
-                    "jobs": {
-                      "items": {
-                        "properties": {
-                          "completed_at": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "created_at": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "failure_reason": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "job_id": {
-                            "description": "The unique identifier for this parse2 job. Format: ``parse2-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
-                            "type": "string"
-                          },
-                          "model_version": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "status": {
-                            "enum": [
-                              "pending",
-                              "processing",
-                              "completed",
-                              "failed"
-                            ],
-                            "type": "string"
-                          }
-                        },
-                        "type": "object"
-                      },
-                      "type": "array"
-                    },
-                    "page": {
-                      "type": "integer"
-                    },
-                    "page_size": {
-                      "type": "integer"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "The caller's jobs, newest first"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Request validation failed."
-          }
-        },
-        "summary": "ADE List Parse v1 Jobs",
-        "tags": [
-          "Parse v1"
-        ]
-      },
-      "post": {
-        "operationId": "parse2_create_job",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "description": "Input to ``Parse2OperationWorkflow`` (gateway) and ``Parse2DocumentWorkflow``\n(work). The document rides as ``document_ref`` (the gateway's multipart adapter\nstages the upload / fetches ``document_url`` → data store, runs the pdf_pages\npre-flight, then starts the operation).",
-                "properties": {
-                  "content_type": {
-                    "title": "Content Type",
-                    "type": "string"
-                  },
-                  "custom_prompts": {
-                    "anyOf": [
-                      {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Custom Prompts"
-                  },
-                  "document_ref": {
-                    "title": "Document Ref",
-                    "type": "string"
-                  },
-                  "filename": {
-                    "title": "Filename",
-                    "type": "string"
-                  },
-                  "job_id": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Job Id"
-                  },
-                  "model_versions": {
-                    "anyOf": [
-                      {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Model Versions"
-                  },
-                  "output_save_url": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Output Save Url"
-                  },
-                  "password": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Password"
-                  },
-                  "pricing_multiplier": {
-                    "default": 1.0,
-                    "title": "Pricing Multiplier",
-                    "type": "number"
-                  },
-                  "processing_mode": {
-                    "default": "sync",
-                    "title": "Processing Mode",
-                    "type": "string"
-                  },
-                  "service_tier": {
-                    "anyOf": [
-                      {
-                        "enum": [
-                          "standard",
-                          "priority"
-                        ],
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
-                  },
-                  "split": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Split"
-                  },
-                  "version": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Version"
-                  },
-                  "x_request_id": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "X Request Id"
-                  }
-                },
-                "required": [
-                  "document_ref",
-                  "filename",
-                  "content_type"
-                ],
-                "title": "Parse2Request",
-                "type": "object"
-              }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "properties": {
-                  "content_type": {
-                    "title": "Content Type",
-                    "type": "string"
-                  },
-                  "custom_prompts": {
-                    "anyOf": [
-                      {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Custom Prompts"
-                  },
-                  "document_ref": {
-                    "description": "File upload.",
-                    "format": "binary",
-                    "type": "string"
-                  },
-                  "filename": {
-                    "title": "Filename",
-                    "type": "string"
-                  },
-                  "job_id": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Job Id"
-                  },
-                  "model_versions": {
-                    "anyOf": [
-                      {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Model Versions"
-                  },
-                  "output_save_url": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Output Save Url"
-                  },
-                  "password": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Password"
-                  },
-                  "pricing_multiplier": {
-                    "default": 1.0,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Pricing Multiplier",
-                    "type": "number"
-                  },
-                  "processing_mode": {
-                    "default": "sync",
-                    "title": "Processing Mode",
-                    "type": "string"
-                  },
-                  "service_tier": {
-                    "anyOf": [
-                      {
-                        "enum": [
-                          "standard",
-                          "priority"
-                        ],
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
-                  },
-                  "split": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Split"
-                  },
-                  "version": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Version"
-                  },
-                  "x_request_id": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "X Request Id"
-                  }
-                },
-                "required": [
-                  "document_ref",
-                  "filename",
-                  "content_type"
-                ],
-                "type": "object"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "202": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "created_at": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "job_id": {
-                      "description": "The unique identifier for this parse2 job. Format: ``parse2-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
-                      "type": "string"
-                    },
-                    "status": {
-                      "enum": [
-                        "pending",
-                        "processing",
-                        "completed",
-                        "failed"
-                      ],
-                      "type": "string"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Job created"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Request validation failed."
-          }
-        },
-        "summary": "ADE Parse v1 Jobs",
-        "tags": [
-          "Parse v1"
-        ]
-      }
-    },
-    "/v1/parse/jobs/{job_id}": {
-      "get": {
-        "description": "Poll a job.\n\nReturns ``{job_id, status, created_at}`` plus ``completed_at`` and\n``result`` (on ``completed``) or ``error: {code, message}`` (on\n``failed``). Statuses: ``pending`` → ``processing`` →\n``completed`` | ``failed``.",
-        "operationId": "parse2_get_job",
-        "parameters": [
-          {
-            "description": "The identifier of the job to retrieve, as returned by the create-job request.",
-            "in": "path",
-            "name": "job_id",
-            "required": true,
-            "schema": {
-              "description": "The identifier of the job to retrieve, as returned by the create-job request.",
-              "title": "Job Id",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "completed_at": {
-                      "description": "Present once the job is terminal.",
-                      "type": "string"
-                    },
-                    "created_at": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "error": {
-                      "description": "Present once status is ``failed``.",
-                      "properties": {
-                        "code": {
-                          "description": "Stable error code (``internal_error`` when unmapped).",
-                          "type": "string"
-                        },
-                        "message": {
-                          "type": "string"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    "job_id": {
-                      "description": "The unique identifier for this parse2 job. Format: ``parse2-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
-                      "type": "string"
-                    },
-                    "metadata": {
-                      "description": "The result's metadata block (billing included), present alongside ``output_url`` once a job with ``output_save_url`` has ``completed`` — the delivery moves the content, not the receipt. Same shape as the inline ``result``'s ``metadata``; inline jobs carry it there instead.",
-                      "type": [
-                        "object",
-                        "null"
-                      ]
-                    },
-                    "output_url": {
-                      "description": "The URL the result was delivered to. Present once the job has ``completed`` and ``output_save_url`` was set, instead of inline ``result``.",
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "progress": {
-                      "description": "Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.",
-                      "maximum": 1,
-                      "minimum": 0,
-                      "type": "number"
-                    },
-                    "result": {
-                      "anyOf": [
-                        {
-                          "description": "Output of ``Parse2DocumentWorkflow``. Carries the customer response plus the\nbilling inputs hoisted to the top level so the gateway operation reads them\nwithout re-parsing the nested tree.\n\nBilling is worker-owned (parse-api parity): the worker finalizes the price and\nreports it on the standard ``credit_usage: CreditUsage`` shape (``credits`` =\nFINAL billed value, ``charge_unit`` = billable pages, ``breakdown`` = itemized),\nplus the record-inference enrichment (``usage`` + ``model_family``). The\ngateway's default biller reads ``credit_usage`` verbatim (a ``JobContract.billed()``\nop — no gateway recomputation).",
-                          "properties": {
-                            "base_credit": {
-                              "default": 0.0,
-                              "title": "Base Credit",
-                              "type": "number"
-                            },
-                            "billable_pages": {
-                              "default": 0,
-                              "title": "Billable Pages",
-                              "type": "integer"
-                            },
-                            "completion_tokens": {
-                              "default": 0,
-                              "title": "Completion Tokens",
-                              "type": "integer"
-                            },
-                            "credit_usage": {
-                              "$ref": "#/components/schemas/CreditUsage"
-                            },
-                            "duration_ms": {
-                              "default": 0,
-                              "title": "Duration Ms",
-                              "type": "integer"
-                            },
-                            "failed_pages": {
-                              "items": {
-                                "type": "integer"
-                              },
-                              "title": "Failed Pages",
-                              "type": "array"
-                            },
-                            "model_family": {
-                              "anyOf": [
-                                {
-                                  "type": "string"
-                                },
-                                {
-                                  "type": "null"
-                                }
-                              ],
-                              "default": null,
-                              "title": "Model Family"
-                            },
-                            "output_ref": {
-                              "anyOf": [
-                                {
-                                  "type": "string"
-                                },
-                                {
-                                  "type": "null"
-                                }
-                              ],
-                              "default": null,
-                              "title": "Output Ref"
-                            },
-                            "page_count": {
-                              "default": 0,
-                              "title": "Page Count",
-                              "type": "integer"
-                            },
-                            "prompt_tokens": {
-                              "default": 0,
-                              "title": "Prompt Tokens",
-                              "type": "integer"
-                            },
-                            "response": {
-                              "additionalProperties": true,
-                              "title": "Response",
-                              "type": "object"
-                            },
-                            "status_code": {
-                              "default": 200,
-                              "title": "Status Code",
-                              "type": "integer"
-                            },
-                            "token_steps": {
-                              "anyOf": [
-                                {
-                                  "items": {
-                                    "additionalProperties": true,
-                                    "type": "object"
-                                  },
-                                  "type": "array"
-                                },
-                                {
-                                  "type": "null"
-                                }
-                              ],
-                              "default": null,
-                              "title": "Token Steps"
-                            },
-                            "total_tokens": {
-                              "default": 0,
-                              "title": "Total Tokens",
-                              "type": "integer"
-                            },
-                            "usage": {
-                              "anyOf": [
-                                {
-                                  "additionalProperties": true,
-                                  "type": "object"
-                                },
-                                {
-                                  "type": "null"
-                                }
-                              ],
-                              "default": null,
-                              "title": "Usage"
-                            }
-                          },
-                          "required": [
-                            "response"
-                          ],
-                          "title": "Parse2Result",
-                          "type": "object"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "description": "Present once status is ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead."
-                    },
-                    "status": {
-                      "enum": [
-                        "pending",
-                        "processing",
-                        "completed",
-                        "failed"
-                      ],
-                      "type": "string"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Job status / result"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Not found (e.g. no such job)."
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Request validation failed."
-          }
-        },
-        "summary": "ADE Get Parse v1 Jobs",
-        "tags": [
-          "Parse v1"
+          "Split"
         ]
       }
     },
@@ -5961,7 +6452,7 @@
                           }
                         ],
                         "default": null,
-                        "description": "Password for encrypted PDFs. Not currently supported — providing a value returns a 422 error; decrypt the file before uploading.",
+                        "description": "Password for an encrypted PDF. The document is decrypted once at the start of processing; the password is not retained with the result. PDFs only — supplying one for an image or Office document returns a 422 (`password_unsupported_content_type`). A wrong password returns a 422 (`encrypted_pdf_wrong_password`); omitting it for a locked PDF returns a 422 (`encrypted_pdf_password_required`).",
                         "title": "Password"
                       }
                     },
@@ -6220,7 +6711,7 @@
                           }
                         ],
                         "default": null,
-                        "description": "Password for encrypted PDFs. Not currently supported — providing a value returns a 422 error; decrypt the file before uploading.",
+                        "description": "Password for an encrypted PDF. The document is decrypted once at the start of processing; the password is not retained with the result. PDFs only — supplying one for an image or Office document returns a 422 (`password_unsupported_content_type`). A wrong password returns a 422 (`encrypted_pdf_wrong_password`); omitting it for a locked PDF returns a 422 (`encrypted_pdf_password_required`).",
                         "title": "Password"
                       }
                     },

--- a/src/landingai_ade/resources/v2/_normalize.py
+++ b/src/landingai_ade/resources/v2/_normalize.py
@@ -12,12 +12,14 @@ from ...types.v2 import (
     JobStatus,
     V2ExtractResult,
     V2ParseResponse,
+    V2ClassifyResponse,
     V2BuildSchemaResponse,
 )
 
 __all__ = [
     "normalize_parse_job",
     "normalize_extract_job",
+    "normalize_classify_job",
     "normalize_build_schema_job",
 ]
 
@@ -117,6 +119,33 @@ def normalize_extract_job(raw: Mapping[str, Any]) -> Job:
         result=result,
         error=error,
         metadata=_metadata(raw.get("metadata")),
+        raw=dict(raw),
+    )
+
+
+def normalize_classify_job(raw: Mapping[str, Any]) -> Job:
+    status = _status(raw)
+    payload = raw.get("result")
+    # Build leniently (like the sync-response path) so unexpected upstream drift
+    # doesn't fail construction.
+    result = V2ClassifyResponse.construct(**cast(Dict[str, Any], payload)) if isinstance(payload, Mapping) else None
+
+    error = None
+    err = raw.get("error")
+    if isinstance(err, Mapping):
+        err = cast(Dict[str, Any], err)
+        error = JobError(code=err.get("code"), message=err.get("message"))
+    elif raw.get("failure_reason"):  # classify *list* uses failure_reason
+        error = JobError(message=str(raw["failure_reason"]))
+
+    return Job(
+        job_id=str(raw["job_id"]),
+        status=status,
+        created_at=_ts(raw.get("created_at")),
+        completed_at=_ts(raw.get("completed_at")),
+        progress=_progress(raw.get("progress")),
+        result=result,
+        error=error,
         raw=dict(raw),
     )
 

--- a/src/landingai_ade/resources/v2/classify.py
+++ b/src/landingai_ade/resources/v2/classify.py
@@ -1,0 +1,402 @@
+# src/landingai_ade/resources/v2/classify.py
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, Mapping, Callable, Iterable, Optional, cast
+from typing_extensions import Literal
+
+import httpx
+
+from ._base import DEFAULT_WAIT_TIMEOUT, JobList, V2ResourceMixin, poll_until_terminal, apoll_until_terminal
+from ..._files import deepcopy_with_paths
+from ..._types import Body, Omit, Query, Headers, NotGiven, FileTypes, omit, not_given
+from ..._utils import is_given, extract_files
+from ...types.v2 import Job, V2ClassifyResponse
+from ._normalize import normalize_classify_job
+from ..._resource import SyncAPIResource, AsyncAPIResource
+from ..._exceptions import APIStatusError
+from ..._base_client import make_request_options
+from ...lib.v2_errors import raise_if_sync_timeout
+
+__all__ = ["ClassifyResource", "AsyncClassifyResource", "ClassifyJobsResource", "AsyncClassifyJobsResource"]
+
+
+def _encode_classes(classes: Iterable[Mapping[str, object]]) -> str:
+    # On a multipart request `classes` rides as a JSON-encoded string form field
+    # (each entry an object with a `class` name and an optional `description`).
+    return json.dumps([dict(entry) for entry in classes])
+
+
+def _build_classify_body(
+    classes: Iterable[Mapping[str, object]],
+    document: object,
+    document_url: object,
+    model: object,
+) -> dict[str, Any]:
+    raw_body: dict[str, Any] = {
+        "classes": _encode_classes(classes),
+        "document": document,
+        "document_url": document_url,
+        "model": model,
+    }
+    # Multipart requests aren't run through `maybe_transform`, which is what
+    # normally strips `omit`/`not_given` sentinels from a params TypedDict --
+    # drop them here so unset fields aren't serialized as form fields. An
+    # explicit `None` is likewise treated as "unset" for these optional wire
+    # fields, since `is_given` only filters the `omit`/`not_given` sentinels
+    # and otherwise returns True for `None`.
+    return {key: value for key, value in raw_body.items() if is_given(value) and value is not None}
+
+
+class ClassifyResource(V2ResourceMixin, SyncAPIResource):
+    def run(
+        self,
+        *,
+        classes: Iterable[Mapping[str, object]],
+        document: Optional[FileTypes] | Omit = omit,
+        document_url: Optional[str] | Omit = omit,
+        model: Optional[str] | Omit = omit,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> V2ClassifyResponse:
+        """Classify each page of a document synchronously against the V2 (ADE)
+        `/v2/classify` endpoint.
+
+        Returns one predicted class per page. Raises `V2SyncTimeoutError` when the
+        server times out the synchronous request (HTTP 504); use the async jobs
+        route (`classify_jobs`) for long-running documents in that case.
+
+        Args:
+          classes: The possible classes that can be assigned to pages in the document. Each
+              entry is a mapping with a `class` name and an optional `description`. Only one
+              class is assigned per page; unclassifiable pages receive 'unknown'.
+
+          document: A file to be classified. Either this parameter or `document_url` must be
+              provided.
+
+          document_url: A publicly accessible URL to the file to be classified. Either this
+              parameter or `document` must be provided.
+
+          model: Classify pipeline version. Defaults to the latest version.
+
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        body = deepcopy_with_paths(
+            _build_classify_body(classes, document, document_url, model),
+            [["document"]],
+        )
+        files = extract_files(cast(Mapping[str, object], body), paths=[["document"]])
+        # It should be noted that the actual Content-Type header that will be
+        # sent to the server will contain a `boundary` parameter, e.g.
+        # multipart/form-data; boundary=---abc--
+        extra_headers = {"Content-Type": "multipart/form-data", **(extra_headers or {})}
+        try:
+            return self._post(
+                self._v2_url("/v2/classify"),
+                body=body,
+                files=files,
+                options=make_request_options(
+                    extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+                ),
+                cast_to=V2ClassifyResponse,
+            )
+        except APIStatusError as exc:
+            raise_if_sync_timeout(exc, jobs_resource="classify_jobs")
+            raise
+
+
+class AsyncClassifyResource(V2ResourceMixin, AsyncAPIResource):
+    async def run(
+        self,
+        *,
+        classes: Iterable[Mapping[str, object]],
+        document: Optional[FileTypes] | Omit = omit,
+        document_url: Optional[str] | Omit = omit,
+        model: Optional[str] | Omit = omit,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> V2ClassifyResponse:
+        """Async mirror of `ClassifyResource.run`. See there for full documentation."""
+        body = deepcopy_with_paths(
+            _build_classify_body(classes, document, document_url, model),
+            [["document"]],
+        )
+        files = extract_files(cast(Mapping[str, object], body), paths=[["document"]])
+        extra_headers = {"Content-Type": "multipart/form-data", **(extra_headers or {})}
+        try:
+            return await self._post(
+                self._v2_url("/v2/classify"),
+                body=body,
+                files=files,
+                options=make_request_options(
+                    extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+                ),
+                cast_to=V2ClassifyResponse,
+            )
+        except APIStatusError as exc:
+            raise_if_sync_timeout(exc, jobs_resource="classify_jobs")
+            raise
+
+
+class ClassifyJobsResource(V2ResourceMixin, SyncAPIResource):
+    def create(
+        self,
+        *,
+        classes: Iterable[Mapping[str, object]],
+        document: Optional[FileTypes] | Omit = omit,
+        document_url: Optional[str] | Omit = omit,
+        model: Optional[str] | Omit = omit,
+        service_tier: Optional[Literal["standard", "priority"]] | Omit = omit,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> Job:
+        """Create an asynchronous classify job against `/v2/classify/jobs`.
+
+        Returns a normalized `Job` immediately (typically `pending`). Poll for
+        completion via `.get(job_id)`, or block until the job is terminal with
+        `.wait(job_id)`.
+
+        Args:
+          classes: The possible classes that can be assigned to pages in the document. Each
+              entry is a mapping with a `class` name and an optional `description`.
+
+          document: A file to be classified. Either this parameter or `document_url` must be
+              provided.
+
+          document_url: A publicly accessible URL to the file to be classified. Either this
+              parameter or `document` must be provided.
+
+          model: Classify pipeline version. Defaults to the latest version.
+
+          service_tier: Service tier for the job: ``standard`` or ``priority``.
+
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        body = _build_classify_body(classes, document, document_url, model)
+        if is_given(service_tier) and service_tier is not None:
+            body["service_tier"] = service_tier
+        body = deepcopy_with_paths(body, [["document"]])
+        files = extract_files(cast(Mapping[str, object], body), paths=[["document"]])
+        extra_headers = {"Content-Type": "multipart/form-data", **(extra_headers or {})}
+        raw = self._post(
+            self._v2_url("/v2/classify/jobs"),
+            body=body,
+            files=files,
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=cast("type[Any]", object),
+        )
+        return normalize_classify_job(cast(Mapping[str, Any], raw))
+
+    def get(
+        self,
+        job_id: str,
+        *,
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> Job:
+        """Get the current status of an async classify job by `job_id`."""
+        if not job_id:
+            raise ValueError(f"Expected a non-empty value for `job_id` but received {job_id!r}")
+        raw = self._get(
+            self._v2_url(f"/v2/classify/jobs/{job_id}"),
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=cast("type[Any]", object),
+        )
+        return normalize_classify_job(cast(Mapping[str, Any], raw))
+
+    def list(
+        self,
+        *,
+        page: int | Omit = omit,
+        page_size: int | Omit = omit,
+        status: Optional[str] | Omit = omit,
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> JobList:
+        """List async classify jobs associated with your API key, newest first."""
+        query = {
+            key: value
+            for key, value in {"page": page, "page_size": page_size, "status": status}.items()
+            if is_given(value) and value is not None
+        }
+        raw = self._get(
+            self._v2_url("/v2/classify/jobs"),
+            options=make_request_options(
+                extra_headers=extra_headers,
+                extra_query=extra_query,
+                extra_body=extra_body,
+                timeout=timeout,
+                query=query,
+            ),
+            cast_to=cast("type[Any]", object),
+        )
+        env = cast(Mapping[str, Any], raw)
+        jobs = [normalize_classify_job(cast(Mapping[str, Any], item)) for item in env.get("jobs", [])]
+        return JobList.build(jobs, has_more=env.get("has_more"), page=env.get("page"), page_size=env.get("page_size"))
+
+    def wait(
+        self,
+        job_id: str,
+        *,
+        timeout: float = DEFAULT_WAIT_TIMEOUT,
+        poll_interval: Optional[float] = None,
+        raise_on_failure: bool = False,
+        _monotonic: Optional[Callable[[], float]] = None,
+    ) -> Job:
+        """Block, polling `.get(job_id)` with backoff, until the job is terminal.
+
+        Raises `JobWaitTimeoutError` if `timeout` seconds elapse before the job
+        reaches a terminal state, and `JobFailedError` if `raise_on_failure` is
+        set and the job ends failed with an error attached. Classify jobs have no
+        `cancelled` status.
+
+        `_monotonic` is a test seam for injecting a fake clock; production
+        callers should leave it unset (defaults to `time.monotonic`).
+        """
+        return poll_until_terminal(
+            lambda: self.get(job_id),
+            monotonic=_monotonic or time.monotonic,
+            sleep=self._sleep,
+            timeout=timeout,
+            poll_interval=poll_interval,
+            raise_on_failure=raise_on_failure,
+        )
+
+
+class AsyncClassifyJobsResource(V2ResourceMixin, AsyncAPIResource):
+    async def create(
+        self,
+        *,
+        classes: Iterable[Mapping[str, object]],
+        document: Optional[FileTypes] | Omit = omit,
+        document_url: Optional[str] | Omit = omit,
+        model: Optional[str] | Omit = omit,
+        service_tier: Optional[Literal["standard", "priority"]] | Omit = omit,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> Job:
+        """Async mirror of `ClassifyJobsResource.create`. See there for full documentation."""
+        body = _build_classify_body(classes, document, document_url, model)
+        if is_given(service_tier) and service_tier is not None:
+            body["service_tier"] = service_tier
+        body = deepcopy_with_paths(body, [["document"]])
+        files = extract_files(cast(Mapping[str, object], body), paths=[["document"]])
+        extra_headers = {"Content-Type": "multipart/form-data", **(extra_headers or {})}
+        raw = await self._post(
+            self._v2_url("/v2/classify/jobs"),
+            body=body,
+            files=files,
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=cast("type[Any]", object),
+        )
+        return normalize_classify_job(cast(Mapping[str, Any], raw))
+
+    async def get(
+        self,
+        job_id: str,
+        *,
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> Job:
+        """Async mirror of `ClassifyJobsResource.get`. See there for full documentation."""
+        if not job_id:
+            raise ValueError(f"Expected a non-empty value for `job_id` but received {job_id!r}")
+        raw = await self._get(
+            self._v2_url(f"/v2/classify/jobs/{job_id}"),
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=cast("type[Any]", object),
+        )
+        return normalize_classify_job(cast(Mapping[str, Any], raw))
+
+    async def list(
+        self,
+        *,
+        page: int | Omit = omit,
+        page_size: int | Omit = omit,
+        status: Optional[str] | Omit = omit,
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> JobList:
+        """Async mirror of `ClassifyJobsResource.list`. See there for full documentation."""
+        query = {
+            key: value
+            for key, value in {"page": page, "page_size": page_size, "status": status}.items()
+            if is_given(value) and value is not None
+        }
+        raw = await self._get(
+            self._v2_url("/v2/classify/jobs"),
+            options=make_request_options(
+                extra_headers=extra_headers,
+                extra_query=extra_query,
+                extra_body=extra_body,
+                timeout=timeout,
+                query=query,
+            ),
+            cast_to=cast("type[Any]", object),
+        )
+        env = cast(Mapping[str, Any], raw)
+        jobs = [normalize_classify_job(cast(Mapping[str, Any], item)) for item in env.get("jobs", [])]
+        return JobList.build(jobs, has_more=env.get("has_more"), page=env.get("page"), page_size=env.get("page_size"))
+
+    async def wait(
+        self,
+        job_id: str,
+        *,
+        timeout: float = DEFAULT_WAIT_TIMEOUT,
+        poll_interval: Optional[float] = None,
+        raise_on_failure: bool = False,
+        _monotonic: Optional[Callable[[], float]] = None,
+    ) -> Job:
+        """Async mirror of `ClassifyJobsResource.wait`; sleeps via `anyio.sleep` instead of blocking."""
+        return await apoll_until_terminal(
+            lambda: self.get(job_id),
+            monotonic=_monotonic or time.monotonic,
+            timeout=timeout,
+            poll_interval=poll_interval,
+            raise_on_failure=raise_on_failure,
+        )

--- a/src/landingai_ade/resources/v2/split.py
+++ b/src/landingai_ade/resources/v2/split.py
@@ -1,0 +1,159 @@
+# src/landingai_ade/resources/v2/split.py
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping, Iterable, Optional, cast
+from pathlib import Path
+
+import httpx
+
+from ._base import V2ResourceMixin
+from ..._files import deepcopy_with_paths
+from ..._types import Body, Omit, Query, Headers, NotGiven, FileTypes, omit, not_given
+from ..._utils import is_given, extract_files
+from ...types.v2 import V2SplitResponse
+from ..._resource import SyncAPIResource, AsyncAPIResource
+from ..._base_client import make_request_options
+
+__all__ = ["SplitResource", "AsyncSplitResource"]
+
+
+def _encode_split_class(split_class: Iterable[Mapping[str, object]]) -> str:
+    # `split_class` rides as a JSON-encoded string form field: an array of objects
+    # with `name` (required), `description`, and `identifier` keys.
+    return json.dumps([dict(entry) for entry in split_class])
+
+
+def _build_split_body(
+    split_class: Iterable[Mapping[str, object]],
+    markdown: object,
+    markdown_url: object,
+    model: object,
+) -> dict[str, Any]:
+    raw_body: dict[str, Any] = {
+        "split_class": _encode_split_class(split_class),
+        "markdown": markdown,
+        "markdown_url": markdown_url,
+        "model": model,
+    }
+    # Multipart requests aren't run through `maybe_transform`; drop the
+    # `omit`/`not_given` sentinels (and explicit `None`) so unset fields aren't
+    # serialized as form fields.
+    return {key: value for key, value in raw_body.items() if is_given(value) and value is not None}
+
+
+class SplitResource(V2ResourceMixin, SyncAPIResource):
+    def run(
+        self,
+        *,
+        split_class: Iterable[Mapping[str, object]],
+        markdown: Optional[FileTypes] | Omit = omit,
+        markdown_url: Optional[str] | Omit = omit,
+        model: Optional[str] | Omit = omit,
+        save_to: str | Path | None = None,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> V2SplitResponse:
+        """Split a Markdown document into segments synchronously against the V2 (ADE)
+        `/v2/split` endpoint.
+
+        Consecutive pages with the same classification merge into one segment; an
+        identifier change starts a new segment. `/v2/split` is synchronous-only
+        (no async jobs route).
+
+        Args:
+          split_class: The split classification entries. Each entry is a mapping with a `name`
+              (required), and optional `description` and `identifier` keys. At most 19
+              entries.
+
+          markdown: The Markdown content to split, as an inline string or a file upload. Either
+              this parameter or `markdown_url` must be provided.
+
+          markdown_url: A publicly accessible URL to the Markdown file to split. Either this
+              parameter or `markdown` must be provided.
+
+          model: The split model version to use. Defaults to the latest snapshot.
+
+          save_to: Optional output path. If a directory, auto-generates the filename
+              (e.g. {input_file}_split_output.json, or split_output.json when no
+              input filename is available). If a full path ending in .json, saves there
+              directly. Parent directories are created automatically.
+
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        original_markdown, original_markdown_url = markdown, markdown_url
+        body = deepcopy_with_paths(
+            _build_split_body(split_class, markdown, markdown_url, model),
+            [["markdown"]],
+        )
+        files = extract_files(cast(Mapping[str, object], body), paths=[["markdown"]])
+        # It should be noted that the actual Content-Type header that will be
+        # sent to the server will contain a `boundary` parameter, e.g.
+        # multipart/form-data; boundary=---abc--
+        extra_headers = {"Content-Type": "multipart/form-data", **(extra_headers or {})}
+        result = self._post(
+            self._v2_url("/v2/split"),
+            body=body,
+            files=files,
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=V2SplitResponse,
+        )
+        if save_to:
+            from ..._client import _save_response, _get_input_filename
+
+            filename = _get_input_filename(original_markdown, original_markdown_url)
+            _save_response(save_to, filename, "split", result)
+        return result
+
+
+class AsyncSplitResource(V2ResourceMixin, AsyncAPIResource):
+    async def run(
+        self,
+        *,
+        split_class: Iterable[Mapping[str, object]],
+        markdown: Optional[FileTypes] | Omit = omit,
+        markdown_url: Optional[str] | Omit = omit,
+        model: Optional[str] | Omit = omit,
+        save_to: str | Path | None = None,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> V2SplitResponse:
+        """Async mirror of `SplitResource.run`. See there for full documentation."""
+        original_markdown, original_markdown_url = markdown, markdown_url
+        body = deepcopy_with_paths(
+            _build_split_body(split_class, markdown, markdown_url, model),
+            [["markdown"]],
+        )
+        files = extract_files(cast(Mapping[str, object], body), paths=[["markdown"]])
+        extra_headers = {"Content-Type": "multipart/form-data", **(extra_headers or {})}
+        result = await self._post(
+            self._v2_url("/v2/split"),
+            body=body,
+            files=files,
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=V2SplitResponse,
+        )
+        if save_to:
+            from ..._client import _save_response, _get_input_filename
+
+            filename = _get_input_filename(original_markdown, original_markdown_url)
+            _save_response(save_to, filename, "split", result)
+        return result

--- a/src/landingai_ade/resources/v2/v2.py
+++ b/src/landingai_ade/resources/v2/v2.py
@@ -1,7 +1,7 @@
 # src/landingai_ade/resources/v2/v2.py
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Type, Union, Mapping, Optional
+from typing import TYPE_CHECKING, Type, Union, Mapping, Iterable, Optional
 from pathlib import Path
 
 import httpx
@@ -10,13 +10,20 @@ from pydantic import BaseModel
 from ._base import V2ResourceMixin
 from ..._types import Body, Omit, Query, Headers, NotGiven, FileTypes, omit, not_given
 from ..._compat import cached_property
-from ...types.v2 import V2GroundResult, V2ExtractResult, V2ParseResponse
+from ...types.v2 import V2GroundResult, V2ExtractResult, V2ParseResponse, V2SplitResponse, V2ClassifyResponse
 from ..._resource import SyncAPIResource, AsyncAPIResource
 
 if TYPE_CHECKING:
     from .parse import ParseResource, ParseJobsResource, AsyncParseResource, AsyncParseJobsResource
+    from .split import SplitResource, AsyncSplitResource
     from .ground import GroundResource, AsyncGroundResource
     from .extract import ExtractResource, ExtractJobsResource, AsyncExtractResource, AsyncExtractJobsResource
+    from .classify import (
+        ClassifyResource,
+        ClassifyJobsResource,
+        AsyncClassifyResource,
+        AsyncClassifyJobsResource,
+    )
 
 __all__ = ["V2Resource", "AsyncV2Resource"]
 
@@ -24,10 +31,10 @@ __all__ = ["V2Resource", "AsyncV2Resource"]
 class V2Resource(SyncAPIResource, V2ResourceMixin):
     """Container for the V2 (ADE) surface: ``client.v2.<resource>``.
 
-    ``parse``, ``extract``, and ``ground`` are wired up; each sub-resource
-    does its own lazy import inside its cached property body -- mirroring
-    ``LandingAIADE.parse_jobs`` -- so that this module keeps importing standalone
-    regardless of which sub-resources exist yet.
+    ``parse``, ``extract``, ``ground``, ``classify``, and ``split`` are wired up;
+    each sub-resource does its own lazy import inside its cached property body --
+    mirroring ``LandingAIADE.parse_jobs`` -- so that this module keeps importing
+    standalone regardless of which sub-resources exist yet.
     """
 
     @cached_property
@@ -136,6 +143,78 @@ class V2Resource(SyncAPIResource, V2ResourceMixin):
         return self._ground.run(
             extraction_metadata=extraction_metadata,
             structure=structure,
+            extra_headers=extra_headers,
+            extra_query=extra_query,
+            extra_body=extra_body,
+            timeout=timeout,
+        )
+
+    @cached_property
+    def _classify(self) -> ClassifyResource:
+        from .classify import ClassifyResource
+
+        return ClassifyResource(self._client)
+
+    @cached_property
+    def classify_jobs(self) -> ClassifyJobsResource:
+        from .classify import ClassifyJobsResource
+
+        return ClassifyJobsResource(self._client)
+
+    def classify(
+        self,
+        *,
+        classes: Iterable[Mapping[str, object]],
+        document: Optional[FileTypes] | Omit = omit,
+        document_url: Optional[str] | Omit = omit,
+        model: Optional[str] | Omit = omit,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> V2ClassifyResponse:
+        """Classify the pages of a document synchronously. See ``ClassifyResource.run`` for full documentation."""
+        return self._classify.run(
+            classes=classes,
+            document=document,
+            document_url=document_url,
+            model=model,
+            extra_headers=extra_headers,
+            extra_query=extra_query,
+            extra_body=extra_body,
+            timeout=timeout,
+        )
+
+    @cached_property
+    def _split(self) -> SplitResource:
+        from .split import SplitResource
+
+        return SplitResource(self._client)
+
+    def split(
+        self,
+        *,
+        split_class: Iterable[Mapping[str, object]],
+        markdown: Optional[FileTypes] | Omit = omit,
+        markdown_url: Optional[str] | Omit = omit,
+        model: Optional[str] | Omit = omit,
+        save_to: str | Path | None = None,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> V2SplitResponse:
+        """Split a Markdown document into segments synchronously. See ``SplitResource.run`` for full documentation."""
+        return self._split.run(
+            split_class=split_class,
+            markdown=markdown,
+            markdown_url=markdown_url,
+            model=model,
+            save_to=save_to,
             extra_headers=extra_headers,
             extra_query=extra_query,
             extra_body=extra_body,
@@ -252,6 +331,78 @@ class AsyncV2Resource(AsyncAPIResource, V2ResourceMixin):
         return await self._ground.run(
             extraction_metadata=extraction_metadata,
             structure=structure,
+            extra_headers=extra_headers,
+            extra_query=extra_query,
+            extra_body=extra_body,
+            timeout=timeout,
+        )
+
+    @cached_property
+    def _classify(self) -> AsyncClassifyResource:
+        from .classify import AsyncClassifyResource
+
+        return AsyncClassifyResource(self._client)
+
+    @cached_property
+    def classify_jobs(self) -> AsyncClassifyJobsResource:
+        from .classify import AsyncClassifyJobsResource
+
+        return AsyncClassifyJobsResource(self._client)
+
+    async def classify(
+        self,
+        *,
+        classes: Iterable[Mapping[str, object]],
+        document: Optional[FileTypes] | Omit = omit,
+        document_url: Optional[str] | Omit = omit,
+        model: Optional[str] | Omit = omit,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> V2ClassifyResponse:
+        """Async mirror of :meth:`V2Resource.classify`."""
+        return await self._classify.run(
+            classes=classes,
+            document=document,
+            document_url=document_url,
+            model=model,
+            extra_headers=extra_headers,
+            extra_query=extra_query,
+            extra_body=extra_body,
+            timeout=timeout,
+        )
+
+    @cached_property
+    def _split(self) -> AsyncSplitResource:
+        from .split import AsyncSplitResource
+
+        return AsyncSplitResource(self._client)
+
+    async def split(
+        self,
+        *,
+        split_class: Iterable[Mapping[str, object]],
+        markdown: Optional[FileTypes] | Omit = omit,
+        markdown_url: Optional[str] | Omit = omit,
+        model: Optional[str] | Omit = omit,
+        save_to: str | Path | None = None,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> V2SplitResponse:
+        """Async mirror of :meth:`V2Resource.split`."""
+        return await self._split.run(
+            split_class=split_class,
+            markdown=markdown,
+            markdown_url=markdown_url,
+            model=model,
+            save_to=save_to,
             extra_headers=extra_headers,
             extra_query=extra_query,
             extra_body=extra_body,

--- a/src/landingai_ade/types/v2/__init__.py
+++ b/src/landingai_ade/types/v2/__init__.py
@@ -16,6 +16,11 @@ from .parse_response import (
     V2ParseGroundingEntry as V2ParseGroundingEntry,
     V2ParseGroundingElement as V2ParseGroundingElement,
 )
+from .split_response import (
+    V2Split as V2Split,
+    V2SplitMetadata as V2SplitMetadata,
+    V2SplitResponse as V2SplitResponse,
+)
 from .ground_response import (
     V2GroundResult as V2GroundResult,
     V2GroundBilling as V2GroundBilling,
@@ -25,6 +30,11 @@ from .extract_response import (
     V2ExtractResult as V2ExtractResult,
     V2ExtractBilling as V2ExtractBilling,
     V2ExtractMetadata as V2ExtractMetadata,
+)
+from .classify_response import (
+    V2Classification as V2Classification,
+    V2ClassifyMetadata as V2ClassifyMetadata,
+    V2ClassifyResponse as V2ClassifyResponse,
 )
 from .build_schema_response import (
     V2BuildSchemaBilling as V2BuildSchemaBilling,

--- a/src/landingai_ade/types/v2/classify_response.py
+++ b/src/landingai_ade/types/v2/classify_response.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import Field as FieldInfo
+
+from ..._models import BaseModel
+
+__all__ = ["V2Classification", "V2ClassifyMetadata", "V2ClassifyResponse"]
+
+
+class V2Classification(BaseModel):
+    """A single page-level classification result."""
+
+    class_: str = FieldInfo(alias="class")
+    """Predicted class label, or 'unknown'."""
+
+    page: int
+    """Page number, zero-indexed (the first page is 0)."""
+
+    reason: str
+    """Why the page was classified this way."""
+
+    suggested_class: Optional[str] = None
+    """A class the model proposes when the prediction is 'unknown'."""
+
+
+class V2ClassifyMetadata(BaseModel):
+    """Response metadata for a V2 classify call."""
+
+    # Required and non-null per the spec.
+    page_count: int
+    duration_ms: int
+    # URL of the OpenAPI spec covering this API. Required and non-null per the spec.
+    openapi_spec: str
+    credit_usage: Optional[float] = None
+    filename: Optional[str] = None
+    # Gateway job id (workflow id). Matches the billing row id in vision-agent.
+    job_id: Optional[str] = None
+    org_id: Optional[str] = None
+    # Resolved classify pipeline version that produced this response.
+    version: Optional[str] = None
+
+
+class V2ClassifyResponse(BaseModel):
+    """Response model for the V2 classify endpoint."""
+
+    classification: List[V2Classification]
+    """One classification result per page, in page order."""
+
+    metadata: V2ClassifyMetadata

--- a/src/landingai_ade/types/v2/split_response.py
+++ b/src/landingai_ade/types/v2/split_response.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from ..._models import BaseModel
+
+__all__ = ["V2Split", "V2SplitMetadata", "V2SplitResponse"]
+
+
+class V2Split(BaseModel):
+    """One split segment: consecutive pages of one classification.
+
+    An identifier change starts a new segment. Every field is required per the
+    spec; `identifier` is required-but-nullable (null when the matching split
+    classification requested no identifier).
+    """
+
+    classification: str
+    """The split classification name this segment was assigned."""
+
+    identifier: Optional[str]
+    """The identifier value extracted for this segment, or null."""
+
+    markdowns: List[str]
+    """The Markdown content of each page in this segment, in order."""
+
+    pages: List[int]
+    """0-indexed page numbers belonging to this segment, in order."""
+
+
+class V2SplitMetadata(BaseModel):
+    """Information about a split request. Every field is required per the spec."""
+
+    filename: str
+    org_id: Optional[str]
+    page_count: int
+    duration_ms: int
+    credit_usage: float
+    # The split job identifier -- server-minted and unique per request.
+    job_id: str
+    # The exact split model snapshot that processed the document, e.g. `split-20251105`.
+    version: str
+
+
+class V2SplitResponse(BaseModel):
+    """Response model for the V2 split endpoint."""
+
+    splits: List[V2Split]
+    """The split segments, in page order."""
+
+    metadata: V2SplitMetadata

--- a/tests/api_resources/v2/test_classify.py
+++ b/tests/api_resources/v2/test_classify.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+import httpx
+import respx
+import pytest
+
+from landingai_ade import LandingAIADE
+from landingai_ade.types.v2 import Job, JobStatus, V2ClassifyResponse
+from landingai_ade.lib.v2_errors import V2SyncTimeoutError
+
+APIKEY = "My Apikey"
+
+CLASSES = [
+    {"class": "invoice", "description": "A billing document"},
+    {"class": "receipt"},
+]
+
+CLASSIFY_BODY: Dict[str, Any] = {
+    "classification": [
+        {"class": "invoice", "page": 0, "reason": "Has an invoice header.", "suggested_class": None},
+        {"class": "unknown", "page": 1, "reason": "No clear signal.", "suggested_class": "receipt"},
+    ],
+    "metadata": {
+        "page_count": 2,
+        "duration_ms": 42,
+        "openapi_spec": "https://api.ade.landing.ai/openapi.json",
+        "credit_usage": 0.2,
+        "filename": "doc.pdf",
+        "job_id": "classify-1",
+        "org_id": "o1",
+        "version": "classify-20260420",
+    },
+}
+
+
+@respx.mock
+def test_classify_sync_routes_to_v2_and_encodes_classes() -> None:
+    client = LandingAIADE(apikey=APIKEY, environment="production")
+    route = respx.post("https://api.ade.landing.ai/v2/classify").mock(
+        return_value=httpx.Response(200, json=CLASSIFY_BODY)
+    )
+    result = client.v2.classify(classes=CLASSES, document=b"pdf", model="classify-latest")
+    assert isinstance(result, V2ClassifyResponse)
+    # The reserved `class` wire key deserializes onto the aliased `class_` field.
+    assert result.classification[0].class_ == "invoice"
+    assert result.classification[0].page == 0
+    assert result.classification[1].suggested_class == "receipt"
+    assert result.metadata.page_count == 2 and result.metadata.openapi_spec
+    # `classes` rides as a JSON-encoded string form field on the multipart body.
+    sent = route.calls.last.request.content
+    assert b'"class": "invoice"' in sent
+    assert route.calls.last.request.headers["content-type"].startswith("multipart/form-data")
+
+
+@respx.mock
+def test_classify_sync_omits_unset_fields_from_multipart_body() -> None:
+    client = LandingAIADE(apikey=APIKEY)
+    route = respx.post("https://api.ade.landing.ai/v2/classify").mock(
+        return_value=httpx.Response(200, json=CLASSIFY_BODY)
+    )
+    client.v2.classify(classes=CLASSES, document=b"pdf", document_url=None, model=None)
+    sent = route.calls.last.request.content
+    assert b"Omit object" not in sent
+    assert b"NOT_GIVEN" not in sent
+    assert b"document_url" not in sent
+    assert b"model" not in sent
+
+
+@respx.mock
+def test_classify_sync_504_raises_v2_sync_timeout() -> None:
+    client = LandingAIADE(apikey=APIKEY, max_retries=0)
+    respx.post("https://api.ade.landing.ai/v2/classify").mock(return_value=httpx.Response(504, json={"detail": "x"}))
+    with pytest.raises(V2SyncTimeoutError):
+        client.v2.classify(classes=CLASSES, document=b"pdf")
+
+
+def test_classify_job_create_sends_service_tier(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = LandingAIADE(apikey=APIKEY)
+    captured: Dict[str, Any] = {}
+
+    def fake_post(path: str, *, cast_to: Any, body: Any = None, files: Any = None, options: Any = None) -> Any:  # noqa: ARG001
+        captured["body"] = body
+        return {"job_id": "c1", "status": "pending"}
+
+    monkeypatch.setattr(client.v2.classify_jobs, "_post", fake_post)
+    client.v2.classify_jobs.create(classes=CLASSES, document=b"x", service_tier="priority")
+    assert captured["body"]["service_tier"] == "priority"
+    # `classes` is JSON-encoded, not a raw list, on the wire.
+    assert isinstance(captured["body"]["classes"], str)
+    assert json.loads(captured["body"]["classes"])[0]["class"] == "invoice"
+
+
+@respx.mock
+def test_classify_job_create_normalizes_envelope() -> None:
+    client = LandingAIADE(apikey=APIKEY)
+    respx.post("https://api.ade.landing.ai/v2/classify/jobs").mock(
+        return_value=httpx.Response(202, json={"job_id": "c1", "status": "pending"})
+    )
+    job = client.v2.classify_jobs.create(classes=CLASSES, document=b"pdf")
+    assert isinstance(job, Job)
+    assert job.job_id == "c1" and job.status is JobStatus.PENDING
+
+
+@respx.mock
+def test_classify_job_get_completed_has_typed_result() -> None:
+    client = LandingAIADE(apikey=APIKEY)
+    respx.get("https://api.ade.landing.ai/v2/classify/jobs/c1").mock(
+        return_value=httpx.Response(
+            200,
+            json={"job_id": "c1", "status": "completed", "created_at": 1700000000, "result": CLASSIFY_BODY},
+        )
+    )
+    job = client.v2.classify_jobs.get("c1")
+    assert job.status is JobStatus.COMPLETED
+    assert isinstance(job.result, V2ClassifyResponse)
+    assert job.result.classification[0].class_ == "invoice"
+
+
+@respx.mock
+def test_classify_job_get_failed_has_error() -> None:
+    client = LandingAIADE(apikey=APIKEY)
+    respx.get("https://api.ade.landing.ai/v2/classify/jobs/c2").mock(
+        return_value=httpx.Response(
+            200,
+            json={"job_id": "c2", "status": "failed", "error": {"code": "bad_doc", "message": "boom"}},
+        )
+    )
+    failed = client.v2.classify_jobs.get("c2")
+    assert failed.status is JobStatus.FAILED
+    assert failed.error is not None and failed.error.code == "bad_doc"
+    assert failed.result is None
+
+
+@respx.mock
+def test_classify_job_list_carries_envelope() -> None:
+    client = LandingAIADE(apikey=APIKEY)
+    respx.get("https://api.ade.landing.ai/v2/classify/jobs").mock(
+        return_value=httpx.Response(
+            200,
+            json={"jobs": [{"job_id": "c1", "status": "completed"}], "page": 0, "page_size": 10, "has_more": False},
+        )
+    )
+    jobs = client.v2.classify_jobs.list()
+    assert len(jobs) == 1 and jobs[0].job_id == "c1"
+    assert jobs.page == 0 and jobs.page_size == 10 and jobs.has_more is False
+
+
+@respx.mock
+def test_classify_job_get_empty_job_id_raises() -> None:
+    client = LandingAIADE(apikey=APIKEY)
+    with pytest.raises(ValueError):
+        client.v2.classify_jobs.get("")
+
+
+@respx.mock
+def test_classify_job_wait_polls_until_completed() -> None:
+    client = LandingAIADE(apikey=APIKEY)
+    responses = [
+        httpx.Response(200, json={"job_id": "c1", "status": "processing", "progress": 0.5}),
+        httpx.Response(200, json={"job_id": "c1", "status": "completed", "result": CLASSIFY_BODY}),
+    ]
+    respx.get("https://api.ade.landing.ai/v2/classify/jobs/c1").mock(side_effect=responses)
+    ticks = iter([0.0, 0.0, 0.1, 0.2, 0.3])
+    job = client.v2.classify_jobs.wait("c1", timeout=30, poll_interval=0.01, _monotonic=lambda: next(ticks))
+    assert job.status is JobStatus.COMPLETED
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_async_classify_sync_ok() -> None:
+    from landingai_ade import AsyncLandingAIADE
+
+    client = AsyncLandingAIADE(apikey=APIKEY)
+    respx.post("https://api.ade.landing.ai/v2/classify").mock(return_value=httpx.Response(200, json=CLASSIFY_BODY))
+    result = await client.v2.classify(classes=CLASSES, document=b"pdf")
+    assert isinstance(result, V2ClassifyResponse)
+    assert result.classification[0].class_ == "invoice"

--- a/tests/api_resources/v2/test_split.py
+++ b/tests/api_resources/v2/test_split.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+from pathlib import Path
+
+import httpx
+import respx
+import pytest
+
+from landingai_ade import LandingAIADE
+from landingai_ade.types.v2 import V2SplitResponse
+
+APIKEY = "My Apikey"
+
+SPLIT_CLASS = [
+    {"name": "invoice", "description": "A billing document", "identifier": "invoice_number"},
+    {"name": "receipt"},
+]
+
+SPLIT_BODY: Dict[str, Any] = {
+    "splits": [
+        {
+            "classification": "invoice",
+            "identifier": "INV-042",
+            "markdowns": ["# Invoice", "## Line items"],
+            "pages": [0, 1],
+        },
+        {
+            "classification": "receipt",
+            "identifier": None,
+            "markdowns": ["# Receipt"],
+            "pages": [2],
+        },
+    ],
+    "metadata": {
+        "filename": "doc.md",
+        "org_id": None,
+        "page_count": 3,
+        "duration_ms": 11,
+        "credit_usage": 0.1,
+        "job_id": "split-1",
+        "version": "split-20251105",
+    },
+}
+
+
+@respx.mock
+def test_split_sync_routes_to_v2_and_encodes_split_class() -> None:
+    client = LandingAIADE(apikey=APIKEY, environment="production")
+    route = respx.post("https://api.ade.landing.ai/v2/split").mock(return_value=httpx.Response(200, json=SPLIT_BODY))
+    result = client.v2.split(split_class=SPLIT_CLASS, markdown="# Hello", model="split-latest")
+    assert isinstance(result, V2SplitResponse)
+    assert result.splits[0].classification == "invoice"
+    assert result.splits[0].identifier == "INV-042"
+    assert result.splits[0].pages == [0, 1]
+    # `identifier`/`org_id` are required-but-nullable; a null wire value survives.
+    assert result.splits[1].identifier is None
+    assert result.metadata.org_id is None
+    assert result.metadata.job_id == "split-1"
+    # `split_class` rides as a JSON-encoded string form field on the multipart body.
+    sent = route.calls.last.request.content
+    assert b'"name": "invoice"' in sent
+    assert route.calls.last.request.headers["content-type"].startswith("multipart/form-data")
+
+
+@respx.mock
+def test_split_sync_omits_unset_fields_from_multipart_body() -> None:
+    client = LandingAIADE(apikey=APIKEY)
+    route = respx.post("https://api.ade.landing.ai/v2/split").mock(return_value=httpx.Response(200, json=SPLIT_BODY))
+    client.v2.split(split_class=SPLIT_CLASS, markdown="# Hello", markdown_url=None, model=None)
+    sent = route.calls.last.request.content
+    assert b"Omit object" not in sent
+    assert b"NOT_GIVEN" not in sent
+    assert b"markdown_url" not in sent
+    assert b'name="model"' not in sent
+
+
+def test_split_body_encodes_split_class_as_json() -> None:
+    from landingai_ade.resources.v2.split import _build_split_body
+
+    body = _build_split_body(SPLIT_CLASS, "# Hello", None, None)
+    assert isinstance(body["split_class"], str)
+    assert json.loads(body["split_class"])[0]["name"] == "invoice"
+    # Explicit `None` optional fields never leak into the multipart body.
+    assert "markdown_url" not in body
+    assert "model" not in body
+
+
+@respx.mock
+def test_split_save_to_writes_file(tmp_path: Path) -> None:
+    client = LandingAIADE(apikey=APIKEY)
+    respx.post("https://api.ade.landing.ai/v2/split").mock(return_value=httpx.Response(200, json=SPLIT_BODY))
+    client.v2.split(split_class=SPLIT_CLASS, markdown="# Hello", save_to=str(tmp_path))
+    written = list(tmp_path.glob("*.json"))
+    assert written and json.loads(written[0].read_text())["metadata"]["job_id"] == "split-1"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_async_split_sync_ok() -> None:
+    from landingai_ade import AsyncLandingAIADE
+
+    client = AsyncLandingAIADE(apikey=APIKEY)
+    respx.post("https://api.ade.landing.ai/v2/split").mock(return_value=httpx.Response(200, json=SPLIT_BODY))
+    result = await client.v2.split(split_class=SPLIT_CLASS, markdown="# Hello")
+    assert isinstance(result, V2SplitResponse)
+    assert result.splits[0].classification == "invoice"

--- a/tests/contract/test_v2_smoke.py
+++ b/tests/contract/test_v2_smoke.py
@@ -14,6 +14,8 @@ from landingai_ade.types.v2 import (
     V2ParseElement,
     V2ExtractResult,
     V2ParseResponse,
+    V2SplitResponse,
+    V2ClassifyResponse,
     V2ParseNodeGrounding,
 )
 
@@ -167,6 +169,47 @@ def test_ground_sync(staging_client: LandingAIADE) -> None:
     assert isinstance(grounded, V2GroundResult)
     assert isinstance(grounded.grounding, dict)
     assert grounded.metadata.job_id
+
+
+def test_classify_sync(staging_client: LandingAIADE) -> None:
+    # Never pin `model=`: the classify model family may not be servable on whatever
+    # the staging cluster is provisioned with. Assert only the guaranteed shape.
+    pdf = Path(__file__).parent / "sample.pdf"
+    res = staging_client.v2.classify(
+        classes=[{"class": "invoice", "description": "A billing document"}, {"class": "other"}],
+        document=pdf,
+    )
+    assert isinstance(res, V2ClassifyResponse)
+    assert isinstance(res.classification, list)
+    # `openapi_spec` is required by the spec; `page_count` is a non-negative count.
+    assert res.metadata.openapi_spec
+    assert res.metadata.page_count >= 0
+    for item in res.classification:
+        assert isinstance(item.class_, str)
+        assert isinstance(item.page, int)
+        # `suggested_class` is optional: absent-or-valid, never asserted populated.
+        if item.suggested_class is not None:
+            assert isinstance(item.suggested_class, str)
+
+
+def test_split_sync(staging_client: LandingAIADE) -> None:
+    # Split takes Markdown (fast, no GPU booking); assert only the guaranteed shape.
+    res = staging_client.v2.split(
+        split_class=[{"name": "report", "description": "A financial report"}],
+        markdown=SAMPLE_MARKDOWN,
+    )
+    assert isinstance(res, V2SplitResponse)
+    assert isinstance(res.splits, list)
+    # `job_id` / `version` are required by the spec.
+    assert res.metadata.job_id
+    assert res.metadata.version
+    assert res.metadata.page_count >= 0
+    for seg in res.splits:
+        assert isinstance(seg.classification, str)
+        assert isinstance(seg.markdowns, list)
+        # `identifier` is required-but-nullable: absent-or-valid.
+        if seg.identifier is not None:
+            assert isinstance(seg.identifier, str)
 
 
 def test_parse_jobs(staging_client: LandingAIADE) -> None:

--- a/tests/test_v2_normalize.py
+++ b/tests/test_v2_normalize.py
@@ -8,11 +8,13 @@ from landingai_ade.types.v2 import (
     JobStatus,
     V2ExtractResult,
     V2ParseResponse,
+    V2ClassifyResponse,
     V2BuildSchemaResponse,
 )
 from landingai_ade.resources.v2._normalize import (
     normalize_parse_job,
     normalize_extract_job,
+    normalize_classify_job,
     normalize_build_schema_job,
 )
 
@@ -235,3 +237,39 @@ def test_normalize_build_schema_job_smoke() -> None:
     job = normalize_build_schema_job(raw)
     assert job.job_id == "bs-x"
     assert job.status is JobStatus.COMPLETED
+
+
+def test_normalize_classify_job_iso_and_result() -> None:
+    raw: Dict[str, Any] = {
+        "job_id": "classify-1",
+        "status": "completed",
+        "created_at": "2026-01-02T03:04:05Z",
+        "completed_at": "2026-01-02T03:04:09Z",
+        "result": {
+            "classification": [{"class": "invoice", "page": 0, "reason": "header"}],
+            "metadata": {"page_count": 1, "duration_ms": 10, "openapi_spec": "https://x/openapi.json"},
+        },
+    }
+    job = normalize_classify_job(raw)
+    assert job.status is JobStatus.COMPLETED
+    assert job.created_at is not None and job.created_at.year == 2026
+    assert isinstance(job.result, V2ClassifyResponse)
+    # The reserved `class` wire key is recursively constructed onto `class_`.
+    assert job.result.classification[0].class_ == "invoice"
+    assert job.result.metadata.page_count == 1
+
+
+def test_normalize_classify_job_error_object() -> None:
+    raw = {"job_id": "c2", "status": "failed", "error": {"code": "bad_doc", "message": "boom"}}
+    job = normalize_classify_job(raw)
+    assert job.status is JobStatus.FAILED
+    assert job.error is not None and job.error.code == "bad_doc"
+    assert job.result is None
+
+
+def test_normalize_classify_job_minimal_create_envelope_defaults_to_pending() -> None:
+    raw = {"job_id": "classify-x"}
+    job = normalize_classify_job(raw)
+    assert job.job_id == "classify-x"
+    assert job.status is JobStatus.PENDING
+    assert job.result is None

--- a/tests/test_v2_types.py
+++ b/tests/test_v2_types.py
@@ -10,6 +10,8 @@ from landingai_ade.types.v2 import (
     V2GroundResult,
     V2ExtractResult,
     V2ParseResponse,
+    V2SplitResponse,
+    V2ClassifyResponse,
     V2BuildSchemaResponse,
 )
 
@@ -311,6 +313,75 @@ def test_build_schema_response_retains_unknown_fields() -> None:
         extraction_schema="{}",
         # `openapi_spec` is required and non-null per the spec.
         metadata={"job_id": "bs", "duration_ms": 1, "openapi_spec": "https://x/openapi.json"},  # type: ignore[arg-type]
+        surprise=1,  # type: ignore[call-arg]
+    )
+    assert r.to_dict()["surprise"] == 1
+
+
+def test_classify_response_builds_from_dicts() -> None:
+    r = V2ClassifyResponse(
+        classification=[  # type: ignore[arg-type]
+            {"class": "invoice", "page": 0, "reason": "has header"},
+            {"class": "unknown", "page": 1, "reason": "no signal", "suggested_class": "receipt"},
+        ],
+        metadata={  # type: ignore[arg-type]
+            "page_count": 2,
+            "duration_ms": 42,
+            "openapi_spec": "https://api.example/openapi.json",
+        },
+    )
+    # The reserved `class` wire key deserializes onto the aliased `class_` field.
+    assert r.classification[0].class_ == "invoice"
+    assert r.classification[0].suggested_class is None
+    assert r.classification[1].suggested_class == "receipt"
+    # Optional metadata fields default to None when the gateway omits them.
+    assert r.metadata.credit_usage is None and r.metadata.org_id is None
+    assert r.metadata.openapi_spec.endswith("openapi.json")
+
+
+def test_classify_response_retains_unknown_fields() -> None:
+    r = V2ClassifyResponse(
+        classification=[],
+        metadata={"page_count": 0, "duration_ms": 1, "openapi_spec": "https://x/openapi.json"},  # type: ignore[arg-type]
+        surprise=1,  # type: ignore[call-arg]
+    )
+    assert r.to_dict()["surprise"] == 1
+
+
+def test_split_response_builds_from_dicts() -> None:
+    r = V2SplitResponse(
+        splits=[  # type: ignore[arg-type]
+            {"classification": "invoice", "identifier": "INV-1", "markdowns": ["# a"], "pages": [0, 1]},
+            {"classification": "receipt", "identifier": None, "markdowns": ["# b"], "pages": [2]},
+        ],
+        metadata={  # type: ignore[arg-type]
+            "filename": "doc.md",
+            "org_id": None,
+            "page_count": 3,
+            "duration_ms": 11,
+            "credit_usage": 0.1,
+            "job_id": "split-1",
+            "version": "split-20251105",
+        },
+    )
+    assert r.splits[0].identifier == "INV-1" and r.splits[0].pages == [0, 1]
+    # `identifier` / `org_id` are required-but-nullable; a null wire value survives.
+    assert r.splits[1].identifier is None
+    assert r.metadata.org_id is None and r.metadata.version == "split-20251105"
+
+
+def test_split_response_retains_unknown_fields() -> None:
+    r = V2SplitResponse(
+        splits=[],
+        metadata={  # type: ignore[arg-type]
+            "filename": "d.md",
+            "org_id": None,
+            "page_count": 0,
+            "duration_ms": 1,
+            "credit_usage": 0.0,
+            "job_id": "s",
+            "version": "split-x",
+        },
         surprise=1,  # type: ignore[call-arg]
     )
     assert r.to_dict()["surprise"] == 1


### PR DESCRIPTION
Automated V2 spec-sync PR (`client.v2`).

- **Commit 1 (mechanical):** normalized V2 spec snapshot + regenerated reference models.
- **Commit 2 (AI, only if the spec diff needs SDK changes):** client.v2 resources/methods/tests/docs wired from the diff, added after this PR opened. Workflow-only drift is excluded and an AI no-op is skipped, so some drifts produce a **mechanical-only PR with no second commit**.

Gates (surface-lock, V2 contract tests, lint/test/typecheck) must pass. When present, the AI commit is a **draft a human finishes** (the V2 ergonomic layer — unified Job, dual-host, schema coercion — is not in the spec). **Human review required before merge.**

<!-- what-changed:start -->
## What changed
_AI-generated from the PR diff — verify against the actual changes._

This PR adds two new synchronous/async ADE endpoints to the SDK's v2 surface — `classify` (with matching `classify_jobs` async job resource) and `split` — along with their typed response models.

**Changes:**
- Added `client.v2.classify(...)` (sync) and `client.v2.classify_jobs.{create,get,list,wait}` (async job lifecycle) methods, returning `V2ClassifyResponse` / unified `Job`.
- Added `client.v2.split(...)` synchronous-only method returning `V2SplitResponse`; no async jobs route for split.
- Added new response types `V2ClassifyResponse`/`V2Classification`/`V2ClassifyMetadata` and `V2SplitResponse`/`V2Split`/`V2SplitMetadata`, exported from `landingai_ade.types.v2`.
- Extended the unified `Job.result` union to include `V2ClassifyResponse` for classify jobs; classify jobs have no `cancelled` status.
- Documented that `classify`/`split` accept `classes`/`split_class` as an iterable of mappings JSON-encoded onto the multipart body, and that `split` (like `parse`/`extract`) supports `save_to`.
<!-- what-changed:end -->