### PR TITLE
fix(spec-sync): scope V2 wiring to /v2 routes, gate wired paths, pin opus-5

### DIFF
--- a/.github/workflows/spec-sync.yml
+++ b/.github/workflows/spec-sync.yml
@@ -14,22 +14,20 @@ permissions:
 
 env:
   # jq program for the "tool-call summary" step that follows each claude-code-action step. It prints
-  # ONLY fixed metadata: the tool name and, for path-like arguments, the value after a strict
-  # character-class check (anything else becomes <redacted>). It deliberately prints NO assistant
-  # text, tool results, file contents, grep patterns or shell commands: the spec the agent reads is
-  # untrusted input, and a prompt-injected agent that has Read its own environment could smuggle a
-  # transformed or chunked credential out through free-form narration, which GitHub's literal secret
-  # masking would not catch. Held here, in the trusted workflow file, so the summary can run right
-  # after the AI step without executing anything the agent could have edited.
+  # ONLY fixed metadata: the tool name and the NAMES of the arguments it was given — never argument
+  # values. A prompt-injected agent that has Read its own environment could hex- or base64-encode a
+  # credential into a file path, and neither a character allowlist nor GitHub's literal secret
+  # masking would catch that; the same goes for assistant text, tool results and file contents, so
+  # none of those are printed either. What the agent actually changed is listed from a trusted
+  # source instead: the commit step prints `git diff --cached --stat`. Held here, in the trusted
+  # workflow file, so the summary can run right after the AI step without executing anything the
+  # agent could have edited.
   TOOL_CALL_SUMMARY_JQ: >-
     (if type == "array" then .[] else . end)
     | select(.type == "assistant") | .message.content[]?
     | select(.type == "tool_use")
-    | "[tool] " + (.name | tostring | if test("^[A-Za-z]{1,32}$") then . else "<redacted>" end) + " "
-      + ((.input // {}) | to_entries
-         | map(select(.key | IN("file_path", "path", "glob", "offset", "limit")))
-         | map(.key + "=" + (.value | tostring | if test("^[A-Za-z0-9_./*{}$-]{1,200}$") then . else "<redacted>" end))
-         | join(" "))
+    | "[tool] " + (.name | tostring | if test("^[A-Za-z]{1,32}$") then . else "<redacted>" end)
+      + " " + ((.input // {}) | keys | map(if test("^[A-Za-z_]{1,32}$") then . else "<redacted>" end) | join(","))
 
 jobs:
   spec-sync:
@@ -207,10 +205,11 @@ jobs:
             --max-turns 250
             --allowedTools "Edit,Write,Read,Glob,Grep,Bash(rye *),Bash(./scripts/*),Bash(git diff:*)"
 
-      # Print the agent's tool calls — tool name plus path-like arguments that pass a strict character
-      # check, nothing else — to the step log, so what the agent read and edited can be audited later:
+      # Print the agent's tool calls — tool name and argument NAMES only, never values — to the step
+      # log, so the shape of what the agent did can be audited later (the commit step lists what it
+      # changed, from the trusted checkout):
       # the action logs only the init and result summaries, and #153 had to be root-caused without
-      # any trace. Deliberately NO assistant text, tool results, patterns or commands: this agent
+      # any trace. Deliberately NO argument values, assistant text, tool results or commands: this agent
       # holds credential-bearing inputs and processes an untrusted spec, and a prompt-injected agent
       # could carry a transformed or chunked credential past GitHub's literal secret masking in
       # free-form narration. Runs straight off the action's own output file with the jq program held
@@ -237,6 +236,8 @@ jobs:
         if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true'
         run: |
           git add -A
+          # Trusted list of what the AI pass changed (the tool-call summary above logs no values).
+          git diff --cached --stat
           if git diff --cached --quiet; then
             echo "AI step produced no changes."
             echo "summary=Mechanical-only PR (AI wiring added no changes). Human review required before merge." >> "$GITHUB_OUTPUT"
@@ -631,10 +632,11 @@ jobs:
             --max-turns 250
             --allowedTools "Edit,Write,Read,Glob,Grep"
 
-      # Print the agent's tool calls — tool name plus path-like arguments that pass a strict character
-      # check, nothing else — to the step log, so what the agent read and edited can be audited later:
+      # Print the agent's tool calls — tool name and argument NAMES only, never values — to the step
+      # log, so the shape of what the agent did can be audited later (the commit step lists what it
+      # changed, from the trusted checkout):
       # the action logs only the init and result summaries, and #153 had to be root-caused without
-      # any trace. Deliberately NO assistant text, tool results, patterns or commands: the spec this
+      # any trace. Deliberately NO argument values, assistant text, tool results or commands: the spec this
       # agent reads is untrusted input, and a prompt-injected agent that has Read its own environment
       # could carry a transformed or chunked credential past GitHub's literal secret masking in
       # free-form narration. Runs BEFORE anything AI-authored can execute, straight off the action's
@@ -771,7 +773,10 @@ jobs:
             registration in src/landingai_ade/resources/v2/v2.py, its types, tests and docs — never
             invent or "translate" a path (a /v1/... route is NOT a /v2/... route; only `/v2/*`
             backs client.v2). (b) A `/v2/*` route in the spec has no resource sending it: wire it,
-            mirroring src/landingai_ade/resources/v2/parse.py and extract.py.
+            mirroring src/landingai_ade/resources/v2/parse.py and extract.py. Paths under
+            /v2/workflow* are out of scope for every AI pass, this one included: never add,
+            remove or edit a workflow resource, and if a `check-v2-paths` error concerns a
+            /v2/workflow* path, leave it for a maintainer.
 
             You may only edit src/, tests/, docs/, and api.md — the same allowlist as before. Do
             NOT edit scripts/, .github/, specs/, pyproject.toml, or any dotfile (including
@@ -890,6 +895,8 @@ jobs:
           # wiring commit.
           rm -f .spec-sync-lint.log .spec-sync-diff.txt
           git add -A
+          # Trusted list of what the AI passes changed (the tool-call summaries above log no values).
+          git diff --cached --stat
           if git diff --cached --quiet; then
             echo "AI step produced no changes."
             echo "changed=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/spec-sync.yml
+++ b/.github/workflows/spec-sync.yml
@@ -13,19 +13,23 @@ permissions:
   contents: read            # all writes go through SPEC_SYNC_TOKEN, never GITHUB_TOKEN
 
 env:
-  # jq program for the "transcript summary" step that follows each claude-code-action step: the
-  # agent's own text blocks plus each tool call as name + target path/pattern — never tool results,
-  # never file contents. Held here, in the trusted workflow file, so the summary can run right after
-  # the AI step without executing anything the agent could have edited.
-  TRANSCRIPT_SUMMARY_JQ: >-
+  # jq program for the "tool-call summary" step that follows each claude-code-action step. It prints
+  # ONLY fixed metadata: the tool name and, for path-like arguments, the value after a strict
+  # character-class check (anything else becomes <redacted>). It deliberately prints NO assistant
+  # text, tool results, file contents, grep patterns or shell commands: the spec the agent reads is
+  # untrusted input, and a prompt-injected agent that has Read its own environment could smuggle a
+  # transformed or chunked credential out through free-form narration, which GitHub's literal secret
+  # masking would not catch. Held here, in the trusted workflow file, so the summary can run right
+  # after the AI step without executing anything the agent could have edited.
+  TOOL_CALL_SUMMARY_JQ: >-
     (if type == "array" then .[] else . end)
     | select(.type == "assistant") | .message.content[]?
-    | if .type == "text" then "\n[assistant] " + .text
-      elif .type == "tool_use" then "[tool] " + .name + " "
-        + ((.input // {}) | to_entries
-           | map(select(.key | IN("file_path", "path", "pattern", "glob", "command", "offset", "limit")))
-           | map(.key + "=" + (.value | tostring)) | join(" "))
-      else empty end
+    | select(.type == "tool_use")
+    | "[tool] " + (.name | tostring | if test("^[A-Za-z]{1,32}$") then . else "<redacted>" end) + " "
+      + ((.input // {}) | to_entries
+         | map(select(.key | IN("file_path", "path", "glob", "offset", "limit")))
+         | map(.key + "=" + (.value | tostring | if test("^[A-Za-z0-9_./*{}$-]{1,200}$") then . else "<redacted>" end))
+         | join(" "))
 
 jobs:
   spec-sync:
@@ -203,21 +207,26 @@ jobs:
             --max-turns 250
             --allowedTools "Edit,Write,Read,Glob,Grep,Bash(rye *),Bash(./scripts/*),Bash(git diff:*)"
 
-      # Print the agent's own narration and tool calls (not tool results, not file contents) to the
-      # step log, so a wiring decision can be audited later — the action logs only the init and
-      # result summaries, and #153 had to be root-caused without any trace. Runs straight off the
-      # action's own output file with the jq program held in this workflow's top-level env, so it
-      # executes nothing the agent could have edited. The LOG, deliberately not an artifact: logs
-      # are secret-masked and artifacts are not, and a prompt-injected agent could Read its own
-      # environment into the transcript. Best-effort.
-      - name: AI wiring transcript summary
+      # Print the agent's tool calls — tool name plus path-like arguments that pass a strict character
+      # check, nothing else — to the step log, so what the agent read and edited can be audited later:
+      # the action logs only the init and result summaries, and #153 had to be root-caused without
+      # any trace. Deliberately NO assistant text, tool results, patterns or commands: this agent
+      # holds credential-bearing inputs and processes an untrusted spec, and a prompt-injected agent
+      # could carry a transformed or chunked credential past GitHub's literal secret masking in
+      # free-form narration. Runs straight off the action's own output file with the jq program held
+      # in this workflow's top-level env, so it executes nothing the agent could have edited.
+      # Best-effort.
+      - name: AI wiring tool-call summary
         if: always() && steps.ai_wiring.outputs.execution_file != ''
         continue-on-error: true
         env:
           TRANSCRIPT: ${{ steps.ai_wiring.outputs.execution_file }}
         run: |
-          echo "::group::AI wiring transcript summary"
-          jq -r "$TRANSCRIPT_SUMMARY_JQ" "$TRANSCRIPT" || echo "transcript summary unavailable (unexpected file shape)"
+          echo "::group::AI wiring tool-call summary"
+          set -o pipefail
+          # Prefix every line: nothing the agent could influence may start at column 0, where a leading
+          # `::` would be parsed as a workflow command (e.g. ::stop-commands::) even inside a group.
+          jq -r "$TOOL_CALL_SUMMARY_JQ" "$TRANSCRIPT" | tr -d '\r' | sed 's/^/  /' || echo "  tool-call summary unavailable (unexpected file shape)"
           echo "::endgroup::"
 
       # Deterministic: commit whatever the AI edited and push to the sync branch. This guarantees
@@ -595,7 +604,7 @@ jobs:
             component schema in `.spec-sync-diff.txt`, mark each IN SCOPE (`/v2/*`, non-workflow) or
             OUT OF SCOPE (`/v1/*`, `/v2/workflow*`), confirm every in-scope item maps to an edit you
             made, and confirm every URL path you wrote exists under `paths` in specs/v2-aide.json.
-            Close any gap before you stop; state the resulting list in your final message.
+            Close any gap before you stop.
 
             Additive-changes rule: BACKWARD-COMPATIBLE ADDITIONS ONLY. You MAY add a new optional
             keyword parameter (with a default) to an existing parse/extract method to wire an
@@ -622,21 +631,26 @@ jobs:
             --max-turns 250
             --allowedTools "Edit,Write,Read,Glob,Grep"
 
-      # Print the agent's own narration and tool calls (not tool results, not file contents) to the
-      # step log, so a wiring decision can be audited later — the action logs only the init and
-      # result summaries, and #153 had to be root-caused without any trace. Runs BEFORE anything
-      # AI-authored can execute, straight off the action's own output file, with the jq program held
-      # in this workflow's top-level env (not in a repo script the agent could have edited). The LOG,
-      # deliberately not an artifact: logs are secret-masked and artifacts are not, and a
-      # prompt-injected agent could Read its own environment into the transcript. Best-effort.
-      - name: AI wiring transcript summary
+      # Print the agent's tool calls — tool name plus path-like arguments that pass a strict character
+      # check, nothing else — to the step log, so what the agent read and edited can be audited later:
+      # the action logs only the init and result summaries, and #153 had to be root-caused without
+      # any trace. Deliberately NO assistant text, tool results, patterns or commands: the spec this
+      # agent reads is untrusted input, and a prompt-injected agent that has Read its own environment
+      # could carry a transformed or chunked credential past GitHub's literal secret masking in
+      # free-form narration. Runs BEFORE anything AI-authored can execute, straight off the action's
+      # own output file, with the jq program held in this workflow's top-level env (not in a repo
+      # script the agent could have edited). Best-effort.
+      - name: AI wiring tool-call summary
         if: always() && steps.ai_wiring.outputs.execution_file != ''
         continue-on-error: true
         env:
           TRANSCRIPT: ${{ steps.ai_wiring.outputs.execution_file }}
         run: |
-          echo "::group::AI wiring transcript summary"
-          jq -r "$TRANSCRIPT_SUMMARY_JQ" "$TRANSCRIPT" || echo "transcript summary unavailable (unexpected file shape)"
+          echo "::group::AI wiring tool-call summary"
+          set -o pipefail
+          # Prefix every line: nothing the agent could influence may start at column 0, where a leading
+          # `::` would be parsed as a workflow command (e.g. ::stop-commands::) even inside a group.
+          jq -r "$TOOL_CALL_SUMMARY_JQ" "$TRANSCRIPT" | tr -d '\r' | sed 's/^/  /' || echo "  tool-call summary unavailable (unexpected file shape)"
           echo "::endgroup::"
 
       # ---- Harden before running ANY trusted command over the AI's edits --------------------
@@ -770,16 +784,19 @@ jobs:
             --max-turns 60
             --allowedTools "Edit,Write,Read,Glob,Grep"
 
-      # Same transcript summary as after the wiring step — see there for why it is the log, and why
+      # Same tool-call summary as after the wiring step — see there for why it is the log, and why
       # it runs before anything AI-authored executes.
-      - name: AI lint repair transcript summary
+      - name: AI lint repair tool-call summary
         if: always() && steps.ai_lint_fix.outputs.execution_file != ''
         continue-on-error: true
         env:
           TRANSCRIPT: ${{ steps.ai_lint_fix.outputs.execution_file }}
         run: |
-          echo "::group::AI lint repair transcript summary"
-          jq -r "$TRANSCRIPT_SUMMARY_JQ" "$TRANSCRIPT" || echo "transcript summary unavailable (unexpected file shape)"
+          echo "::group::AI lint repair tool-call summary"
+          set -o pipefail
+          # Prefix every line: nothing the agent could influence may start at column 0, where a leading
+          # `::` would be parsed as a workflow command (e.g. ::stop-commands::) even inside a group.
+          jq -r "$TOOL_CALL_SUMMARY_JQ" "$TRANSCRIPT" | tr -d '\r' | sed 's/^/  /' || echo "  tool-call summary unavailable (unexpected file shape)"
           echo "::endgroup::"
 
       # The repair pass is exactly as untrusted as the wiring pass, so repeat the hardening too:

--- a/.github/workflows/spec-sync.yml
+++ b/.github/workflows/spec-sync.yml
@@ -12,6 +12,21 @@ concurrency:
 permissions:
   contents: read            # all writes go through SPEC_SYNC_TOKEN, never GITHUB_TOKEN
 
+env:
+  # jq program for the "transcript summary" step that follows each claude-code-action step: the
+  # agent's own text blocks plus each tool call as name + target path/pattern — never tool results,
+  # never file contents. Held here, in the trusted workflow file, so the summary can run right after
+  # the AI step without executing anything the agent could have edited.
+  TRANSCRIPT_SUMMARY_JQ: >-
+    (if type == "array" then .[] else . end)
+    | select(.type == "assistant") | .message.content[]?
+    | if .type == "text" then "\n[assistant] " + .text
+      elif .type == "tool_use" then "[tool] " + .name + " "
+        + ((.input // {}) | to_entries
+           | map(select(.key | IN("file_path", "path", "pattern", "glob", "command", "offset", "limit")))
+           | map(.key + "=" + (.value | tostring)) | join(" "))
+      else empty end
+
 jobs:
   spec-sync:
     # Guard so the scheduled/dispatch job only runs on the canonical repo — forks lack the
@@ -181,10 +196,29 @@ jobs:
             step commits and pushes your edits.
           # Pin the model: the action otherwise inherits Claude Code's default, which floats
           # across CLI releases and makes spec-sync output non-reproducible. `[1m]` = 1M context.
+          # claude-opus-5 is the pin in BOTH SDK repos (ade-python and ade-typescript) — keep them
+          # equal, or the two SDKs quietly diverge on the same spec change.
           claude_args: |
-            --model "claude-opus-4-8[1m]"
+            --model "claude-opus-5[1m]"
             --max-turns 250
             --allowedTools "Edit,Write,Read,Glob,Grep,Bash(rye *),Bash(./scripts/*),Bash(git diff:*)"
+
+      # Print the agent's own narration and tool calls (not tool results, not file contents) to the
+      # step log, so a wiring decision can be audited later — the action logs only the init and
+      # result summaries, and #153 had to be root-caused without any trace. Runs straight off the
+      # action's own output file with the jq program held in this workflow's top-level env, so it
+      # executes nothing the agent could have edited. The LOG, deliberately not an artifact: logs
+      # are secret-masked and artifacts are not, and a prompt-injected agent could Read its own
+      # environment into the transcript. Best-effort.
+      - name: AI wiring transcript summary
+        if: always() && steps.ai_wiring.outputs.execution_file != ''
+        continue-on-error: true
+        env:
+          TRANSCRIPT: ${{ steps.ai_wiring.outputs.execution_file }}
+        run: |
+          echo "::group::AI wiring transcript summary"
+          jq -r "$TRANSCRIPT_SUMMARY_JQ" "$TRANSCRIPT" || echo "transcript summary unavailable (unexpected file shape)"
+          echo "::endgroup::"
 
       # Deterministic: commit whatever the AI edited and push to the sync branch. This guarantees
       # the AI changes actually reach the PR (the action's automation mode does not push), and it
@@ -452,21 +486,34 @@ jobs:
             specs/_generated/v2_models.py. Wire the client.v2 SDK to match the spec diff. This is
             the V2 surface (client.v2.*), NOT V1 — do not touch V1 resources.
 
+            SCOPE — exactly which routes back client.v2: the `/v2/*` paths in this spec, and
+            nothing else. This spec is the AIDE gateway's and ALSO carries `/v1/*` routes (for
+            example /v1/ade/parse, /v1/classify, /v1/split): that is the V1-compatibility surface,
+            tracked by the separate V1 spec-sync job against its own spec, and it is NOT part of
+            client.v2. Do not wire a `/v1/*` route into client.v2, and never "translate" one into a
+            `/v2/...` URL. Every path you write into a resource must appear verbatim under `paths`
+            in specs/v2-aide.json — a trusted step (scripts/spec-sync/check-v2-paths.sh) verifies
+            this after you finish and rejects any path the spec does not have. A diff whose only new
+            ROUTES are `/v1/*` is not "nothing to do": still wire every in-scope change listed
+            below (a new request field on /v2/parse, say) and leave the `/v1/*` routes alone.
+
             OUT OF SCOPE — do NOT implement: /v2/workflow, /v2/workflow/jobs, and
             /v2/workflow/jobs/{job_id}. That surface is intentionally deferred; skip it entirely
             even though it appears in the spec and reference models. If the spec diff touches only
-            workflow, make no changes.
+            workflow and/or `/v1/*` routes, make no changes.
 
             First read the ENTIRE mechanical commit diff, which a trusted step has already written
             to `.spec-sync-diff.txt` in the repo root (you have no shell — use Read, do not try to
-            run git) — the
-            operation/path hunks AND changed entries under `components.schemas` — to find every
-            change backing client.v2. A response-field addition often changes ONLY a component
-            schema (e.g. /v2/parse references #/components/schemas/ParseResponse) and its generated
-            model, not the operation hunk, so for every changed schema trace its `$ref` consumers to
-            the non-workflow operations that use it. Cover: (a) newly added /v2 routes; (b) field or
-            schema changes on existing operations, INCLUDING component-only changes; (c) changes to
-            /v1/files, which backs client.v2.files (src/landingai_ade/resources/v2/files.py).
+            run git; the file runs to thousands of lines, so page through it with offset/limit until
+            you have seen the final hunk) — the operation/path hunks AND changed entries under
+            `components.schemas` — to find every change backing client.v2. A response-field
+            addition often changes ONLY a component schema (e.g. /v2/parse references
+            #/components/schemas/ParseResponse) and its generated model, not the operation hunk, so
+            for every changed schema trace its `$ref` consumers to the non-workflow `/v2/*`
+            operations that use it. Cover: (a) newly added `/v2/*` routes; (b) request-field,
+            response-field or schema changes on existing `/v2/*` operations, INCLUDING
+            component-only changes. A new optional request field on /v2/parse is exactly case (b)
+            and must be wired even when the same diff is dominated by unrelated `/v1/*` additions.
 
             Distinguish REQUEST fields — wire as a new optional keyword parameter on the existing
             method (see the additive-changes rule below) — from RESPONSE-model fields — add the
@@ -544,6 +591,12 @@ jobs:
             you then access attributes on the value, which yields `reportUnknown*` errors; and do
             not add `# type: ignore` to silence an annotation you could have written correctly.
 
+            Before you finish, self-check coverage: list every operation hunk and every changed
+            component schema in `.spec-sync-diff.txt`, mark each IN SCOPE (`/v2/*`, non-workflow) or
+            OUT OF SCOPE (`/v1/*`, `/v2/workflow*`), confirm every in-scope item maps to an edit you
+            made, and confirm every URL path you wrote exists under `paths` in specs/v2-aide.json.
+            Close any gap before you stop; state the resulting list in your final message.
+
             Additive-changes rule: BACKWARD-COMPATIBLE ADDITIONS ONLY. You MAY add a new optional
             keyword parameter (with a default) to an existing parse/extract method to wire an
             additive request field — surface-lock permits that. You must NOT remove or rename a
@@ -552,7 +605,11 @@ jobs:
             all; the diff you need is already in `.spec-sync-diff.txt`. A later workflow step
             commits and pushes your edits.
           # Pin the model: the action otherwise inherits Claude Code's default, which floats
-          # across CLI releases and makes spec-sync output non-reproducible. `[1m]` = 1M context.
+          # across CLI releases and makes spec-sync output non-reproducible. `[1m]` = 1M context —
+          # the mechanical diff alone can run to ~100K tokens. claude-opus-5 is the pin in BOTH SDK
+          # repos; keep them equal. (On the drift behind #153 the then-pinned claude-opus-4-8
+          # rewrote new /v1 routes as non-existent /v2 ones and skipped the in-scope field, while
+          # ade-typescript's unpinned run — opus-5 by default — wired exactly the right thing, twice.)
           #
           # NO Bash tool. `Bash(git diff:*)` was allowed here so the agent could inspect the
           # mechanical diff, but `git diff` is NOT inert: an agent that writes `.git/config` can
@@ -561,9 +618,26 @@ jobs:
           # hardening applies. A trusted step precomputes the diff into .spec-sync-diff.txt
           # instead, so the agent keeps the input and loses the execution primitive.
           claude_args: |
-            --model "claude-opus-4-8[1m]"
+            --model "claude-opus-5[1m]"
             --max-turns 250
             --allowedTools "Edit,Write,Read,Glob,Grep"
+
+      # Print the agent's own narration and tool calls (not tool results, not file contents) to the
+      # step log, so a wiring decision can be audited later — the action logs only the init and
+      # result summaries, and #153 had to be root-caused without any trace. Runs BEFORE anything
+      # AI-authored can execute, straight off the action's own output file, with the jq program held
+      # in this workflow's top-level env (not in a repo script the agent could have edited). The LOG,
+      # deliberately not an artifact: logs are secret-masked and artifacts are not, and a
+      # prompt-injected agent could Read its own environment into the transcript. Best-effort.
+      - name: AI wiring transcript summary
+        if: always() && steps.ai_wiring.outputs.execution_file != ''
+        continue-on-error: true
+        env:
+          TRANSCRIPT: ${{ steps.ai_wiring.outputs.execution_file }}
+        run: |
+          echo "::group::AI wiring transcript summary"
+          jq -r "$TRANSCRIPT_SUMMARY_JQ" "$TRANSCRIPT" || echo "transcript summary unavailable (unexpected file shape)"
+          echo "::endgroup::"
 
       # ---- Harden before running ANY trusted command over the AI's edits --------------------
       #
@@ -642,10 +716,13 @@ jobs:
         continue-on-error: true
         run: |
           set -o pipefail
-          # Run both even if the first fails, so the repair pass sees every error at once.
+          # Run all three even if one fails, so the repair pass sees every error at once.
           status=0
           rye run check:ruff 2>&1 | tee .spec-sync-lint.log || status=1
           rye run typecheck 2>&1 | tee -a .spec-sync-lint.log || status=1
+          # Both directions: a wired path the spec lacks (#153 invented /v2/classify and /v2/split)
+          # and a /v2 spec route nothing sends. grep + jq over source only — as safe here as ruff.
+          ./scripts/spec-sync/check-v2-paths.sh specs/v2-aide.json src/landingai_ade/resources/v2 2>&1 | tee -a .spec-sync-lint.log || status=1
           exit $status
 
       - name: AI lint repair (edits only)
@@ -662,10 +739,11 @@ jobs:
           # the top of this file); SPEC_SYNC_TOKEN is reserved for the trusted push step.
           github_token: ${{ github.token }}
           prompt: |
-            `./scripts/lint` failed on the client.v2 wiring you just wrote. Read
+            The trusted lint step failed on the client.v2 wiring you just wrote. Read
             .spec-sync-lint.log in the repo root — it is the captured output of that run (ruff
-            check, then pyright in STRICT mode, then an import check) — and fix every error it
-            reports.
+            check, then pyright in STRICT mode and mypy, then scripts/spec-sync/check-v2-paths.sh,
+            which cross-checks the URL paths the V2 resources send against specs/v2-aide.json) —
+            and fix every error it reports.
 
             Fix the CAUSE, not the symptom. Specifically, do NOT silence anything: no
             `# type: ignore`, no `cast(Any, ...)`, no widening an annotation to `object`/`Any`, no
@@ -674,15 +752,35 @@ jobs:
             landingai_ade.types.v2 (a recursive helper over parse elements takes
             `List[V2ParseElement]`, not `object`). Keep the behavior the wiring was written to have.
 
+            A `check-v2-paths` error means one of two things. (a) A resource sends a path that is
+            not under `paths` in specs/v2-aide.json: remove that method/resource together with its
+            registration in src/landingai_ade/resources/v2/v2.py, its types, tests and docs — never
+            invent or "translate" a path (a /v1/... route is NOT a /v2/... route; only `/v2/*`
+            backs client.v2). (b) A `/v2/*` route in the spec has no resource sending it: wire it,
+            mirroring src/landingai_ade/resources/v2/parse.py and extract.py.
+
             You may only edit src/, tests/, docs/, and api.md — the same allowlist as before. Do
             NOT edit scripts/, .github/, specs/, pyproject.toml, or any dotfile (including
             .spec-sync-lint.log itself: it is an input, and it is deleted before anything is
             committed). You have NO shell and no git access at all.
           # NO Bash tool — see the wiring step above for why `Bash(git diff:*)` was removed.
+          # Same model pin as the wiring step, for the same reasons.
           claude_args: |
-            --model "claude-opus-4-8[1m]"
+            --model "claude-opus-5[1m]"
             --max-turns 60
             --allowedTools "Edit,Write,Read,Glob,Grep"
+
+      # Same transcript summary as after the wiring step — see there for why it is the log, and why
+      # it runs before anything AI-authored executes.
+      - name: AI lint repair transcript summary
+        if: always() && steps.ai_lint_fix.outputs.execution_file != ''
+        continue-on-error: true
+        env:
+          TRANSCRIPT: ${{ steps.ai_lint_fix.outputs.execution_file }}
+        run: |
+          echo "::group::AI lint repair transcript summary"
+          jq -r "$TRANSCRIPT_SUMMARY_JQ" "$TRANSCRIPT" || echo "transcript summary unavailable (unexpected file shape)"
+          echo "::endgroup::"
 
       # The repair pass is exactly as untrusted as the wiring pass, so repeat the hardening too:
       # it could have written .venv/** or .git/hooks/** just as the wiring pass could, and the
@@ -722,6 +820,7 @@ jobs:
           status=0
           rye run check:ruff || status=1
           rye run typecheck || status=1
+          ./scripts/spec-sync/check-v2-paths.sh specs/v2-aide.json src/landingai_ade/resources/v2 || status=1
           exit $status
 
       # LAST line of defence, and it must come after the last step that executes anything.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,9 +152,24 @@ two attributed commits (paths shown for V1; the V2 loop uses the `v2-aide`/`v2_m
    These reference models are an input for the AI step and for review — they are **not** shipped and
    do **not** replace `src/landingai_ade/types/*`.
 2. **AI** — `anthropics/claude-code-action` (automation mode) wires the resources, methods, param
-   types, tests, and docs from the spec diff, following existing conventions.
+   types, tests, and docs from the spec diff, following existing conventions. Every AI step pins
+   `--model "claude-opus-5[1m]"` (the same pin as `ade-typescript`); left unpinned, the action
+   floats with whatever Claude Code release it ships, and the two SDKs silently diverge. Right after
+   each AI step the run prints the agent's narration and tool calls (a `jq` filter over the
+   action's transcript, held in the workflow's top-level `env`) to the step log so a wiring
+   decision can be audited after the fact — the log rather than an artifact, because only logs
+   are secret-masked.
 
-Every spec-sync PR (and any PR to `main`) must pass `.github/workflows/pr-gates.yml`:
+Every spec-sync PR (and any PR to `main`) must pass `.github/workflows/pr-gates.yml` and the CI
+`lint` job, which includes:
+
+- **check-v2-paths** (`scripts/spec-sync/check-v2-paths.sh`, run by `./scripts/lint` and inside
+  the spec-sync run's own lint step so the AI repair pass sees it) — cross-checks the URL paths the
+  `client.v2` resources send against `specs/v2-aide.json` in both directions. A wired path the spec
+  lacks fails: in #153 the AI pass rewrote the gateway's new `/v1/classify` and `/v1/split` routes
+  as `client.v2.classify`/`split` hitting non-existent `/v2/classify`/`/v2/split` (404 on staging).
+  A `/v2/*` spec route no resource sends also fails, unless it is listed as deferred in the script
+  (today: `/v2/workflow*`).
 
 - **surface-lock** (`scripts/spec-sync/surface-lock.sh`, `griffe`) — baseline is the **last release
   tag**, so any change to *released* public surface fails mechanically. Merged-but-unreleased surface
@@ -178,8 +193,16 @@ changes.
 **V2 status:** the V2 loop is **implemented** (the `spec-sync-v2` job + `specs/v2-aide.json` +
 `specs/_generated/v2_models.py`). Its baseline is the full current spec, so it ships live but quiet
 and fires only on a future real change; `/v2/workflow` is intentionally deferred (kept in the
-baseline and excluded in the AI prompt). Its AI step is hardened beyond V1's — no shell, and a
-product-code allowlist enforced before formatting/staging (see `.github/workflows/spec-sync.yml`).
+baseline, excluded in the AI prompt, and listed as deferred in `check-v2-paths.sh`). Its AI step is
+hardened beyond V1's — no shell, and a product-code allowlist enforced before formatting/staging
+(see `.github/workflows/spec-sync.yml`).
+
+**V2 scope:** `client.v2` is backed by the spec's `/v2/*` routes **only**. The AIDE spec also
+carries `/v1/*` compatibility routes (`/v1/ade/*`, `/v1/classify`, `/v1/split`, …); those are the V1
+surface and are never wired into `client.v2` — the AI prompt says so, and `check-v2-paths` rejects
+any wired path the snapshot does not have, so a `/v1/*` route can no longer be "translated" into a
+`/v2/*` one. A new `/v1/*` route in the V2 spec is therefore expected to produce a PR that wires
+only the in-scope `/v2/*` changes (if any) and mentions the unwired routes in its description.
 
 The same pipeline shape ports to `ade-typescript` with `openapi-typescript` (mechanical) and
 `api-extractor` (surface-lock), tracked separately.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,21 +155,24 @@ two attributed commits (paths shown for V1; the V2 loop uses the `v2-aide`/`v2_m
    types, tests, and docs from the spec diff, following existing conventions. Every AI step pins
    `--model "claude-opus-5[1m]"` (the same pin as `ade-typescript`); left unpinned, the action
    floats with whatever Claude Code release it ships, and the two SDKs silently diverge. Right after
-   each AI step the run prints the agent's narration and tool calls (a `jq` filter over the
-   action's transcript, held in the workflow's top-level `env`) to the step log so a wiring
-   decision can be audited after the fact — the log rather than an artifact, because only logs
-   are secret-masked.
+   each AI step the run prints the agent's tool calls — tool name plus path-like arguments that pass
+   a strict character check, nothing else — to the step log (a `jq` filter held in the workflow's
+   top-level `env`), so what the agent read and edited can be audited after the fact. Free-form
+   agent text is deliberately not logged: the spec is untrusted input, and narration from a
+   prompt-injected agent could carry a transformed credential past secret masking.
 
 Every spec-sync PR (and any PR to `main`) must pass `.github/workflows/pr-gates.yml` and the CI
 `lint` job, which includes:
 
-- **check-v2-paths** (`scripts/spec-sync/check-v2-paths.sh`, run by `./scripts/lint` and inside
-  the spec-sync run's own lint step so the AI repair pass sees it) — cross-checks the URL paths the
-  `client.v2` resources send against `specs/v2-aide.json` in both directions. A wired path the spec
-  lacks fails: in #153 the AI pass rewrote the gateway's new `/v1/classify` and `/v1/split` routes
+- **check-v2-paths** (`scripts/spec-sync/check-v2-paths.sh`, identical in both SDK repos; run by
+  `./scripts/lint` and inside the spec-sync run's own lint step so the AI repair pass sees it) —
+  cross-checks the URL paths the `client.v2` resources use against `specs/v2-aide.json` in both
+  directions. Forward: every `/vN/` literal in the V2 resources must be a `/v2/*` spec route (or the
+  hidden build-schema surface) — a `/v1/*` route is reported as out of scope, a missing one as not
+  in the spec; in #153 the AI pass rewrote the gateway's new `/v1/classify` and `/v1/split` routes
   as `client.v2.classify`/`split` hitting non-existent `/v2/classify`/`/v2/split` (404 on staging).
-  A `/v2/*` spec route no resource sends also fails, unless it is listed as deferred in the script
-  (today: `/v2/workflow*`).
+  Reverse: every `/v2/*` spec route outside the not-auto-wired `/v2/workflow*` namespace must be
+  *sent* at a `_v2_url(...)` call site — a docstring mention does not count.
 
 - **surface-lock** (`scripts/spec-sync/surface-lock.sh`, `griffe`) — baseline is the **last release
   tag**, so any change to *released* public surface fails mechanically. Merged-but-unreleased surface
@@ -193,7 +196,7 @@ changes.
 **V2 status:** the V2 loop is **implemented** (the `spec-sync-v2` job + `specs/v2-aide.json` +
 `specs/_generated/v2_models.py`). Its baseline is the full current spec, so it ships live but quiet
 and fires only on a future real change; `/v2/workflow` is intentionally deferred (kept in the
-baseline, excluded in the AI prompt, and listed as deferred in `check-v2-paths.sh`). Its AI step is
+baseline, excluded in the AI prompt, and excluded from the reverse check in `check-v2-paths.sh`). Its AI step is
 hardened beyond V1's — no shell, and a product-code allowlist enforced before formatting/staging
 (see `.github/workflows/spec-sync.yml`).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,11 +155,11 @@ two attributed commits (paths shown for V1; the V2 loop uses the `v2-aide`/`v2_m
    types, tests, and docs from the spec diff, following existing conventions. Every AI step pins
    `--model "claude-opus-5[1m]"` (the same pin as `ade-typescript`); left unpinned, the action
    floats with whatever Claude Code release it ships, and the two SDKs silently diverge. Right after
-   each AI step the run prints the agent's tool calls — tool name plus path-like arguments that pass
-   a strict character check, nothing else — to the step log (a `jq` filter held in the workflow's
-   top-level `env`), so what the agent read and edited can be audited after the fact. Free-form
-   agent text is deliberately not logged: the spec is untrusted input, and narration from a
-   prompt-injected agent could carry a transformed credential past secret masking.
+   each AI step the run prints the agent's tool calls — tool name and argument names only, no
+   values — to the step log (a `jq` filter held in the workflow's top-level `env`), and the commit
+   step prints `git diff --cached --stat`, so what the agent did and changed can be audited after
+   the fact. No agent-controlled value is logged: the spec is untrusted input, and a prompt-injected
+   agent could encode a credential into narration or a file path and carry it past secret masking.
 
 Every spec-sync PR (and any PR to `main`) must pass `.github/workflows/pr-gates.yml` and the CI
 `lint` job, which includes:

--- a/docs/design/v2-spec-sync-extension.md
+++ b/docs/design/v2-spec-sync-extension.md
@@ -66,6 +66,16 @@ non-workflow V2 drift.
   - Inspect the mechanical diff (`git diff HEAD~1..HEAD`) for **every changed operation backing
     `client.v2`** — new `/v2` routes, field/schema changes on existing operations, and changes to
     `/v1/files` (which backs `client.v2.files`). Workflow is explicitly excluded.
+
+    > **Note (2026-09-07):** `client.v2.files` and `/v1/files` are gone (removed with #129), and
+    > the scope is now stated the other way round: **only `/v2/*` routes back `client.v2`**. The
+    > AIDE spec also carries `/v1/*` compatibility routes (`/v1/ade/*`, `/v1/classify`,
+    > `/v1/split`, …); those are the V1 surface and are never wired here. The prompt says so, and
+    > `scripts/spec-sync/check-v2-paths.sh` enforces it mechanically: every URL a V2 resource sends
+    > must exist in the snapshot, and every `/v2/*` snapshot route must be sent by a resource (or
+    > be listed as deferred). Motivation: #153, where the AI pass rewrote the new `/v1/classify` and
+    > `/v1/split` routes as `client.v2.classify`/`split` hitting non-existent `/v2/*` paths and
+    > skipped the in-scope `password` field on `/v2/parse`.
   - For a **field change on an existing operation**, wire it into the existing resource/method
     (adding a new *optional* keyword parameter is permitted — surface-lock allows backward-
     compatible additions). For a **new route**, mirror `resources/v2/extract.py` + `parse.py`:

--- a/docs/design/v2-spec-sync-extension.md
+++ b/docs/design/v2-spec-sync-extension.md
@@ -72,8 +72,9 @@ non-workflow V2 drift.
     > AIDE spec also carries `/v1/*` compatibility routes (`/v1/ade/*`, `/v1/classify`,
     > `/v1/split`, …); those are the V1 surface and are never wired here. The prompt says so, and
     > `scripts/spec-sync/check-v2-paths.sh` enforces it mechanically: every URL a V2 resource sends
-    > must exist in the snapshot, and every `/v2/*` snapshot route must be sent by a resource (or
-    > be listed as deferred). Motivation: #153, where the AI pass rewrote the new `/v1/classify` and
+    > must be a `/v2/*` route of the snapshot, and every `/v2/*` snapshot route outside the
+    > not-auto-wired `/v2/workflow*` namespace must be sent at a `_v2_url(...)` call site.
+    > Motivation: #153, where the AI pass rewrote the new `/v1/classify` and
     > `/v1/split` routes as `client.v2.classify`/`split` hitting non-existent `/v2/*` paths and
     > skipped the in-scope `password` field on `/v2/parse`.
   - For a **field change on an existing operation**, wire it into the existing resource/method

--- a/scripts/lint
+++ b/scripts/lint
@@ -12,5 +12,8 @@ else
   rye run lint
 fi
 
+echo "==> Checking client.v2 routes against the spec snapshot"
+./scripts/spec-sync/check-v2-paths.sh specs/v2-aide.json src/landingai_ade/resources/v2
+
 echo "==> Making sure it imports"
 rye run python -c 'import landingai_ade'

--- a/scripts/spec-sync/check-v2-paths.sh
+++ b/scripts/spec-sync/check-v2-paths.sh
@@ -14,20 +14,25 @@
 #      URL that bypasses the builder is still caught; prose that quotes a non-existent path fails
 #      too, which is acceptable — it is misleading prose.
 #   2. REVERSE — every `/v2/*` path in the snapshot must be SENT by some V2 resource. "Sent" means
-#      it appears at a request call site — the V2 URL builder (`_v2_url(` in Python, `v2Url(` in
-#      TypeScript) applied to the literal — not merely mentioned in a docstring or comment, so a
-#      resource that only documents a route cannot satisfy the check. Catches a new /v2 route the
-#      wiring pass skipped. Namespaces the AI pass is told not to wire (NOT_AUTO_WIRED_PREFIXES) are
-#      excluded from this direction only; routes hidden from the snapshot in fetch-normalize.sh
-#      (build-schema) never appear in it.
+#      the literal sits at a request call site: the V2 URL builder (`_v2_url(` in Python, `v2Url(`
+#      in TypeScript) as the first argument of a request method (`self._get/_post/...(` in Python,
+#      `this._client.get/post/...(` in TypeScript). A route that is only mentioned in a docstring or
+#      comment, or only passed through the builder without being sent, does not count. The scan is
+#      whitespace-insensitive across lines, so a formatter splitting the call is fine. Catches a new
+#      /v2 route the wiring pass skipped. Namespaces the AI pass is told not to wire
+#      (NOT_AUTO_WIRED_PREFIXES) are excluded from this direction only; routes hidden from the
+#      snapshot in fetch-normalize.sh (build-schema) never appear in it.
 #
 # Path parameters compare structurally: `{job_id}` in the spec, `{job_id}` in a Python f-string and
 # `${jobID}` in a TypeScript template literal all normalize to `{}`.
 #
 # Runs in `./scripts/lint` (so the CI `lint` job enforces it on every PR) and inside the spec-sync
 # workflow's lint step, where a failure is fed back to the AI repair pass. It only READS source:
-# grep + jq over files, nothing is imported or executed — so it is safe to run over AI-authored code
-# in a trusted step, like the linters. This file is identical in ade-python and ade-typescript.
+# grep + a JSON key dump over files, nothing is imported or executed — so it is safe to run over
+# AI-authored code in a trusted step, like the linters. Reading the snapshot's `paths` keys uses
+# whichever of jq, python3 or node is on PATH, so a plain checkout needs no extra tool: the Python
+# repo always has python3 and the TypeScript repo always has node. This file is identical in
+# ade-python and ade-typescript.
 #
 # usage: check-v2-paths.sh <spec-snapshot.json> <v2-resources-dir>
 #   exit 0 -> consistent
@@ -58,6 +63,22 @@ HIDDEN='/v2/extract/build-schema
 # path under them that IS wired is still validated by the forward check. One prefix per line.
 NOT_AUTO_WIRED_PREFIXES='/v2/workflow'
 
+# Print the snapshot's `paths` keys, one per line, with whatever JSON reader is available.
+spec_paths() {
+  if command -v jq >/dev/null 2>&1; then
+    jq -r '.paths | keys[]' "$1"
+  elif command -v python3 >/dev/null 2>&1; then
+    python3 -c 'import json, sys
+for key in json.load(open(sys.argv[1], encoding="utf-8"))["paths"]:
+    print(key)' "$1"
+  elif command -v node >/dev/null 2>&1; then
+    node -e 'for (const k of Object.keys(JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")).paths)) console.log(k)' "$1"
+  else
+    echo "check-v2-paths: need jq, python3 or node on PATH to read $1" >&2
+    exit 2
+  fi
+}
+
 normalize() {
   # `${jobID}` (TS template) and `{job_id}` (spec / Python f-string) -> `{}`
   sed -E 's/\$\{[^}]*\}/{}/g; s/\{[^}]*\}/{}/g'
@@ -66,36 +87,44 @@ normalize() {
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
-jq -r '.paths | keys[]' "$spec" | normalize | sort -u > "$tmp/spec"
+spec_paths "$spec" | normalize | sort -u > "$tmp/spec"
 grep '^/v2/' "$tmp/spec" > "$tmp/spec_v2" || true
 printf '%s\n' "$HIDDEN" | sed '/^$/d' | sort -u > "$tmp/hidden"
 
 # Lines that are comments: `#`, `//`, a block-comment opener `/*` / `/**`, or a `*` continuation.
-comment_re='^[^:]+:[0-9]+:[[:space:]]*(#|//|/\*|\*)'
+comment_line_re='^[[:space:]]*(#|//|/\*|\*)'
 quote="[\"'\`]"
 literal="${quote}/v[0-9]+/[^\"'\`[:space:]]*${quote}"
-# A request call site: the V2 URL builder applied to the literal, optionally through the TS `path`
-# template tag — `self._v2_url("/v2/parse")`, `self._v2_url(f"/v2/parse/jobs/{job_id}")`,
-# `this.v2Url('/v2/parse')`, `this.v2Url(path\`/v2/parse/jobs/${jobID}\`)`.
-callsite="(_v2_url|v2Url)\\([[:space:]]*(path)?[[:space:]]*f?${literal}"
+# A request call site, matched against a file whose comment lines were dropped and whose remaining
+# lines were joined with spaces (so the pattern spans formatter line breaks):
+#   Python:      self._post(  self._v2_url("/v2/parse")      self._get(  self._v2_url(f"/v2/x/{id}")
+#   TypeScript:  this._client.post<T>(  this.v2Url('/v2/parse')   this._client.get<T>(this.v2Url(path`/v2/x/${id}`)
+methods='(get|post|put|patch|delete)'
+callsite="(\\._${methods}|\\._client\\.${methods}(<[^(]*>)?)\\([[:space:]]*(self|this)\\.(_v2_url|v2Url)\\([[:space:]]*(path)?[[:space:]]*f?${literal}"
 
-# All non-comment lines carrying a quoted /vN/ literal, as `<file>:<line>\t<text>`.
-grep -rnE --include='*.py' --include='*.ts' --exclude='*.test.ts' --exclude='*.d.ts' \
-  -e "$literal" "$srcdir" 2>/dev/null \
-  | grep -vE "$comment_re" \
-  | sed -E $'s/^([^:]+:[0-9]+):(.*)$/\\1\t\\2/' > "$tmp/lines" || true
+find "$srcdir" -type f \( -name '*.py' -o -name '*.ts' \) ! -name '*.test.ts' ! -name '*.d.ts' | sort > "$tmp/files"
 
-# FORWARD input: every literal on those lines, as `<file>:<line>\t<normalized path>`.
+# FORWARD input: every literal on a non-comment line, as `<file>:<line>\t<normalized path>`.
 : > "$tmp/mentioned_loc"
-while IFS=$'\t' read -r loc text; do
-  printf '%s\n' "$text" | grep -oE "$literal" | sed -E 's/^.//; s/.$//' | normalize \
-    | while IFS= read -r p; do printf '%s\t%s\n' "$loc" "$p"; done
-done < "$tmp/lines" > "$tmp/mentioned_loc"
+while IFS= read -r file; do
+  # `|| true`: a file without any literal makes grep exit 1, which under pipefail must not abort.
+  grep -nE -e "$literal" "$file" 2>/dev/null \
+    | grep -vE "^[0-9]+:${comment_line_re#^}" \
+    | while IFS= read -r hit; do
+        lineno="${hit%%:*}"
+        text="${hit#*:}"
+        printf '%s\n' "$text" | grep -oE "$literal" | sed -E 's/^.//; s/.$//' | normalize \
+          | while IFS= read -r p; do printf '%s:%s\t%s\n' "$file" "$lineno" "$p"; done
+      done || true
+done < "$tmp/files" >> "$tmp/mentioned_loc"
 cut -f2 "$tmp/mentioned_loc" | sort -u > "$tmp/mentioned"
 
-# REVERSE input: only literals at a request call site.
-cut -f2 "$tmp/lines" | grep -oE "$callsite" | grep -oE "$literal" | sed -E 's/^.//; s/.$//' | normalize \
-  | sort -u > "$tmp/sent" || true
+# REVERSE input: literals at a request call site, scanned over the comment-stripped, joined file.
+: > "$tmp/sent"
+while IFS= read -r file; do
+  grep -vE "$comment_line_re" "$file" | tr '\n' ' ' | grep -oE "$callsite" | grep -oE "$literal" \
+    | sed -E 's/^.//; s/.$//' | normalize || true
+done < "$tmp/files" | sort -u > "$tmp/sent"
 
 status=0
 
@@ -133,9 +162,10 @@ if [ -s "$tmp/unwired" ]; then
   status=1
   while IFS= read -r p; do
     echo "check-v2-paths: ERROR — '$spec' has the route '$p' under 'paths', but no V2 resource in '$srcdir' sends it."
-    echo "  \"Sends\" means a request call site (the V2 URL builder applied to the path), not a mention in a"
-    echo "  comment or docstring. Wire it (mirror the parse/extract resources), or — as an explicit product"
-    echo "  decision — add its namespace to NOT_AUTO_WIRED_PREFIXES in scripts/spec-sync/check-v2-paths.sh."
+    echo "  \"Sends\" means a request call site — the V2 URL builder as the first argument of a request method"
+    echo "  (self._post(self._v2_url(...)) / this._client.post(this.v2Url(...))) — not a mention in a comment"
+    echo "  or docstring. Wire it (mirror the parse/extract resources), or — as an explicit product decision —"
+    echo "  add its namespace to NOT_AUTO_WIRED_PREFIXES in scripts/spec-sync/check-v2-paths.sh."
   done < "$tmp/unwired"
 fi
 

--- a/scripts/spec-sync/check-v2-paths.sh
+++ b/scripts/spec-sync/check-v2-paths.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Cross-check the V2 resource sources against the committed V2 spec snapshot, in BOTH directions:
+#
+#   1. Every URL path a V2 resource sends (a quoted `/v2/...` or `/v1/...` literal) must exist under
+#      `paths` in the snapshot. This catches a wired route the spec does not have. It is the exact
+#      failure of ade-python#153: the spec added /v1/classify and /v1/split (V1-compatibility routes
+#      of the AIDE gateway), and the AI-wiring pass "translated" them into client.v2.classify /
+#      client.v2.split hitting /v2/classify and /v2/split — paths that exist nowhere. Staging 404'd
+#      and the contract gate went red, but nothing said WHY until a human read the spec.
+#   2. Every `/v2/*` path in the snapshot must be sent by some V2 resource. This catches a new /v2
+#      route the wiring pass skipped. A route that is deliberately not wired goes in DEFERRED below,
+#      or is stripped from the snapshot in fetch-normalize.sh (how build-schema is hidden).
+#
+# Path parameters compare structurally: `{job_id}` in the spec, `{job_id}` in a Python f-string and
+# `${jobID}` in a TypeScript template literal all normalize to `{}`.
+#
+# Runs in `./scripts/lint` (so the CI `lint` job enforces it on every PR) and inside the spec-sync
+# workflow's lint step, where a failure is fed back to the AI repair pass. It only READS source:
+# grep + jq over files, nothing is imported or executed — so it is safe to run over AI-authored code
+# in a trusted step, like ruff/pyright.
+#
+# usage: check-v2-paths.sh <spec-snapshot.json> <v2-resources-dir>
+#   exit 0 -> consistent
+#   exit 1 -> mismatch (details on stdout, one line per finding)
+#   exit 2 -> usage error
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: check-v2-paths.sh <spec-snapshot.json> <v2-resources-dir>" >&2
+  exit 2
+fi
+
+spec="$1"
+srcdir="$2"
+[ -f "$spec" ] || { echo "check-v2-paths: spec snapshot not found: $spec" >&2; exit 2; }
+[ -d "$srcdir" ] || { echo "check-v2-paths: resources dir not found: $srcdir" >&2; exit 2; }
+
+# Wired on purpose but absent from the snapshot: the hidden build-schema surface. Keep in sync with
+# the `del(...)` list in fetch-normalize.sh — the resource module is retained (not public), so its
+# URL literals stay in src/ while the routes are stripped from specs/v2-aide.json.
+HIDDEN='/v2/extract/build-schema
+/v2/extract/build-schema/jobs
+/v2/extract/build-schema/jobs/{}'
+
+# In the snapshot on purpose but NOT wired: deferred surface a maintainer has decided to skip for
+# now. /v2/workflow* is kept in the baseline as a drift signal but intentionally not implemented in
+# this SDK (the AI-wiring prompt excludes it too). Add a path here (normalized: parameters as `{}`)
+# only as an explicit product decision; remove it when the surface ships.
+DEFERRED='/v2/workflow
+/v2/workflow/jobs
+/v2/workflow/jobs/{}'
+
+normalize() {
+  # `${jobID}` (TS template) and `{job_id}` (spec / Python f-string) -> `{}`
+  sed -E 's/\$\{[^}]*\}/{}/g; s/\{[^}]*\}/{}/g'
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+jq -r '.paths | keys[]' "$spec" | normalize | sort -u > "$tmp/spec"
+printf '%s\n' "$HIDDEN" | sed '/^$/d' | sort -u > "$tmp/hidden"
+printf '%s\n' "$DEFERRED" | sed '/^$/d' | sort -u > "$tmp/deferred"
+
+# Every quoted `/vN/...` literal in the resource sources, as `<file>:<line>\t<normalized path>`.
+# Comment lines (`#`, `//`, `*`) are skipped so prose that mentions a path is not mistaken for a
+# request. Quote characters: " ' and ` (TS template literals).
+quote="[\"'\`]"
+literal="${quote}/v[0-9]+/[^\"'\`[:space:]]*${quote}"
+: > "$tmp/wired_loc"
+grep -rnE --include='*.py' --include='*.ts' --exclude='*.test.ts' --exclude='*.d.ts' \
+  -e "$literal" "$srcdir" 2>/dev/null \
+  | grep -vE '^[^:]+:[0-9]+:[[:space:]]*(#|//|\*)' \
+  | sed -E $'s/^([^:]+:[0-9]+):(.*)$/\\1\t\\2/' \
+  | while IFS=$'\t' read -r loc text; do
+      printf '%s\n' "$text" | grep -oE "$literal" | sed -E 's/^.//; s/.$//' | normalize \
+        | while IFS= read -r p; do printf '%s\t%s\n' "$loc" "$p"; done
+    done > "$tmp/wired_loc" || true
+cut -f2 "$tmp/wired_loc" | sort -u > "$tmp/wired"
+
+status=0
+
+# 1. wired ⊆ spec ∪ hidden
+sort -u "$tmp/spec" "$tmp/hidden" > "$tmp/known"
+comm -23 "$tmp/wired" "$tmp/known" > "$tmp/unknown"
+if [ -s "$tmp/unknown" ]; then
+  status=1
+  while IFS= read -r p; do
+    echo "check-v2-paths: ERROR — a V2 resource sends '$p', but '$spec' has no such path under 'paths'."
+    echo "  A client.v2 method must call a route that exists in the spec. Never invent or translate a"
+    echo "  path (e.g. a /v1/... route rewritten as /v2/...): if the spec has no /v2 route for this"
+    echo "  capability it is out of scope for client.v2 — remove the method/resource, its registration,"
+    echo "  types, tests and docs. Sent from:"
+    awk -F'\t' -v p="$p" '$2 == p { print "    " $1 }' "$tmp/wired_loc"
+  done < "$tmp/unknown"
+fi
+
+# 2. spec[/v2/*] ⊆ wired ∪ deferred
+grep '^/v2/' "$tmp/spec" > "$tmp/spec_v2" || true
+sort -u "$tmp/wired" "$tmp/deferred" > "$tmp/covered"
+comm -23 "$tmp/spec_v2" "$tmp/covered" > "$tmp/unwired"
+if [ -s "$tmp/unwired" ]; then
+  status=1
+  while IFS= read -r p; do
+    echo "check-v2-paths: ERROR — '$spec' has the route '$p' under 'paths', but no V2 resource in '$srcdir' sends it."
+    echo "  Wire it (mirror the parse/extract resources), or record an explicit decision to skip it"
+    echo "  in DEFERRED in scripts/spec-sync/check-v2-paths.sh."
+  done < "$tmp/unwired"
+fi
+
+if [ "$status" -eq 0 ]; then
+  echo "check-v2-paths: OK — $(wc -l < "$tmp/wired" | tr -d ' ') wired path(s) all present in $spec; all $(wc -l < "$tmp/spec_v2" | tr -d ' ') /v2 spec route(s) wired."
+fi
+exit "$status"

--- a/scripts/spec-sync/check-v2-paths.sh
+++ b/scripts/spec-sync/check-v2-paths.sh
@@ -1,15 +1,25 @@
 #!/usr/bin/env bash
 # Cross-check the V2 resource sources against the committed V2 spec snapshot, in BOTH directions:
 #
-#   1. Every URL path a V2 resource sends (a quoted `/v2/...` or `/v1/...` literal) must exist under
-#      `paths` in the snapshot. This catches a wired route the spec does not have. It is the exact
-#      failure of ade-python#153: the spec added /v1/classify and /v1/split (V1-compatibility routes
-#      of the AIDE gateway), and the AI-wiring pass "translated" them into client.v2.classify /
-#      client.v2.split hitting /v2/classify and /v2/split — paths that exist nowhere. Staging 404'd
-#      and the contract gate went red, but nothing said WHY until a human read the spec.
-#   2. Every `/v2/*` path in the snapshot must be sent by some V2 resource. This catches a new /v2
-#      route the wiring pass skipped. A route that is deliberately not wired goes in DEFERRED below,
-#      or is stripped from the snapshot in fetch-normalize.sh (how build-schema is hidden).
+#   1. FORWARD — every URL path a V2 resource mentions in code (a quoted `/v2/...` or `/v1/...`
+#      literal outside comment lines) must be a `/v2/*` path under `paths` in the snapshot (or a
+#      HIDDEN path, see below). Two failure classes, reported separately:
+#        - not in the spec at all: a wired route the spec does not have. This is the exact failure
+#          of landing-ai/ade-python#153: the spec added /v1/classify and /v1/split (V1-compat routes
+#          of the AIDE gateway) and the AI-wiring pass "translated" them into client.v2.classify /
+#          client.v2.split hitting /v2/classify and /v2/split — paths that exist nowhere.
+#        - in the spec but not `/v2/*`: a V1-compatibility route wired into client.v2 directly.
+#          Only `/v2/*` backs client.v2; the `/v1/*` routes in this spec are the V1 surface.
+#      The forward scan is deliberately broad (any quoted literal, comments excluded) so a hardcoded
+#      URL that bypasses the builder is still caught; prose that quotes a non-existent path fails
+#      too, which is acceptable — it is misleading prose.
+#   2. REVERSE — every `/v2/*` path in the snapshot must be SENT by some V2 resource. "Sent" means
+#      it appears at a request call site — the V2 URL builder (`_v2_url(` in Python, `v2Url(` in
+#      TypeScript) applied to the literal — not merely mentioned in a docstring or comment, so a
+#      resource that only documents a route cannot satisfy the check. Catches a new /v2 route the
+#      wiring pass skipped. Namespaces the AI pass is told not to wire (NOT_AUTO_WIRED_PREFIXES) are
+#      excluded from this direction only; routes hidden from the snapshot in fetch-normalize.sh
+#      (build-schema) never appear in it.
 #
 # Path parameters compare structurally: `{job_id}` in the spec, `{job_id}` in a Python f-string and
 # `${jobID}` in a TypeScript template literal all normalize to `{}`.
@@ -17,7 +27,7 @@
 # Runs in `./scripts/lint` (so the CI `lint` job enforces it on every PR) and inside the spec-sync
 # workflow's lint step, where a failure is fed back to the AI repair pass. It only READS source:
 # grep + jq over files, nothing is imported or executed — so it is safe to run over AI-authored code
-# in a trusted step, like ruff/pyright.
+# in a trusted step, like the linters. This file is identical in ade-python and ade-typescript.
 #
 # usage: check-v2-paths.sh <spec-snapshot.json> <v2-resources-dir>
 #   exit 0 -> consistent
@@ -42,13 +52,11 @@ HIDDEN='/v2/extract/build-schema
 /v2/extract/build-schema/jobs
 /v2/extract/build-schema/jobs/{}'
 
-# In the snapshot on purpose but NOT wired: deferred surface a maintainer has decided to skip for
-# now. /v2/workflow* is kept in the baseline as a drift signal but intentionally not implemented in
-# this SDK (the AI-wiring prompt excludes it too). Add a path here (normalized: parameters as `{}`)
-# only as an explicit product decision; remove it when the surface ships.
-DEFERRED='/v2/workflow
-/v2/workflow/jobs
-/v2/workflow/jobs/{}'
+# Snapshot namespaces the AI-wiring prompt explicitly does NOT wire (hand-maintained in
+# ade-typescript, deferred in ade-python). Excluded from the REVERSE check only, so a new route
+# under them does not fail lint and push the repair pass into wiring what the prompt forbids. A
+# path under them that IS wired is still validated by the forward check. One prefix per line.
+NOT_AUTO_WIRED_PREFIXES='/v2/workflow'
 
 normalize() {
   # `${jobID}` (TS template) and `{job_id}` (spec / Python f-string) -> `{}`
@@ -59,56 +67,79 @@ tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
 jq -r '.paths | keys[]' "$spec" | normalize | sort -u > "$tmp/spec"
+grep '^/v2/' "$tmp/spec" > "$tmp/spec_v2" || true
 printf '%s\n' "$HIDDEN" | sed '/^$/d' | sort -u > "$tmp/hidden"
-printf '%s\n' "$DEFERRED" | sed '/^$/d' | sort -u > "$tmp/deferred"
 
-# Every quoted `/vN/...` literal in the resource sources, as `<file>:<line>\t<normalized path>`.
-# Comment lines (`#`, `//`, `*`) are skipped so prose that mentions a path is not mistaken for a
-# request. Quote characters: " ' and ` (TS template literals).
+# Lines that are comments: `#`, `//`, a block-comment opener `/*` / `/**`, or a `*` continuation.
+comment_re='^[^:]+:[0-9]+:[[:space:]]*(#|//|/\*|\*)'
 quote="[\"'\`]"
 literal="${quote}/v[0-9]+/[^\"'\`[:space:]]*${quote}"
-: > "$tmp/wired_loc"
+# A request call site: the V2 URL builder applied to the literal, optionally through the TS `path`
+# template tag — `self._v2_url("/v2/parse")`, `self._v2_url(f"/v2/parse/jobs/{job_id}")`,
+# `this.v2Url('/v2/parse')`, `this.v2Url(path\`/v2/parse/jobs/${jobID}\`)`.
+callsite="(_v2_url|v2Url)\\([[:space:]]*(path)?[[:space:]]*f?${literal}"
+
+# All non-comment lines carrying a quoted /vN/ literal, as `<file>:<line>\t<text>`.
 grep -rnE --include='*.py' --include='*.ts' --exclude='*.test.ts' --exclude='*.d.ts' \
   -e "$literal" "$srcdir" 2>/dev/null \
-  | grep -vE '^[^:]+:[0-9]+:[[:space:]]*(#|//|\*)' \
-  | sed -E $'s/^([^:]+:[0-9]+):(.*)$/\\1\t\\2/' \
-  | while IFS=$'\t' read -r loc text; do
-      printf '%s\n' "$text" | grep -oE "$literal" | sed -E 's/^.//; s/.$//' | normalize \
-        | while IFS= read -r p; do printf '%s\t%s\n' "$loc" "$p"; done
-    done > "$tmp/wired_loc" || true
-cut -f2 "$tmp/wired_loc" | sort -u > "$tmp/wired"
+  | grep -vE "$comment_re" \
+  | sed -E $'s/^([^:]+:[0-9]+):(.*)$/\\1\t\\2/' > "$tmp/lines" || true
+
+# FORWARD input: every literal on those lines, as `<file>:<line>\t<normalized path>`.
+: > "$tmp/mentioned_loc"
+while IFS=$'\t' read -r loc text; do
+  printf '%s\n' "$text" | grep -oE "$literal" | sed -E 's/^.//; s/.$//' | normalize \
+    | while IFS= read -r p; do printf '%s\t%s\n' "$loc" "$p"; done
+done < "$tmp/lines" > "$tmp/mentioned_loc"
+cut -f2 "$tmp/mentioned_loc" | sort -u > "$tmp/mentioned"
+
+# REVERSE input: only literals at a request call site.
+cut -f2 "$tmp/lines" | grep -oE "$callsite" | grep -oE "$literal" | sed -E 's/^.//; s/.$//' | normalize \
+  | sort -u > "$tmp/sent" || true
 
 status=0
 
-# 1. wired ⊆ spec ∪ hidden
-sort -u "$tmp/spec" "$tmp/hidden" > "$tmp/known"
-comm -23 "$tmp/wired" "$tmp/known" > "$tmp/unknown"
+# 1. FORWARD: mentioned ⊆ spec[/v2/*] ∪ hidden
+sort -u "$tmp/spec_v2" "$tmp/hidden" > "$tmp/known"
+comm -23 "$tmp/mentioned" "$tmp/known" > "$tmp/unknown"
 if [ -s "$tmp/unknown" ]; then
   status=1
   while IFS= read -r p; do
-    echo "check-v2-paths: ERROR — a V2 resource sends '$p', but '$spec' has no such path under 'paths'."
-    echo "  A client.v2 method must call a route that exists in the spec. Never invent or translate a"
-    echo "  path (e.g. a /v1/... route rewritten as /v2/...): if the spec has no /v2 route for this"
-    echo "  capability it is out of scope for client.v2 — remove the method/resource, its registration,"
-    echo "  types, tests and docs. Sent from:"
-    awk -F'\t' -v p="$p" '$2 == p { print "    " $1 }' "$tmp/wired_loc"
+    if grep -qxF "$p" "$tmp/spec"; then
+      echo "check-v2-paths: ERROR — a V2 resource uses '$p', which is in '$spec' but is NOT a /v2 route: it is out of scope for client.v2."
+      echo "  Only the spec's /v2/* routes back client.v2. The /v1/* routes in this spec are the V1-compatibility"
+      echo "  surface (tracked by the V1 spec-sync job) and must not be wired into client.v2 — remove the"
+      echo "  method/resource, its registration, types, tests and docs. Used at:"
+    else
+      echo "check-v2-paths: ERROR — a V2 resource uses '$p', but '$spec' has no such path under 'paths'."
+      echo "  A client.v2 method must call a route that exists in the spec. Never invent or translate a"
+      echo "  path (e.g. a /v1/... route rewritten as /v2/...): if the spec has no /v2 route for this"
+      echo "  capability it is out of scope for client.v2 — remove the method/resource, its registration,"
+      echo "  types, tests and docs. Used at:"
+    fi
+    awk -F'\t' -v p="$p" '$2 == p { print "    " $1 }' "$tmp/mentioned_loc"
   done < "$tmp/unknown"
 fi
 
-# 2. spec[/v2/*] ⊆ wired ∪ deferred
-grep '^/v2/' "$tmp/spec" > "$tmp/spec_v2" || true
-sort -u "$tmp/wired" "$tmp/deferred" > "$tmp/covered"
-comm -23 "$tmp/spec_v2" "$tmp/covered" > "$tmp/unwired"
+# 2. REVERSE: spec[/v2/*] minus not-auto-wired namespaces ⊆ sent
+cp "$tmp/spec_v2" "$tmp/must_wire"
+while IFS= read -r prefix; do
+  [ -n "$prefix" ] || continue
+  grep -vE "^$(printf '%s' "$prefix" | sed -E 's/[][\.*^$/]/\\&/g')(/|$)" "$tmp/must_wire" > "$tmp/must_wire.next" || true
+  mv "$tmp/must_wire.next" "$tmp/must_wire"
+done <<< "$NOT_AUTO_WIRED_PREFIXES"
+comm -23 "$tmp/must_wire" "$tmp/sent" > "$tmp/unwired"
 if [ -s "$tmp/unwired" ]; then
   status=1
   while IFS= read -r p; do
     echo "check-v2-paths: ERROR — '$spec' has the route '$p' under 'paths', but no V2 resource in '$srcdir' sends it."
-    echo "  Wire it (mirror the parse/extract resources), or record an explicit decision to skip it"
-    echo "  in DEFERRED in scripts/spec-sync/check-v2-paths.sh."
+    echo "  \"Sends\" means a request call site (the V2 URL builder applied to the path), not a mention in a"
+    echo "  comment or docstring. Wire it (mirror the parse/extract resources), or — as an explicit product"
+    echo "  decision — add its namespace to NOT_AUTO_WIRED_PREFIXES in scripts/spec-sync/check-v2-paths.sh."
   done < "$tmp/unwired"
 fi
 
 if [ "$status" -eq 0 ]; then
-  echo "check-v2-paths: OK — $(wc -l < "$tmp/wired" | tr -d ' ') wired path(s) all present in $spec; all $(wc -l < "$tmp/spec_v2" | tr -d ' ') /v2 spec route(s) wired."
+  echo "check-v2-paths: OK — $(wc -l < "$tmp/mentioned" | tr -d ' ') path(s) used by V2 resources are all /v2 routes of $spec (or hidden); all $(wc -l < "$tmp/must_wire" | tr -d ' ') auto-wired /v2 spec route(s) are sent."
 fi
 exit "$status"


### PR DESCRIPTION
Root cause of #153: the AI commit wired `client.v2.classify` / `client.v2.split` against `/v2/classify` and `/v2/split`, which the spec does not have (staging 404 → contract tests red), and skipped the one in-scope change, the new `password` field on `/v2/parse`. The drift only added `/v1/*` routes (`/v1/classify*`, `/v1/split`, `/v1/ade/*`); the prompt never said what to do with non-`/v2` routes in the AIDE spec, and nothing checked that a wired path exists.

- **Prompt (V2):** explicit SCOPE — only `/v2/*` backs `client.v2`; `/v1/*` routes in this spec are the V1 surface, never wired or "translated"; every written path must exist in the snapshot. Drops the stale `/v1/files` → `client.v2.files` clause (gone since #129), adds a paging hint for the multi-thousand-line diff and a coverage self-check before finishing.
- **Gate:** `scripts/spec-sync/check-v2-paths.sh` (identical file in both repos). Forward: every `/vN/` literal a V2 resource uses must be a `/v2/*` spec route or the hidden build-schema surface — a `/v1/*` route is reported as out of scope, a missing one as not in the spec. Reverse: every `/v2/*` spec route outside the not-auto-wired `/v2/workflow*` namespace must be *sent* — `self._post(self._v2_url(...))` / `self._get(...)`, matched across line breaks — so a docstring mention or an unused builder call does not count. Reads the snapshot with jq, python3 or node, whichever is on PATH (no new prerequisite). Runs in `./scripts/lint` (CI `lint`, a required check) and inside the spec-sync lint step so the AI repair pass sees it. Rejects #153's tree with exactly the four invented paths; passes `main`.
- **Model:** every AI step pins `claude-opus-5[1m]` (was `claude-opus-4-8[1m]`). ade-typescript pins the same in landing-ai/ade-typescript#119 — it was unpinned, ran opus-5 by default, and wired this very drift correctly twice.
- **Observability:** right after each AI step the run prints the agent's tool calls to the step log — tool name and argument *names* only, never values, every line prefixed so none can start a workflow command — and the commit step prints `git diff --cached --stat` from the trusted checkout. No agent-controlled value is logged: a prompt-injected agent could encode a credential into narration or a file path and carry it past secret masking. The `jq` filter lives in the workflow's top-level `env` and runs before any AI-authored code can execute.
- Docs: CONTRIBUTING, dated note in the V2 design doc.

Follow-up once merged: close #153 so the next hourly run re-wires the drift under the new prompt and gate.
