### PR TITLE
spec-sync(v2): support encrypted-pdf password option in parse and parse_jobs

### DIFF
--- a/api.md
+++ b/api.md
@@ -111,6 +111,8 @@ Methods:
 
   Synchronous parse. Provide exactly one of `document` (file) or `document_url`. Returns a `V2ParseResponse` on both full success (HTTP 200) and partial success (HTTP 206, where `result.metadata.failed_pages` lists unparsed pages). Raises `V2SyncTimeoutError` (from `landingai_ade.lib.v2_errors`) on a 504; use `parse_jobs` for long-running documents.
 
+  `password` unlocks an encrypted PDF. It is sent as `options.password` (an explicit `options["password"]` wins over the kwarg) and, for older gateways, also as a top-level form field; the server decrypts the document once at the start of processing and does not retain the password with the result. PDFs only -- the server answers 422 with a documented `code`: `password_unsupported_content_type` for a password supplied alongside an image or an Office document, `encrypted_pdf_wrong_password` for a wrong password, and `encrypted_pdf_password_required` for a locked PDF sent without one. `parse_jobs.create` takes the same `password` with the same semantics.
+
 - <code title="post /v2/parse/jobs">client.v2.parse_jobs.<a href="./src/landingai_ade/resources/v2/parse.py">create</a>(\*, document=..., document_url=..., model=..., options=..., password=..., output_save_url=..., service_tier=...) -> <a href="./src/landingai_ade/types/v2/job.py">Job</a></code>
 - <code title="get /v2/parse/jobs/{job_id}">client.v2.parse_jobs.<a href="./src/landingai_ade/resources/v2/parse.py">get</a>(job_id) -> <a href="./src/landingai_ade/types/v2/job.py">Job</a></code>
 - <code title="get /v2/parse/jobs">client.v2.parse_jobs.<a href="./src/landingai_ade/resources/v2/parse.py">list</a>(\*, page=..., page_size=..., status=...) -> JobList[<a href="./src/landingai_ade/types/v2/job.py">Job</a>]</code>

--- a/docs/v2-testing.md
+++ b/docs/v2-testing.md
@@ -59,6 +59,37 @@ The legacy top-level `grounding` tree (`V2ParseGrounding` and friends) is retain
 on the model for backward compatibility with older gateway responses; current
 responses omit it in favor of the inline `grounding` above.
 
+### Encrypted PDFs (`password`)
+
+`options.password` is a **supported** parse option — earlier snapshots documented
+it as unimplemented (any value returned a 422), so a 422 mentioning the password
+is no longer the expected outcome of merely supplying one.
+
+- `client.v2.parse(...)` and `client.v2.parse_jobs.create(...)` both take a
+  top-level `password=` kwarg. It is folded into `options.password` (an explicit
+  `options["password"]` wins) and kept as a top-level form field for older
+  gateways — `_build_parse_body` in `resources/v2/parse.py` owns that merge, so
+  both routes behave identically.
+- The document is decrypted once at the start of processing and the password is
+  not retained with the result, so nothing in `V2ParseResponse` echoes it. There
+  is no response-model change to assert.
+- The field is PDF-only. Three failures are documented, each a 422 carrying a
+  stable `code` in the `ErrorResponse` body (`{code, message}`):
+  `password_unsupported_content_type` (password supplied for an image or an
+  Office document), `encrypted_pdf_wrong_password`, and
+  `encrypted_pdf_password_required` (a locked PDF sent without one).
+
+Testing it: `/v2/parse` declares only `200`, `206` and `422`, so *any* rejection
+is a 422 — that much is a spec guarantee and safe to assert live
+(`test_parse_sync_password_requires_pdf` in `tests/contract/test_v2_smoke.py`
+sends a password with a non-PDF byte payload and asserts the status only).
+Asserting a specific `code` needs a controlled response body and belongs in
+`tests/api_resources/v2/test_parse.py`
+(`test_parse_sync_surfaces_encrypted_pdf_error_code`); do not assert it live, and
+do not add an encrypted-PDF fixture to the contract suite — the correct-password
+success path cannot be pinned without one, and staging is not guaranteed to have
+the field deployed ahead of the snapshot.
+
 ## Current extract-response shape
 
 `POST /v2/extract` (and the completed `extract_jobs` result) returns a

--- a/specs/_generated/v2_models.py
+++ b/specs/_generated/v2_models.py
@@ -68,6 +68,29 @@ class BuildSchemaWarning(BaseModel):
     )
 
 
+class ClassifyClass(BaseModel):
+    """
+    One classification option: a class name plus an optional description.
+
+    Wire key ``class`` (VTRA's ``ClassifyClass``); the field is ``class_name``
+    because ``class`` is a Python keyword, with the alias carrying the wire
+    name. ``populate_by_name`` lets the Temporal round-trip (which serializes by
+    FIELD name) rebuild the object on the worker side.
+    """
+
+    class_: str = Field(
+        ...,
+        alias='class',
+        description='Class name assigned to a page when it matches.',
+        title='Class',
+    )
+    description: Optional[str] = Field(
+        None,
+        description='What this class represents. Improves classification.',
+        title='Description',
+    )
+
+
 class CreditUsage(BaseModel):
     """
     The standard credit-usage shape a billable WORK result carries.
@@ -219,6 +242,86 @@ class Range(BaseModel):
     )
 
 
+class Split(BaseModel):
+    """
+    One split segment: consecutive pages of one classification (an
+    identifier change starts a new segment).
+    """
+
+    classification: str = Field(
+        ...,
+        description='The split classification name this segment was assigned.',
+        title='Classification',
+    )
+    identifier: Optional[str] = Field(
+        ...,
+        description='The identifier value extracted for this segment, when the matching split classification requested one. Null otherwise.',
+        title='Identifier',
+    )
+    markdowns: list[str] = Field(
+        ...,
+        description='The Markdown content of each page in this segment, in order.',
+        title='Markdowns',
+    )
+    pages: list[int] = Field(
+        ...,
+        description='0-indexed page numbers belonging to this segment, in order.',
+        title='Pages',
+    )
+
+
+class SplitMetadata(BaseModel):
+    """
+    Information about a split request.
+    """
+
+    credit_usage: float = Field(
+        ...,
+        description='Credits consumed by this request: the input Markdown length in characters divided by 5000. Billed usage rounds this up to the next 0.1 credit.',
+        title='Credit Usage',
+    )
+    duration_ms: int = Field(
+        ..., description='Total processing time in milliseconds.', title='Duration Ms'
+    )
+    filename: str = Field(
+        ...,
+        description="Display name of the split document: the URL path's file name for `markdown_url` inputs, or a generated name for inline and uploaded Markdown.",
+        title='Filename',
+    )
+    job_id: str = Field(
+        ...,
+        description="The split job identifier — server-minted and unique per request. Correlates with the request's entry in your billing dashboard.",
+        title='Job Id',
+    )
+    org_id: Optional[str] = Field(..., description='Organization ID.', title='Org Id')
+    page_count: int = Field(
+        ...,
+        description='Total number of pages in the input Markdown.',
+        title='Page Count',
+    )
+    version: str = Field(
+        ...,
+        description='The exact split model snapshot that processed the document, e.g. `split-20251105`.',
+        title='Version',
+    )
+
+
+class SplitResponse(BaseModel):
+    """
+    The split result: the merged `splits` segments and request `metadata`.
+    """
+
+    metadata: SplitMetadata = Field(
+        ...,
+        description='Information about the request: file name, page count, duration, credits, and the resolved model version.',
+    )
+    splits: list[Split] = Field(
+        ...,
+        description='The split segments, in page order. Consecutive pages with the same classification merge into one segment; an identifier change starts a new segment.',
+        title='Splits',
+    )
+
+
 class Format(Enum):
     markdown = 'markdown'
     html = 'html'
@@ -278,6 +381,42 @@ class V1BuildSchemaMetadata(BaseModel):
         None,
         description='Structured warnings from the schema-generation process. Each is a ``{code, msg}`` object (e.g. code ``nonconformant_schema``).',
         title='Warnings',
+    )
+
+
+class V1ClassifyMetadata(BaseModel):
+    """
+    Response metadata for a classify call — VTRA's ``ClassifyMetadata``.
+    """
+
+    credit_usage: Optional[float] = Field(
+        0.0, description='Credits billed for this request.', title='Credit Usage'
+    )
+    duration_ms: int = Field(
+        ...,
+        description='End-to-end request duration in milliseconds.',
+        title='Duration Ms',
+    )
+    filename: Optional[str] = Field(
+        '', description='Name of the classified file.', title='Filename'
+    )
+    job_id: Optional[str] = Field(
+        '',
+        description='Gateway job id (workflow id). Matches the billing row id in vision-agent.',
+        title='Job Id',
+    )
+    openapi_spec: str = Field(
+        ...,
+        description='URL of the OpenAPI spec covering this API, for inspection and client generation.',
+    )
+    org_id: Optional[str] = Field(None, description='Organization ID.', title='Org Id')
+    page_count: int = Field(
+        ..., description='Number of pages classified.', title='Page Count'
+    )
+    version: Optional[str] = Field(
+        None,
+        description='Resolved classify pipeline version that produced this response.',
+        title='Version',
     )
 
 
@@ -525,6 +664,422 @@ class WorkflowStepOptions(BaseModel):
     )
 
 
+class V1AdeClassifyPostRequest(BaseModel):
+    """
+    Input to ``V1ClassifyOperationWorkflow`` (gateway) and, threaded
+    unchanged, to ``ClassifyWorkflow`` (work) — the ``/v1/classify`` request
+    body. Mirrors VTRA's ``ClassifyRequest``.
+    """
+
+    classes: list[ClassifyClass] = Field(
+        ...,
+        description="The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string.",
+        title='Classes',
+    )
+    content_type: Optional[str] = Field('', title='Content Type')
+    document_ref: str = Field(..., title='Document Ref')
+    filename: Optional[str] = Field('', title='Filename')
+    model: Optional[str] = Field(
+        None,
+        description='Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version.',
+        title='Model',
+    )
+
+
+class V1AdeClassifyPostRequest1(BaseModel):
+    classes: list[ClassifyClass] = Field(
+        ...,
+        description="The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string. JSON-serialized string in form data.",
+        title='Classes',
+    )
+    content_type: Optional[str] = Field('', title='Content Type')
+    document: Optional[bytes] = Field(
+        None,
+        description='The file to process. Provide either `document` or `document_url`, not both.',
+    )
+    document_url: Optional[str] = Field(
+        None,
+        description='A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.',
+    )
+    filename: Optional[str] = Field('', title='Filename')
+    model: Optional[str] = Field(
+        None,
+        description='Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version. JSON-serialized string in form data.',
+        title='Model',
+    )
+
+
+class ClassificationItem(BaseModel):
+    class_: str = Field(
+        ..., alias='class', description="Predicted class label, or 'unknown'."
+    )
+    page: int = Field(
+        ..., description='Page number, zero-indexed (the first page is 0).'
+    )
+    reason: str = Field(..., description='Why the page was classified this way.')
+    suggested_class: Optional[str] = Field(
+        None, description="A class the model proposes when the prediction is 'unknown'."
+    )
+
+
+class V1AdeClassifyPostResponse(BaseModel):
+    """
+    Result returned by ``V1ClassifyOperationWorkflow`` — the
+    ``/v1/classify`` response body (VTRA's ``ClassifyResponse``).
+    """
+
+    classification: list[ClassificationItem] = Field(
+        ...,
+        description='One classification result per page, in page order.',
+        title='Classification',
+    )
+    metadata: V1ClassifyMetadata = Field(
+        ..., description='Metadata for the classification request.'
+    )
+
+
+class V1AdeClassifyJobsGetParametersQuery(BaseModel):
+    page: Optional[int] = Field(
+        0, description='Page number (0-indexed).', ge=0, title='Page'
+    )
+    page_size: Optional[int] = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    )
+    status: Optional[str] = Field(
+        None, description='Filter by job status.', title='Status'
+    )
+
+
+class Status1(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+
+
+class Job(BaseModel):
+    completed_at: Optional[str] = None
+    created_at: Optional[str] = None
+    failure_reason: Optional[str] = None
+    job_id: Optional[str] = Field(
+        None,
+        description='The unique identifier for this v1-ade-classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    model_version: Optional[str] = None
+    status: Optional[Status1] = None
+
+
+class V1AdeClassifyJobsGetResponse(BaseModel):
+    has_more: Optional[bool] = None
+    jobs: Optional[list[Job]] = None
+    page: Optional[int] = None
+    page_size: Optional[int] = None
+
+
+class ServiceTier2(Enum):
+    """
+    Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.
+    """
+
+    standard = 'standard'
+    priority = 'priority'
+
+
+class V1AdeClassifyJobsPostRequest(BaseModel):
+    """
+    Input to ``V1ClassifyOperationWorkflow`` (gateway) and, threaded
+    unchanged, to ``ClassifyWorkflow`` (work) — the ``/v1/classify`` request
+    body. Mirrors VTRA's ``ClassifyRequest``.
+    """
+
+    classes: list[ClassifyClass] = Field(
+        ...,
+        description="The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string.",
+        title='Classes',
+    )
+    content_type: Optional[str] = Field('', title='Content Type')
+    document_ref: str = Field(..., title='Document Ref')
+    filename: Optional[str] = Field('', title='Filename')
+    model: Optional[str] = Field(
+        None,
+        description='Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version.',
+        title='Model',
+    )
+    service_tier: Optional[ServiceTier2] = Field(
+        None,
+        description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
+    )
+
+
+class V1AdeClassifyJobsPostRequest1(BaseModel):
+    classes: list[ClassifyClass] = Field(
+        ...,
+        description="The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string. JSON-serialized string in form data.",
+        title='Classes',
+    )
+    content_type: Optional[str] = Field('', title='Content Type')
+    document: Optional[bytes] = Field(
+        None,
+        description='The file to process. Provide either `document` or `document_url`, not both.',
+    )
+    document_url: Optional[str] = Field(
+        None,
+        description='A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.',
+    )
+    filename: Optional[str] = Field('', title='Filename')
+    model: Optional[str] = Field(
+        None,
+        description='Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version. JSON-serialized string in form data.',
+        title='Model',
+    )
+    service_tier: Optional[ServiceTier2] = Field(
+        None,
+        description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
+    )
+
+
+class V1AdeClassifyJobsPostResponse(BaseModel):
+    created_at: Optional[str] = None
+    job_id: Optional[str] = Field(
+        None,
+        description='The unique identifier for this v1-ade-classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    status: Optional[Status1] = None
+
+
+class Error(BaseModel):
+    """
+    Present once status is ``failed``.
+    """
+
+    code: Optional[str] = Field(
+        None, description='Stable error code (``internal_error`` when unmapped).'
+    )
+    message: Optional[str] = None
+
+
+class Result(BaseModel):
+    """
+    Result returned by ``V1ClassifyOperationWorkflow`` — the
+    ``/v1/classify`` response body (VTRA's ``ClassifyResponse``).
+    """
+
+    classification: list[ClassificationItem] = Field(
+        ...,
+        description='One classification result per page, in page order.',
+        title='Classification',
+    )
+    metadata: V1ClassifyMetadata = Field(
+        ..., description='Metadata for the classification request.'
+    )
+
+
+class V1AdeClassifyJobsJobIdGetResponse(BaseModel):
+    completed_at: Optional[str] = Field(
+        None, description='Present once the job is terminal.'
+    )
+    created_at: Optional[str] = None
+    error: Optional[Error] = Field(
+        None, description='Present once status is ``failed``.'
+    )
+    job_id: Optional[str] = Field(
+        None,
+        description='The unique identifier for this v1-ade-classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    progress: Optional[float] = Field(
+        None,
+        description='Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.',
+        ge=0.0,
+        le=1.0,
+    )
+    result: Optional[Result] = Field(
+        None, description='Present once status is ``completed``.'
+    )
+    status: Optional[Status1] = None
+
+
+class V1AdeExtractPostRequest(BaseModel):
+    """
+    Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.
+
+    VTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline
+    string), ``markdown_url``, ``schema``, ``strict``. Nothing else — AIDE's own
+    extras (``return_reasoning``, ``fallback_model``, ``output_save_url``) stay on
+    the R&D ``/api/extract`` contract, so the customer surface publishes the VTRA
+    contract and only that.
+    """
+
+    markdown: Optional[str] = Field(None, title='Markdown')
+    markdown_url: Optional[str] = Field(None, title='Markdown Url')
+    model: Optional[str] = Field(None, title='Model')
+    schema_: Optional[str] = Field(None, alias='schema', title='Schema')
+    strict: Optional[bool] = Field(False, title='Strict')
+
+
+class V1AdeExtractPostRequest1(BaseModel):
+    markdown: Optional[bytes] = Field(None, description='File upload.')
+    markdown_url: Optional[str] = Field(
+        None, description='JSON-serialized string in form data.', title='Markdown Url'
+    )
+    model: Optional[str] = Field(
+        None, description='JSON-serialized string in form data.', title='Model'
+    )
+    schema_: Optional[str] = Field(
+        None,
+        alias='schema',
+        description='JSON-serialized string in form data.',
+        title='Schema',
+    )
+    strict: Optional[bool] = Field(
+        False, description='JSON-serialized string in form data.', title='Strict'
+    )
+
+
+class V1AdeExtractPostResponse(BaseModel):
+    """
+    VTRA's ``ExtractResponse`` — the ``/v1/extract`` response body.
+
+    ``extraction`` is ALWAYS inline. The internal ``ExtractResult`` returns an
+    ``output_ref`` instead when the payload is too large for the Temporal wire; on
+    this route that pointer is resolved back to inline content at the render
+    boundary, because VTRA always inlines and a client migrating off it has no
+    ``output_ref`` handling at all.
+    """
+
+    extraction: Optional[dict[str, Any]] = Field(None, title='Extraction')
+    extraction_metadata: Optional[dict[str, Any]] = Field(
+        None, title='Extraction Metadata'
+    )
+    metadata: Optional[V1ExtractMetadata] = None
+
+
+class V1AdeExtractJobsGetParametersQuery(BaseModel):
+    page: Optional[int] = Field(
+        0, description='Page number (0-indexed).', ge=0, title='Page'
+    )
+    page_size: Optional[int] = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    )
+    status: Optional[str] = Field(
+        None, description='Filter by job status.', title='Status'
+    )
+
+
+class Job1(BaseModel):
+    completed_at: Optional[str] = None
+    created_at: Optional[str] = None
+    failure_reason: Optional[str] = None
+    job_id: Optional[str] = Field(
+        None,
+        description='The unique identifier for this v1-ade-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    model_version: Optional[str] = None
+    status: Optional[Status1] = None
+
+
+class V1AdeExtractJobsGetResponse(BaseModel):
+    has_more: Optional[bool] = None
+    jobs: Optional[list[Job1]] = None
+    page: Optional[int] = None
+    page_size: Optional[int] = None
+
+
+class V1AdeExtractJobsPostRequest(BaseModel):
+    """
+    Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.
+
+    VTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline
+    string), ``markdown_url``, ``schema``, ``strict``. Nothing else — AIDE's own
+    extras (``return_reasoning``, ``fallback_model``, ``output_save_url``) stay on
+    the R&D ``/api/extract`` contract, so the customer surface publishes the VTRA
+    contract and only that.
+    """
+
+    markdown: Optional[str] = Field(None, title='Markdown')
+    markdown_url: Optional[str] = Field(None, title='Markdown Url')
+    model: Optional[str] = Field(None, title='Model')
+    schema_: Optional[str] = Field(None, alias='schema', title='Schema')
+    service_tier: Optional[ServiceTier2] = Field(
+        None,
+        description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
+    )
+    strict: Optional[bool] = Field(False, title='Strict')
+
+
+class V1AdeExtractJobsPostRequest1(BaseModel):
+    markdown: Optional[bytes] = Field(None, description='File upload.')
+    markdown_url: Optional[str] = Field(
+        None, description='JSON-serialized string in form data.', title='Markdown Url'
+    )
+    model: Optional[str] = Field(
+        None, description='JSON-serialized string in form data.', title='Model'
+    )
+    schema_: Optional[str] = Field(
+        None,
+        alias='schema',
+        description='JSON-serialized string in form data.',
+        title='Schema',
+    )
+    service_tier: Optional[ServiceTier2] = Field(
+        None,
+        description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
+    )
+    strict: Optional[bool] = Field(
+        False, description='JSON-serialized string in form data.', title='Strict'
+    )
+
+
+class V1AdeExtractJobsPostResponse(BaseModel):
+    created_at: Optional[str] = None
+    job_id: Optional[str] = Field(
+        None,
+        description='The unique identifier for this v1-ade-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    status: Optional[Status1] = None
+
+
+class Result1(BaseModel):
+    """
+    VTRA's ``ExtractResponse`` — the ``/v1/extract`` response body.
+
+    ``extraction`` is ALWAYS inline. The internal ``ExtractResult`` returns an
+    ``output_ref`` instead when the payload is too large for the Temporal wire; on
+    this route that pointer is resolved back to inline content at the render
+    boundary, because VTRA always inlines and a client migrating off it has no
+    ``output_ref`` handling at all.
+    """
+
+    extraction: Optional[dict[str, Any]] = Field(None, title='Extraction')
+    extraction_metadata: Optional[dict[str, Any]] = Field(
+        None, title='Extraction Metadata'
+    )
+    metadata: Optional[V1ExtractMetadata] = None
+
+
+class V1AdeExtractJobsJobIdGetResponse(BaseModel):
+    completed_at: Optional[str] = Field(
+        None, description='Present once the job is terminal.'
+    )
+    created_at: Optional[str] = None
+    error: Optional[Error] = Field(
+        None, description='Present once status is ``failed``.'
+    )
+    job_id: Optional[str] = Field(
+        None,
+        description='The unique identifier for this v1-ade-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    progress: Optional[float] = Field(
+        None,
+        description='Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.',
+        ge=0.0,
+        le=1.0,
+    )
+    result: Optional[Result1] = Field(
+        None, description='Present once status is ``completed``.'
+    )
+    status: Optional[Status1] = None
+
+
 class V1AdeParsePostRequest(BaseModel):
     """
     Input to ``Parse2OperationWorkflow`` (gateway) and ``Parse2DocumentWorkflow``
@@ -552,7 +1107,14 @@ class V1AdeParsePostRequest1(BaseModel):
     custom_prompts: Optional[dict[str, str]] = Field(
         None, description='JSON-serialized string in form data.', title='Custom Prompts'
     )
-    document_ref: bytes = Field(..., description='File upload.')
+    document: Optional[bytes] = Field(
+        None,
+        description='The file to process. Provide either `document` or `document_url`, not both.',
+    )
+    document_url: Optional[str] = Field(
+        None,
+        description='A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.',
+    )
     filename: str = Field(..., title='Filename')
     job_id: Optional[str] = Field(
         None, description='JSON-serialized string in form data.', title='Job Id'
@@ -596,6 +1158,7 @@ class V1AdeParsePostResponse(BaseModel):
 
     base_credit: Optional[float] = Field(0.0, title='Base Credit')
     billable_pages: Optional[int] = Field(0, title='Billable Pages')
+    billing_suppressed: Optional[bool] = Field(False, title='Billing Suppressed')
     completion_tokens: Optional[int] = Field(0, title='Completion Tokens')
     credit_usage: Optional[CreditUsage] = None
     duration_ms: Optional[int] = Field(0, title='Duration Ms')
@@ -623,14 +1186,7 @@ class V1AdeParseJobsGetParametersQuery(BaseModel):
     )
 
 
-class Status1(Enum):
-    pending = 'pending'
-    processing = 'processing'
-    completed = 'completed'
-    failed = 'failed'
-
-
-class Job(BaseModel):
+class Job2(BaseModel):
     completed_at: Optional[str] = None
     created_at: Optional[str] = None
     failure_reason: Optional[str] = None
@@ -644,18 +1200,9 @@ class Job(BaseModel):
 
 class V1AdeParseJobsGetResponse(BaseModel):
     has_more: Optional[bool] = None
-    jobs: Optional[list[Job]] = None
+    jobs: Optional[list[Job2]] = None
     page: Optional[int] = None
     page_size: Optional[int] = None
-
-
-class ServiceTier2(Enum):
-    """
-    Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.
-    """
-
-    standard = 'standard'
-    priority = 'priority'
 
 
 class V1AdeParseJobsPostRequest(BaseModel):
@@ -690,7 +1237,14 @@ class V1AdeParseJobsPostRequest1(BaseModel):
     custom_prompts: Optional[dict[str, str]] = Field(
         None, description='JSON-serialized string in form data.', title='Custom Prompts'
     )
-    document_ref: bytes = Field(..., description='File upload.')
+    document: Optional[bytes] = Field(
+        None,
+        description='The file to process. Provide either `document` or `document_url`, not both.',
+    )
+    document_url: Optional[str] = Field(
+        None,
+        description='A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.',
+    )
     filename: str = Field(..., title='Filename')
     job_id: Optional[str] = Field(
         None, description='JSON-serialized string in form data.', title='Job Id'
@@ -736,18 +1290,7 @@ class V1AdeParseJobsPostResponse(BaseModel):
     status: Optional[Status1] = None
 
 
-class Error(BaseModel):
-    """
-    Present once status is ``failed``.
-    """
-
-    code: Optional[str] = Field(
-        None, description='Stable error code (``internal_error`` when unmapped).'
-    )
-    message: Optional[str] = None
-
-
-class Result(BaseModel):
+class Result2(BaseModel):
     """
     Output of ``Parse2DocumentWorkflow``. Carries the customer response plus the
     billing inputs hoisted to the top level so the gateway operation reads them
@@ -763,6 +1306,7 @@ class Result(BaseModel):
 
     base_credit: Optional[float] = Field(0.0, title='Base Credit')
     billable_pages: Optional[int] = Field(0, title='Billable Pages')
+    billing_suppressed: Optional[bool] = Field(False, title='Billing Suppressed')
     completion_tokens: Optional[int] = Field(0, title='Completion Tokens')
     credit_usage: Optional[CreditUsage] = None
     duration_ms: Optional[int] = Field(0, title='Duration Ms')
@@ -804,66 +1348,205 @@ class V1AdeParseJobsJobIdGetResponse(BaseModel):
         ge=0.0,
         le=1.0,
     )
-    result: Optional[Result] = Field(
+    result: Optional[Result2] = Field(
         None,
         description='Present once status is ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead.',
     )
     status: Optional[Status1] = None
 
 
-class V1ExtractPostRequest(BaseModel):
+class V1ClassifyPostRequest(BaseModel):
     """
-    Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.
-
-    VTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline
-    string), ``markdown_url``, ``schema``, ``strict``. Nothing else — AIDE's own
-    extras (``return_reasoning``, ``fallback_model``, ``output_save_url``) stay on
-    the R&D ``/api/extract`` contract, so the customer surface publishes the VTRA
-    contract and only that.
+    Input to ``V1ClassifyOperationWorkflow`` (gateway) and, threaded
+    unchanged, to ``ClassifyWorkflow`` (work) — the ``/v1/classify`` request
+    body. Mirrors VTRA's ``ClassifyRequest``.
     """
 
-    markdown: Optional[str] = Field(None, title='Markdown')
-    markdown_url: Optional[str] = Field(None, title='Markdown Url')
-    model: Optional[str] = Field(None, title='Model')
-    schema_: Optional[str] = Field(None, alias='schema', title='Schema')
-    strict: Optional[bool] = Field(False, title='Strict')
-
-
-class V1ExtractPostRequest1(BaseModel):
-    markdown: Optional[bytes] = Field(None, description='File upload.')
-    markdown_url: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='Markdown Url'
+    classes: list[ClassifyClass] = Field(
+        ...,
+        description="The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string.",
+        title='Classes',
     )
+    content_type: Optional[str] = Field('', title='Content Type')
+    document_ref: str = Field(..., title='Document Ref')
+    filename: Optional[str] = Field('', title='Filename')
     model: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='Model'
-    )
-    schema_: Optional[str] = Field(
         None,
-        alias='schema',
-        description='JSON-serialized string in form data.',
-        title='Schema',
-    )
-    strict: Optional[bool] = Field(
-        False, description='JSON-serialized string in form data.', title='Strict'
+        description='Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version.',
+        title='Model',
     )
 
 
-class V1ExtractPostResponse(BaseModel):
+class V1ClassifyPostRequest1(BaseModel):
+    classes: list[ClassifyClass] = Field(
+        ...,
+        description="The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string. JSON-serialized string in form data.",
+        title='Classes',
+    )
+    content_type: Optional[str] = Field('', title='Content Type')
+    document: Optional[bytes] = Field(
+        None,
+        description='The file to process. Provide either `document` or `document_url`, not both.',
+    )
+    document_url: Optional[str] = Field(
+        None,
+        description='A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.',
+    )
+    filename: Optional[str] = Field('', title='Filename')
+    model: Optional[str] = Field(
+        None,
+        description='Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version. JSON-serialized string in form data.',
+        title='Model',
+    )
+
+
+class V1ClassifyPostResponse(BaseModel):
     """
-    VTRA's ``ExtractResponse`` — the ``/v1/extract`` response body.
-
-    ``extraction`` is ALWAYS inline. The internal ``ExtractResult`` returns an
-    ``output_ref`` instead when the payload is too large for the Temporal wire; on
-    this route that pointer is resolved back to inline content at the render
-    boundary, because VTRA always inlines and a client migrating off it has no
-    ``output_ref`` handling at all.
+    Result returned by ``V1ClassifyOperationWorkflow`` — the
+    ``/v1/classify`` response body (VTRA's ``ClassifyResponse``).
     """
 
-    extraction: Optional[dict[str, Any]] = Field(None, title='Extraction')
-    extraction_metadata: Optional[dict[str, Any]] = Field(
-        None, title='Extraction Metadata'
+    classification: list[ClassificationItem] = Field(
+        ...,
+        description='One classification result per page, in page order.',
+        title='Classification',
     )
-    metadata: Optional[V1ExtractMetadata] = None
+    metadata: V1ClassifyMetadata = Field(
+        ..., description='Metadata for the classification request.'
+    )
+
+
+class V1ClassifyJobsGetParametersQuery(BaseModel):
+    page: Optional[int] = Field(
+        0, description='Page number (0-indexed).', ge=0, title='Page'
+    )
+    page_size: Optional[int] = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    )
+    status: Optional[str] = Field(
+        None, description='Filter by job status.', title='Status'
+    )
+
+
+class Job3(BaseModel):
+    completed_at: Optional[str] = None
+    created_at: Optional[str] = None
+    failure_reason: Optional[str] = None
+    job_id: Optional[str] = Field(
+        None,
+        description='The unique identifier for this classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    model_version: Optional[str] = None
+    status: Optional[Status1] = None
+
+
+class V1ClassifyJobsGetResponse(BaseModel):
+    has_more: Optional[bool] = None
+    jobs: Optional[list[Job3]] = None
+    page: Optional[int] = None
+    page_size: Optional[int] = None
+
+
+class V1ClassifyJobsPostRequest(BaseModel):
+    """
+    Input to ``V1ClassifyOperationWorkflow`` (gateway) and, threaded
+    unchanged, to ``ClassifyWorkflow`` (work) — the ``/v1/classify`` request
+    body. Mirrors VTRA's ``ClassifyRequest``.
+    """
+
+    classes: list[ClassifyClass] = Field(
+        ...,
+        description="The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string.",
+        title='Classes',
+    )
+    content_type: Optional[str] = Field('', title='Content Type')
+    document_ref: str = Field(..., title='Document Ref')
+    filename: Optional[str] = Field('', title='Filename')
+    model: Optional[str] = Field(
+        None,
+        description='Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version.',
+        title='Model',
+    )
+    service_tier: Optional[ServiceTier2] = Field(
+        None,
+        description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
+    )
+
+
+class V1ClassifyJobsPostRequest1(BaseModel):
+    classes: list[ClassifyClass] = Field(
+        ...,
+        description="The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string. JSON-serialized string in form data.",
+        title='Classes',
+    )
+    content_type: Optional[str] = Field('', title='Content Type')
+    document: Optional[bytes] = Field(
+        None,
+        description='The file to process. Provide either `document` or `document_url`, not both.',
+    )
+    document_url: Optional[str] = Field(
+        None,
+        description='A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.',
+    )
+    filename: Optional[str] = Field('', title='Filename')
+    model: Optional[str] = Field(
+        None,
+        description='Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version. JSON-serialized string in form data.',
+        title='Model',
+    )
+    service_tier: Optional[ServiceTier2] = Field(
+        None,
+        description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
+    )
+
+
+class V1ClassifyJobsPostResponse(BaseModel):
+    created_at: Optional[str] = None
+    job_id: Optional[str] = Field(
+        None,
+        description='The unique identifier for this classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    status: Optional[Status1] = None
+
+
+class Result3(BaseModel):
+    """
+    Result returned by ``V1ClassifyOperationWorkflow`` — the
+    ``/v1/classify`` response body (VTRA's ``ClassifyResponse``).
+    """
+
+    classification: list[ClassificationItem] = Field(
+        ...,
+        description='One classification result per page, in page order.',
+        title='Classification',
+    )
+    metadata: V1ClassifyMetadata = Field(
+        ..., description='Metadata for the classification request.'
+    )
+
+
+class V1ClassifyJobsJobIdGetResponse(BaseModel):
+    completed_at: Optional[str] = Field(
+        None, description='Present once the job is terminal.'
+    )
+    created_at: Optional[str] = None
+    error: Optional[Error] = Field(
+        None, description='Present once status is ``failed``.'
+    )
+    job_id: Optional[str] = Field(
+        None,
+        description='The unique identifier for this classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+    )
+    progress: Optional[float] = Field(
+        None,
+        description='Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.',
+        ge=0.0,
+        le=1.0,
+    )
+    result: Optional[Result3] = Field(
+        None, description='Present once status is ``completed``.'
+    )
+    status: Optional[Status1] = None
 
 
 class V1ExtractBuildSchemaPostRequest(BaseModel):
@@ -975,7 +1658,7 @@ class V1ExtractBuildSchemaJobsGetParametersQuery(BaseModel):
     )
 
 
-class Job1(BaseModel):
+class Job4(BaseModel):
     completed_at: Optional[str] = None
     created_at: Optional[str] = None
     failure_reason: Optional[str] = None
@@ -989,7 +1672,7 @@ class Job1(BaseModel):
 
 class V1ExtractBuildSchemaJobsGetResponse(BaseModel):
     has_more: Optional[bool] = None
-    jobs: Optional[list[Job1]] = None
+    jobs: Optional[list[Job4]] = None
     page: Optional[int] = None
     page_size: Optional[int] = None
 
@@ -1090,7 +1773,7 @@ class V1ExtractBuildSchemaJobsPostResponse(BaseModel):
     status: Optional[Status1] = None
 
 
-class Result1(BaseModel):
+class Result4(BaseModel):
     """
     Result of a **v1** build-schema call — VTRA's ``BuildSchemaResponse``.
 
@@ -1126,396 +1809,29 @@ class V1ExtractBuildSchemaJobsJobIdGetResponse(BaseModel):
         ge=0.0,
         le=1.0,
     )
-    result: Optional[Result1] = Field(
+    result: Optional[Result4] = Field(
         None, description='Present once status is ``completed``.'
     )
     status: Optional[Status1] = None
 
 
-class V1ExtractJobsGetParametersQuery(BaseModel):
-    page: Optional[int] = Field(
-        0, description='Page number (0-indexed).', ge=0, title='Page'
-    )
-    page_size: Optional[int] = Field(
-        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
-    )
-    status: Optional[str] = Field(
-        None, description='Filter by job status.', title='Status'
-    )
-
-
-class Job2(BaseModel):
-    completed_at: Optional[str] = None
-    created_at: Optional[str] = None
-    failure_reason: Optional[str] = None
-    job_id: Optional[str] = Field(
+class V1SplitPostRequest(BaseModel):
+    markdown: Optional[Union[bytes, str]] = Field(
         None,
-        description='The unique identifier for this v1-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
+        description='Markdown content to split, as an inline string or an uploaded file. Provide either `markdown` or `markdown_url`, not both.',
     )
-    model_version: Optional[str] = None
-    status: Optional[Status1] = None
-
-
-class V1ExtractJobsGetResponse(BaseModel):
-    has_more: Optional[bool] = None
-    jobs: Optional[list[Job2]] = None
-    page: Optional[int] = None
-    page_size: Optional[int] = None
-
-
-class V1ExtractJobsPostRequest(BaseModel):
-    """
-    Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.
-
-    VTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline
-    string), ``markdown_url``, ``schema``, ``strict``. Nothing else — AIDE's own
-    extras (``return_reasoning``, ``fallback_model``, ``output_save_url``) stay on
-    the R&D ``/api/extract`` contract, so the customer surface publishes the VTRA
-    contract and only that.
-    """
-
-    markdown: Optional[str] = Field(None, title='Markdown')
-    markdown_url: Optional[str] = Field(None, title='Markdown Url')
-    model: Optional[str] = Field(None, title='Model')
-    schema_: Optional[str] = Field(None, alias='schema', title='Schema')
-    service_tier: Optional[ServiceTier2] = Field(
-        None,
-        description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
-    )
-    strict: Optional[bool] = Field(False, title='Strict')
-
-
-class V1ExtractJobsPostRequest1(BaseModel):
-    markdown: Optional[bytes] = Field(None, description='File upload.')
     markdown_url: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='Markdown Url'
+        None,
+        description='A publicly accessible URL to the Markdown file to split. Provide either `markdown` or `markdown_url`, not both.',
     )
     model: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='Model'
-    )
-    schema_: Optional[str] = Field(
         None,
-        alias='schema',
-        description='JSON-serialized string in form data.',
-        title='Schema',
+        description='The split model version to use. Accepts a dated snapshot (`split-20251105`), `split-latest`, or `split` (both aliases resolve to the latest snapshot). Defaults to the latest snapshot. The resolved version is echoed back as `metadata.version`.',
     )
-    service_tier: Optional[ServiceTier2] = Field(
-        None,
-        description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
+    split_class: str = Field(
+        ...,
+        description='The split classification entries, as a JSON-encoded array of objects with `name` (required), `description`, and `identifier` keys. At most 19 entries. Sent as a JSON-serialized string in form data.',
     )
-    strict: Optional[bool] = Field(
-        False, description='JSON-serialized string in form data.', title='Strict'
-    )
-
-
-class V1ExtractJobsPostResponse(BaseModel):
-    created_at: Optional[str] = None
-    job_id: Optional[str] = Field(
-        None,
-        description='The unique identifier for this v1-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
-    )
-    status: Optional[Status1] = None
-
-
-class Result2(BaseModel):
-    """
-    VTRA's ``ExtractResponse`` — the ``/v1/extract`` response body.
-
-    ``extraction`` is ALWAYS inline. The internal ``ExtractResult`` returns an
-    ``output_ref`` instead when the payload is too large for the Temporal wire; on
-    this route that pointer is resolved back to inline content at the render
-    boundary, because VTRA always inlines and a client migrating off it has no
-    ``output_ref`` handling at all.
-    """
-
-    extraction: Optional[dict[str, Any]] = Field(None, title='Extraction')
-    extraction_metadata: Optional[dict[str, Any]] = Field(
-        None, title='Extraction Metadata'
-    )
-    metadata: Optional[V1ExtractMetadata] = None
-
-
-class V1ExtractJobsJobIdGetResponse(BaseModel):
-    completed_at: Optional[str] = Field(
-        None, description='Present once the job is terminal.'
-    )
-    created_at: Optional[str] = None
-    error: Optional[Error] = Field(
-        None, description='Present once status is ``failed``.'
-    )
-    job_id: Optional[str] = Field(
-        None,
-        description='The unique identifier for this v1-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
-    )
-    progress: Optional[float] = Field(
-        None,
-        description='Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.',
-        ge=0.0,
-        le=1.0,
-    )
-    result: Optional[Result2] = Field(
-        None, description='Present once status is ``completed``.'
-    )
-    status: Optional[Status1] = None
-
-
-class V1ParsePostRequest(BaseModel):
-    """
-    Input to ``Parse2OperationWorkflow`` (gateway) and ``Parse2DocumentWorkflow``
-    (work). The document rides as ``document_ref`` (the gateway's multipart adapter
-    stages the upload / fetches ``document_url`` → data store, runs the pdf_pages
-    pre-flight, then starts the operation).
-    """
-
-    content_type: str = Field(..., title='Content Type')
-    custom_prompts: Optional[dict[str, str]] = Field(None, title='Custom Prompts')
-    document_ref: str = Field(..., title='Document Ref')
-    filename: str = Field(..., title='Filename')
-    job_id: Optional[str] = Field(None, title='Job Id')
-    model_versions: Optional[dict[str, str]] = Field(None, title='Model Versions')
-    password: Optional[str] = Field(None, title='Password')
-    pricing_multiplier: Optional[float] = Field(1.0, title='Pricing Multiplier')
-    processing_mode: Optional[str] = Field('sync', title='Processing Mode')
-    split: Optional[str] = Field(None, title='Split')
-    version: Optional[str] = Field(None, title='Version')
-    x_request_id: Optional[str] = Field(None, title='X Request Id')
-
-
-class V1ParsePostRequest1(BaseModel):
-    content_type: str = Field(..., title='Content Type')
-    custom_prompts: Optional[dict[str, str]] = Field(
-        None, description='JSON-serialized string in form data.', title='Custom Prompts'
-    )
-    document_ref: bytes = Field(..., description='File upload.')
-    filename: str = Field(..., title='Filename')
-    job_id: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='Job Id'
-    )
-    model_versions: Optional[dict[str, str]] = Field(
-        None, description='JSON-serialized string in form data.', title='Model Versions'
-    )
-    password: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='Password'
-    )
-    pricing_multiplier: Optional[float] = Field(
-        1.0,
-        description='JSON-serialized string in form data.',
-        title='Pricing Multiplier',
-    )
-    processing_mode: Optional[str] = Field('sync', title='Processing Mode')
-    split: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='Split'
-    )
-    version: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='Version'
-    )
-    x_request_id: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='X Request Id'
-    )
-
-
-class V1ParsePostResponse(BaseModel):
-    """
-    Output of ``Parse2DocumentWorkflow``. Carries the customer response plus the
-    billing inputs hoisted to the top level so the gateway operation reads them
-    without re-parsing the nested tree.
-
-    Billing is worker-owned (parse-api parity): the worker finalizes the price and
-    reports it on the standard ``credit_usage: CreditUsage`` shape (``credits`` =
-    FINAL billed value, ``charge_unit`` = billable pages, ``breakdown`` = itemized),
-    plus the record-inference enrichment (``usage`` + ``model_family``). The
-    gateway's default biller reads ``credit_usage`` verbatim (a ``JobContract.billed()``
-    op — no gateway recomputation).
-    """
-
-    base_credit: Optional[float] = Field(0.0, title='Base Credit')
-    billable_pages: Optional[int] = Field(0, title='Billable Pages')
-    completion_tokens: Optional[int] = Field(0, title='Completion Tokens')
-    credit_usage: Optional[CreditUsage] = None
-    duration_ms: Optional[int] = Field(0, title='Duration Ms')
-    failed_pages: Optional[list[int]] = Field(None, title='Failed Pages')
-    model_family: Optional[str] = Field(None, title='Model Family')
-    output_ref: Optional[str] = Field(None, title='Output Ref')
-    page_count: Optional[int] = Field(0, title='Page Count')
-    prompt_tokens: Optional[int] = Field(0, title='Prompt Tokens')
-    response: dict[str, Any] = Field(..., title='Response')
-    status_code: Optional[int] = Field(200, title='Status Code')
-    token_steps: Optional[list[dict[str, Any]]] = Field(None, title='Token Steps')
-    total_tokens: Optional[int] = Field(0, title='Total Tokens')
-    usage: Optional[dict[str, Any]] = Field(None, title='Usage')
-
-
-class V1ParseJobsGetParametersQuery(BaseModel):
-    page: Optional[int] = Field(
-        0, description='Page number (0-indexed).', ge=0, title='Page'
-    )
-    page_size: Optional[int] = Field(
-        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
-    )
-    status: Optional[str] = Field(
-        None, description='Filter by job status.', title='Status'
-    )
-
-
-class Job3(BaseModel):
-    completed_at: Optional[str] = None
-    created_at: Optional[str] = None
-    failure_reason: Optional[str] = None
-    job_id: Optional[str] = Field(
-        None,
-        description='The unique identifier for this parse2 job. Format: ``parse2-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
-    )
-    model_version: Optional[str] = None
-    status: Optional[Status1] = None
-
-
-class V1ParseJobsGetResponse(BaseModel):
-    has_more: Optional[bool] = None
-    jobs: Optional[list[Job3]] = None
-    page: Optional[int] = None
-    page_size: Optional[int] = None
-
-
-class V1ParseJobsPostRequest(BaseModel):
-    """
-    Input to ``Parse2OperationWorkflow`` (gateway) and ``Parse2DocumentWorkflow``
-    (work). The document rides as ``document_ref`` (the gateway's multipart adapter
-    stages the upload / fetches ``document_url`` → data store, runs the pdf_pages
-    pre-flight, then starts the operation).
-    """
-
-    content_type: str = Field(..., title='Content Type')
-    custom_prompts: Optional[dict[str, str]] = Field(None, title='Custom Prompts')
-    document_ref: str = Field(..., title='Document Ref')
-    filename: str = Field(..., title='Filename')
-    job_id: Optional[str] = Field(None, title='Job Id')
-    model_versions: Optional[dict[str, str]] = Field(None, title='Model Versions')
-    output_save_url: Optional[str] = Field(None, title='Output Save Url')
-    password: Optional[str] = Field(None, title='Password')
-    pricing_multiplier: Optional[float] = Field(1.0, title='Pricing Multiplier')
-    processing_mode: Optional[str] = Field('sync', title='Processing Mode')
-    service_tier: Optional[ServiceTier2] = Field(
-        None,
-        description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
-    )
-    split: Optional[str] = Field(None, title='Split')
-    version: Optional[str] = Field(None, title='Version')
-    x_request_id: Optional[str] = Field(None, title='X Request Id')
-
-
-class V1ParseJobsPostRequest1(BaseModel):
-    content_type: str = Field(..., title='Content Type')
-    custom_prompts: Optional[dict[str, str]] = Field(
-        None, description='JSON-serialized string in form data.', title='Custom Prompts'
-    )
-    document_ref: bytes = Field(..., description='File upload.')
-    filename: str = Field(..., title='Filename')
-    job_id: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='Job Id'
-    )
-    model_versions: Optional[dict[str, str]] = Field(
-        None, description='JSON-serialized string in form data.', title='Model Versions'
-    )
-    output_save_url: Optional[str] = Field(
-        None,
-        description='JSON-serialized string in form data.',
-        title='Output Save Url',
-    )
-    password: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='Password'
-    )
-    pricing_multiplier: Optional[float] = Field(
-        1.0,
-        description='JSON-serialized string in form data.',
-        title='Pricing Multiplier',
-    )
-    processing_mode: Optional[str] = Field('sync', title='Processing Mode')
-    service_tier: Optional[ServiceTier2] = Field(
-        None,
-        description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
-    )
-    split: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='Split'
-    )
-    version: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='Version'
-    )
-    x_request_id: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='X Request Id'
-    )
-
-
-class V1ParseJobsPostResponse(BaseModel):
-    created_at: Optional[str] = None
-    job_id: Optional[str] = Field(
-        None,
-        description='The unique identifier for this parse2 job. Format: ``parse2-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
-    )
-    status: Optional[Status1] = None
-
-
-class Result3(BaseModel):
-    """
-    Output of ``Parse2DocumentWorkflow``. Carries the customer response plus the
-    billing inputs hoisted to the top level so the gateway operation reads them
-    without re-parsing the nested tree.
-
-    Billing is worker-owned (parse-api parity): the worker finalizes the price and
-    reports it on the standard ``credit_usage: CreditUsage`` shape (``credits`` =
-    FINAL billed value, ``charge_unit`` = billable pages, ``breakdown`` = itemized),
-    plus the record-inference enrichment (``usage`` + ``model_family``). The
-    gateway's default biller reads ``credit_usage`` verbatim (a ``JobContract.billed()``
-    op — no gateway recomputation).
-    """
-
-    base_credit: Optional[float] = Field(0.0, title='Base Credit')
-    billable_pages: Optional[int] = Field(0, title='Billable Pages')
-    completion_tokens: Optional[int] = Field(0, title='Completion Tokens')
-    credit_usage: Optional[CreditUsage] = None
-    duration_ms: Optional[int] = Field(0, title='Duration Ms')
-    failed_pages: Optional[list[int]] = Field(None, title='Failed Pages')
-    model_family: Optional[str] = Field(None, title='Model Family')
-    output_ref: Optional[str] = Field(None, title='Output Ref')
-    page_count: Optional[int] = Field(0, title='Page Count')
-    prompt_tokens: Optional[int] = Field(0, title='Prompt Tokens')
-    response: dict[str, Any] = Field(..., title='Response')
-    status_code: Optional[int] = Field(200, title='Status Code')
-    token_steps: Optional[list[dict[str, Any]]] = Field(None, title='Token Steps')
-    total_tokens: Optional[int] = Field(0, title='Total Tokens')
-    usage: Optional[dict[str, Any]] = Field(None, title='Usage')
-
-
-class V1ParseJobsJobIdGetResponse(BaseModel):
-    completed_at: Optional[str] = Field(
-        None, description='Present once the job is terminal.'
-    )
-    created_at: Optional[str] = None
-    error: Optional[Error] = Field(
-        None, description='Present once status is ``failed``.'
-    )
-    job_id: Optional[str] = Field(
-        None,
-        description='The unique identifier for this parse2 job. Format: ``parse2-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
-    )
-    metadata: Optional[dict[str, Any]] = Field(
-        None,
-        description="The result's metadata block (billing included), present alongside ``output_url`` once a job with ``output_save_url`` has ``completed`` — the delivery moves the content, not the receipt. Same shape as the inline ``result``'s ``metadata``; inline jobs carry it there instead.",
-    )
-    output_url: Optional[str] = Field(
-        None,
-        description='The URL the result was delivered to. Present once the job has ``completed`` and ``output_save_url`` was set, instead of inline ``result``.',
-    )
-    progress: Optional[float] = Field(
-        None,
-        description='Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.',
-        ge=0.0,
-        le=1.0,
-    )
-    result: Optional[Result3] = Field(
-        None,
-        description='Present once status is ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead.',
-    )
-    status: Optional[Status1] = None
 
 
 class V2ExtractPostRequest(BaseModel):
@@ -1645,7 +1961,7 @@ class V2ExtractJobsGetParametersQuery(BaseModel):
     )
 
 
-class Job4(BaseModel):
+class Job5(BaseModel):
     completed_at: Optional[str] = None
     created_at: Optional[str] = None
     failure_reason: Optional[str] = None
@@ -1659,7 +1975,7 @@ class Job4(BaseModel):
 
 class V2ExtractJobsGetResponse(BaseModel):
     has_more: Optional[bool] = None
-    jobs: Optional[list[Job4]] = None
+    jobs: Optional[list[Job5]] = None
     page: Optional[int] = None
     page_size: Optional[int] = None
 
@@ -1769,7 +2085,7 @@ class V2ExtractJobsPostResponse(BaseModel):
     status: Optional[Status1] = None
 
 
-class Result4(BaseModel):
+class Result5(BaseModel):
     """
     Result returned by V2ExtractOperationWorkflow — the ``/v2/extract``
     response body (``docs/extract-v2-contract.md`` → Response).
@@ -1832,7 +2148,7 @@ class V2ExtractJobsJobIdGetResponse(BaseModel):
         ge=0.0,
         le=1.0,
     )
-    result: Optional[Result4] = Field(
+    result: Optional[Result5] = Field(
         None,
         description='Present once status is ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead.',
     )
@@ -1948,7 +2264,7 @@ class V2ParseJobsGetParametersQuery(BaseModel):
     )
 
 
-class Status16(Enum):
+class Status19(Enum):
     """
     The job's current status: ``pending``, ``processing``, ``completed``, or ``failed``.
     """
@@ -1959,7 +2275,7 @@ class Status16(Enum):
     failed = 'failed'
 
 
-class Job5(BaseModel):
+class Job6(BaseModel):
     completed_at: Optional[str] = Field(
         None, description='ISO-8601 timestamp for when the job finished, if terminal.'
     )
@@ -1977,7 +2293,7 @@ class Job5(BaseModel):
     model_version: Optional[str] = Field(
         None, description='The model snapshot used to parse the document.'
     )
-    status: Optional[Status16] = Field(
+    status: Optional[Status19] = Field(
         None,
         description="The job's current status: ``pending``, ``processing``, ``completed``, or ``failed``.",
     )
@@ -1988,14 +2304,14 @@ class V2ParseJobsGetResponse(BaseModel):
         None,
         description='Whether more jobs exist beyond this page; request the next ``page`` to fetch them.',
     )
-    jobs: Optional[list[Job5]] = Field(
+    jobs: Optional[list[Job6]] = Field(
         None, description="The caller's parse jobs for this page, newest first."
     )
     page: Optional[int] = Field(None, description='The 0-indexed page number.')
     page_size: Optional[int] = Field(None, description='Items per page.')
 
 
-class ServiceTier12(Enum):
+class ServiceTier14(Enum):
     """
     Async service tier (``POST /jobs`` only). ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.
     """
@@ -2004,7 +2320,7 @@ class ServiceTier12(Enum):
     priority = 'priority'
 
 
-class Status17(Enum):
+class Status20(Enum):
     """
     The job's status at creation — normally ``pending`` (a just-created job that is still running is reported as ``pending``), but may already be a terminal ``completed`` / ``failed`` if the job finished before the create response was rendered.
     """
@@ -2023,13 +2339,13 @@ class V2ParseJobsPostResponse(BaseModel):
         ...,
         description='The unique identifier for the created parse job. Poll ``GET /v2/parse/jobs/{job_id}`` for its status and result. Format: ``<service>-<26-character Crockford base32 ULID>`` matching ``^(parse|extract)-[0-9a-hjkmnp-tv-z]{26}$``. Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
-    status: Status17 = Field(
+    status: Status20 = Field(
         ...,
         description="The job's status at creation — normally ``pending`` (a just-created job that is still running is reported as ``pending``), but may already be a terminal ``completed`` / ``failed`` if the job finished before the create response was rendered.",
     )
 
 
-class Error5(BaseModel):
+class Error6(BaseModel):
     """
     Present once the job has ``failed`` — the failure code + message.
     """
@@ -2038,7 +2354,7 @@ class Error5(BaseModel):
     message: Optional[str] = None
 
 
-class Status18(Enum):
+class Status21(Enum):
     """
     The job's current status: ``pending``, ``processing``, ``completed``, or ``failed``.
     """
@@ -2097,14 +2413,14 @@ class V2WorkflowJobsGetParametersQuery(BaseModel):
     )
 
 
-class Status19(Enum):
+class Status22(Enum):
     pending = 'pending'
     processing = 'processing'
     completed = 'completed'
     failed = 'failed'
 
 
-class Job6(BaseModel):
+class Job7(BaseModel):
     completed_at: Optional[str] = None
     created_at: Optional[str] = None
     failure_reason: Optional[str] = None
@@ -2113,17 +2429,17 @@ class Job6(BaseModel):
         description='The unique identifier for this v2-workflow job. Format: ``v2-workflow-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
     model_version: Optional[str] = None
-    status: Optional[Status19] = None
+    status: Optional[Status22] = None
 
 
 class V2WorkflowJobsGetResponse(BaseModel):
     has_more: Optional[bool] = None
-    jobs: Optional[list[Job6]] = None
+    jobs: Optional[list[Job7]] = None
     page: Optional[int] = None
     page_size: Optional[int] = None
 
 
-class ServiceTier13(Enum):
+class ServiceTier15(Enum):
     """
     Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.
     """
@@ -2138,10 +2454,10 @@ class V2WorkflowJobsPostResponse(BaseModel):
         None,
         description='The unique identifier for this v2-workflow job. Format: ``v2-workflow-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
-    status: Optional[Status19] = None
+    status: Optional[Status22] = None
 
 
-class Error6(BaseModel):
+class Error7(BaseModel):
     """
     Present once status is ``failed``.
     """
@@ -2152,7 +2468,7 @@ class Error6(BaseModel):
     message: Optional[str] = None
 
 
-class Result5(BaseModel):
+class Result6(BaseModel):
     """
     Result returned by V2WorkflowOperationWorkflow.
 
@@ -2193,7 +2509,7 @@ class V2WorkflowJobsJobIdGetResponse(BaseModel):
         None, description='Present once the job is terminal.'
     )
     created_at: Optional[str] = None
-    error: Optional[Error6] = Field(
+    error: Optional[Error7] = Field(
         None, description='Present once status is ``failed``.'
     )
     job_id: Optional[str] = Field(
@@ -2206,10 +2522,10 @@ class V2WorkflowJobsJobIdGetResponse(BaseModel):
         ge=0.0,
         le=1.0,
     )
-    result: Optional[Result5] = Field(
+    result: Optional[Result6] = Field(
         None, description='Present once status is ``completed``.'
     )
-    status: Optional[Status19] = None
+    status: Optional[Status22] = None
 
 
 class BlocksOptions(BaseModel):
@@ -2309,7 +2625,7 @@ class Options(BaseModel):
     pages: Optional[list[int]] = Field(None, title='Pages')
     password: Optional[str] = Field(
         None,
-        description='Password for encrypted PDFs. Not currently supported — providing a value returns a 422 error; decrypt the file before uploading.',
+        description='Password for an encrypted PDF. The document is decrypted once at the start of processing; the password is not retained with the result. PDFs only — supplying one for an image or Office document returns a 422 (`password_unsupported_content_type`). A wrong password returns a 422 (`encrypted_pdf_wrong_password`); omitting it for a locked PDF returns a 422 (`encrypted_pdf_password_required`).',
         title='Password',
     )
 
@@ -2356,7 +2672,7 @@ class V2ParseJobsPostRequest(BaseModel):
         None,
         description="Public URL the full response is delivered to; the API response then carries ``output_url`` instead of inline data. A presigned URL must stay valid until the job COMPLETES, not just past submit: an already-expired URL, or one whose remaining validity is too short for the document's page count, is rejected at submit (422). By default the URL must retain at least 15 minutes of validity at submit, plus 3 seconds per document page; the 422 message names the exact window required. Sign with credentials that outlive the expected job duration — a URL signed with temporary (assumed-role/session) credentials dies when that session expires, regardless of the URL's stated expiry.",
     )
-    service_tier: Optional[ServiceTier12] = Field(
+    service_tier: Optional[ServiceTier14] = Field(
         None,
         description='Async service tier (``POST /jobs`` only). ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
     )
@@ -2506,7 +2822,7 @@ class V2WorkflowJobsPostRequest(BaseModel):
         ],
         title='Output',
     )
-    service_tier: Optional[ServiceTier13] = Field(
+    service_tier: Optional[ServiceTier15] = Field(
         None,
         description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
     )
@@ -2547,7 +2863,7 @@ class V2WorkflowJobsPostRequest1(BaseModel):
         ],
         title='Output',
     )
-    service_tier: Optional[ServiceTier13] = Field(
+    service_tier: Optional[ServiceTier15] = Field(
         None,
         description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
     )
@@ -2708,7 +3024,7 @@ class V2ParseJobsJobIdGetResponse(BaseModel):
     created_at: Optional[str] = Field(
         None, description='ISO-8601 timestamp for when the job was created.'
     )
-    error: Optional[Error5] = Field(
+    error: Optional[Error6] = Field(
         None,
         description='Present once the job has ``failed`` — the failure code + message.',
     )
@@ -2732,7 +3048,7 @@ class V2ParseJobsJobIdGetResponse(BaseModel):
         None,
         description='The parse response, present once the job has ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead.',
     )
-    status: Optional[Status18] = Field(
+    status: Optional[Status21] = Field(
         None,
         description="The job's current status: ``pending``, ``processing``, ``completed``, or ``failed``.",
     )

--- a/specs/v2-aide.json
+++ b/specs/v2-aide.json
@@ -98,6 +98,34 @@
         "title": "BuildSchemaWarning",
         "type": "object"
       },
+      "ClassifyClass": {
+        "description": "One classification option: a class name plus an optional description.\n\nWire key ``class`` (VTRA's ``ClassifyClass``); the field is ``class_name``\nbecause ``class`` is a Python keyword, with the alias carrying the wire\nname. ``populate_by_name`` lets the Temporal round-trip (which serializes by\nFIELD name) rebuild the object on the worker side.",
+        "properties": {
+          "class": {
+            "description": "Class name assigned to a page when it matches.",
+            "title": "Class",
+            "type": "string"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "What this class represents. Improves classification.",
+            "title": "Description"
+          }
+        },
+        "required": [
+          "class"
+        ],
+        "title": "ClassifyClass",
+        "type": "object"
+      },
       "CreditUsage": {
         "description": "The standard credit-usage shape a billable WORK result carries.\n\nA billed passthrough operation's work result declares\n``credit_usage: CreditUsage`` and the gateway's default\n``build_success_record`` bills it verbatim — no per-op billing code\n(operations/base.py requires it: a result carrying anything else raises).\n\nStdlib result modules embedding CreditUsage should follow the pdf.py posture\n(no ``from __future__ import annotations``) or use pydantic dataclasses (the\nextract_v2 posture).",
         "properties": {
@@ -675,6 +703,133 @@
         "title": "Range",
         "type": "object"
       },
+      "Split": {
+        "description": "One split segment: consecutive pages of one classification (an\nidentifier change starts a new segment).",
+        "properties": {
+          "classification": {
+            "description": "The split classification name this segment was assigned.",
+            "title": "Classification",
+            "type": "string"
+          },
+          "identifier": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The identifier value extracted for this segment, when the matching split classification requested one. Null otherwise.",
+            "title": "Identifier"
+          },
+          "markdowns": {
+            "description": "The Markdown content of each page in this segment, in order.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Markdowns",
+            "type": "array"
+          },
+          "pages": {
+            "description": "0-indexed page numbers belonging to this segment, in order.",
+            "items": {
+              "type": "integer"
+            },
+            "title": "Pages",
+            "type": "array"
+          }
+        },
+        "required": [
+          "classification",
+          "identifier",
+          "pages",
+          "markdowns"
+        ],
+        "title": "Split",
+        "type": "object"
+      },
+      "SplitMetadata": {
+        "description": "Information about a split request.",
+        "properties": {
+          "credit_usage": {
+            "description": "Credits consumed by this request: the input Markdown length in characters divided by 5000. Billed usage rounds this up to the next 0.1 credit.",
+            "title": "Credit Usage",
+            "type": "number"
+          },
+          "duration_ms": {
+            "description": "Total processing time in milliseconds.",
+            "title": "Duration Ms",
+            "type": "integer"
+          },
+          "filename": {
+            "description": "Display name of the split document: the URL path's file name for `markdown_url` inputs, or a generated name for inline and uploaded Markdown.",
+            "title": "Filename",
+            "type": "string"
+          },
+          "job_id": {
+            "description": "The split job identifier — server-minted and unique per request. Correlates with the request's entry in your billing dashboard.",
+            "title": "Job Id",
+            "type": "string"
+          },
+          "org_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Organization ID.",
+            "title": "Org Id"
+          },
+          "page_count": {
+            "description": "Total number of pages in the input Markdown.",
+            "title": "Page Count",
+            "type": "integer"
+          },
+          "version": {
+            "description": "The exact split model snapshot that processed the document, e.g. `split-20251105`.",
+            "title": "Version",
+            "type": "string"
+          }
+        },
+        "required": [
+          "filename",
+          "org_id",
+          "page_count",
+          "duration_ms",
+          "credit_usage",
+          "job_id",
+          "version"
+        ],
+        "title": "SplitMetadata",
+        "type": "object"
+      },
+      "SplitResponse": {
+        "description": "The split result: the merged `splits` segments and request `metadata`.",
+        "properties": {
+          "metadata": {
+            "$ref": "#/components/schemas/SplitMetadata",
+            "description": "Information about the request: file name, page count, duration, credits, and the resolved model version."
+          },
+          "splits": {
+            "description": "The split segments, in page order. Consecutive pages with the same classification merge into one segment; an identifier change starts a new segment.",
+            "items": {
+              "$ref": "#/components/schemas/Split"
+            },
+            "title": "Splits",
+            "type": "array"
+          }
+        },
+        "required": [
+          "splits",
+          "metadata"
+        ],
+        "title": "SplitResponse",
+        "type": "object"
+      },
       "TableOptions": {
         "additionalProperties": false,
         "properties": {
@@ -773,6 +928,76 @@
           "openapi_spec"
         ],
         "title": "V1BuildSchemaMetadata",
+        "type": "object"
+      },
+      "V1ClassifyMetadata": {
+        "description": "Response metadata for a classify call — VTRA's ``ClassifyMetadata``.",
+        "properties": {
+          "credit_usage": {
+            "default": 0.0,
+            "description": "Credits billed for this request.",
+            "title": "Credit Usage",
+            "type": "number"
+          },
+          "duration_ms": {
+            "description": "End-to-end request duration in milliseconds.",
+            "title": "Duration Ms",
+            "type": "integer"
+          },
+          "filename": {
+            "default": "",
+            "description": "Name of the classified file.",
+            "title": "Filename",
+            "type": "string"
+          },
+          "job_id": {
+            "default": "",
+            "description": "Gateway job id (workflow id). Matches the billing row id in vision-agent.",
+            "title": "Job Id",
+            "type": "string"
+          },
+          "openapi_spec": {
+            "description": "URL of the OpenAPI spec covering this API, for inspection and client generation.",
+            "type": "string"
+          },
+          "org_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Organization ID.",
+            "title": "Org Id"
+          },
+          "page_count": {
+            "description": "Number of pages classified.",
+            "title": "Page Count",
+            "type": "integer"
+          },
+          "version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Resolved classify pipeline version that produced this response.",
+            "title": "Version"
+          }
+        },
+        "required": [
+          "page_count",
+          "duration_ms",
+          "openapi_spec"
+        ],
+        "title": "V1ClassifyMetadata",
         "type": "object"
       },
       "V1ExtractMetadata": {
@@ -1244,6 +1469,1312 @@
   },
   "openapi": "3.1.0",
   "paths": {
+    "/v1/ade/classify": {
+      "post": {
+        "description": "Classify each page of a document into classes you define. Accepts a PDF, an image, or an Office document, plus the list of candidate classes; returns one predicted class per page. Runs synchronously and returns the result inline.",
+        "operationId": "v1-ade-classify_run_sync",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Input to ``V1ClassifyOperationWorkflow`` (gateway) and, threaded\nunchanged, to ``ClassifyWorkflow`` (work) — the ``/v1/classify`` request\nbody. Mirrors VTRA's ``ClassifyRequest``.",
+                "properties": {
+                  "classes": {
+                    "description": "The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string.",
+                    "items": {
+                      "$ref": "#/components/schemas/ClassifyClass"
+                    },
+                    "title": "Classes",
+                    "type": "array"
+                  },
+                  "content_type": {
+                    "default": "",
+                    "title": "Content Type",
+                    "type": "string"
+                  },
+                  "document_ref": {
+                    "title": "Document Ref",
+                    "type": "string"
+                  },
+                  "filename": {
+                    "default": "",
+                    "title": "Filename",
+                    "type": "string"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version.",
+                    "title": "Model"
+                  }
+                },
+                "required": [
+                  "document_ref",
+                  "classes"
+                ],
+                "title": "ClassifyRequest",
+                "type": "object"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "classes": {
+                    "description": "The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string. JSON-serialized string in form data.",
+                    "items": {
+                      "$ref": "#/components/schemas/ClassifyClass"
+                    },
+                    "title": "Classes",
+                    "type": "array"
+                  },
+                  "content_type": {
+                    "default": "",
+                    "title": "Content Type",
+                    "type": "string"
+                  },
+                  "document": {
+                    "description": "The file to process. Provide either `document` or `document_url`, not both.",
+                    "format": "binary",
+                    "type": "string"
+                  },
+                  "document_url": {
+                    "description": "A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.",
+                    "type": "string"
+                  },
+                  "filename": {
+                    "default": "",
+                    "title": "Filename",
+                    "type": "string"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version. JSON-serialized string in form data.",
+                    "title": "Model"
+                  }
+                },
+                "required": [
+                  "classes"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Result returned by ``V1ClassifyOperationWorkflow`` — the\n``/v1/classify`` response body (VTRA's ``ClassifyResponse``).",
+                  "properties": {
+                    "classification": {
+                      "description": "One classification result per page, in page order.",
+                      "items": {
+                        "properties": {
+                          "class": {
+                            "description": "Predicted class label, or 'unknown'.",
+                            "type": "string"
+                          },
+                          "page": {
+                            "description": "Page number, zero-indexed (the first page is 0).",
+                            "type": "integer"
+                          },
+                          "reason": {
+                            "description": "Why the page was classified this way.",
+                            "type": "string"
+                          },
+                          "suggested_class": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "description": "A class the model proposes when the prediction is 'unknown'."
+                          }
+                        },
+                        "required": [
+                          "class",
+                          "reason",
+                          "page"
+                        ],
+                        "title": "ClassificationItem",
+                        "type": "object"
+                      },
+                      "title": "Classification",
+                      "type": "array"
+                    },
+                    "metadata": {
+                      "$ref": "#/components/schemas/V1ClassifyMetadata",
+                      "description": "Metadata for the classification request."
+                    }
+                  },
+                  "required": [
+                    "classification",
+                    "metadata"
+                  ],
+                  "title": "V1ClassifyResponse",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "v1-ade-classify result"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Classify",
+        "tags": [
+          "Classify"
+        ]
+      }
+    },
+    "/v1/ade/classify/jobs": {
+      "get": {
+        "description": "List your Classify jobs, newest first.",
+        "operationId": "v1-ade-classify_list_jobs",
+        "parameters": [
+          {
+            "description": "Page number (0-indexed).",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Page number (0-indexed).",
+              "minimum": 0,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of items per page.",
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "description": "Number of items per page.",
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Page Size",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Filter by job status.",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by job status.",
+              "title": "Status"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "has_more": {
+                      "type": "boolean"
+                    },
+                    "jobs": {
+                      "items": {
+                        "properties": {
+                          "completed_at": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "created_at": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "failure_reason": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "job_id": {
+                            "description": "The unique identifier for this v1-ade-classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                            "type": "string"
+                          },
+                          "model_version": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "status": {
+                            "enum": [
+                              "pending",
+                              "processing",
+                              "completed",
+                              "failed"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "page": {
+                      "type": "integer"
+                    },
+                    "page_size": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "The caller's jobs, newest first"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE List Classify Jobs",
+        "tags": [
+          "Classify"
+        ]
+      },
+      "post": {
+        "description": "Classify each page of a document into classes you define. Accepts a PDF, an image, or an Office document, plus the list of candidate classes; returns one predicted class per page. Runs asynchronously and returns a job ID; use it to poll for status and retrieve the result once processing completes.",
+        "operationId": "v1-ade-classify_create_job",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Input to ``V1ClassifyOperationWorkflow`` (gateway) and, threaded\nunchanged, to ``ClassifyWorkflow`` (work) — the ``/v1/classify`` request\nbody. Mirrors VTRA's ``ClassifyRequest``.",
+                "properties": {
+                  "classes": {
+                    "description": "The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string.",
+                    "items": {
+                      "$ref": "#/components/schemas/ClassifyClass"
+                    },
+                    "title": "Classes",
+                    "type": "array"
+                  },
+                  "content_type": {
+                    "default": "",
+                    "title": "Content Type",
+                    "type": "string"
+                  },
+                  "document_ref": {
+                    "title": "Document Ref",
+                    "type": "string"
+                  },
+                  "filename": {
+                    "default": "",
+                    "title": "Filename",
+                    "type": "string"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version.",
+                    "title": "Model"
+                  },
+                  "service_tier": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "standard",
+                          "priority"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
+                  }
+                },
+                "required": [
+                  "document_ref",
+                  "classes"
+                ],
+                "title": "ClassifyRequest",
+                "type": "object"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "classes": {
+                    "description": "The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string. JSON-serialized string in form data.",
+                    "items": {
+                      "$ref": "#/components/schemas/ClassifyClass"
+                    },
+                    "title": "Classes",
+                    "type": "array"
+                  },
+                  "content_type": {
+                    "default": "",
+                    "title": "Content Type",
+                    "type": "string"
+                  },
+                  "document": {
+                    "description": "The file to process. Provide either `document` or `document_url`, not both.",
+                    "format": "binary",
+                    "type": "string"
+                  },
+                  "document_url": {
+                    "description": "A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.",
+                    "type": "string"
+                  },
+                  "filename": {
+                    "default": "",
+                    "title": "Filename",
+                    "type": "string"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version. JSON-serialized string in form data.",
+                    "title": "Model"
+                  },
+                  "service_tier": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "standard",
+                          "priority"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
+                  }
+                },
+                "required": [
+                  "classes"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "created_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "job_id": {
+                      "description": "The unique identifier for this v1-ade-classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                      "type": "string"
+                    },
+                    "status": {
+                      "enum": [
+                        "pending",
+                        "processing",
+                        "completed",
+                        "failed"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Job created"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Classify Jobs",
+        "tags": [
+          "Classify"
+        ]
+      }
+    },
+    "/v1/ade/classify/jobs/{job_id}": {
+      "get": {
+        "description": "Get the status of an async Classify job, including its result once the job has completed.",
+        "operationId": "v1-ade-classify_get_job",
+        "parameters": [
+          {
+            "description": "The identifier of the job to retrieve, as returned by the create-job request.",
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "description": "The identifier of the job to retrieve, as returned by the create-job request.",
+              "title": "Job Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "completed_at": {
+                      "description": "Present once the job is terminal.",
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "description": "Present once status is ``failed``.",
+                      "properties": {
+                        "code": {
+                          "description": "Stable error code (``internal_error`` when unmapped).",
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "job_id": {
+                      "description": "The unique identifier for this v1-ade-classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                      "type": "string"
+                    },
+                    "progress": {
+                      "description": "Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.",
+                      "maximum": 1,
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    "result": {
+                      "anyOf": [
+                        {
+                          "description": "Result returned by ``V1ClassifyOperationWorkflow`` — the\n``/v1/classify`` response body (VTRA's ``ClassifyResponse``).",
+                          "properties": {
+                            "classification": {
+                              "description": "One classification result per page, in page order.",
+                              "items": {
+                                "properties": {
+                                  "class": {
+                                    "description": "Predicted class label, or 'unknown'.",
+                                    "type": "string"
+                                  },
+                                  "page": {
+                                    "description": "Page number, zero-indexed (the first page is 0).",
+                                    "type": "integer"
+                                  },
+                                  "reason": {
+                                    "description": "Why the page was classified this way.",
+                                    "type": "string"
+                                  },
+                                  "suggested_class": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ],
+                                    "description": "A class the model proposes when the prediction is 'unknown'."
+                                  }
+                                },
+                                "required": [
+                                  "class",
+                                  "reason",
+                                  "page"
+                                ],
+                                "title": "ClassificationItem",
+                                "type": "object"
+                              },
+                              "title": "Classification",
+                              "type": "array"
+                            },
+                            "metadata": {
+                              "$ref": "#/components/schemas/V1ClassifyMetadata",
+                              "description": "Metadata for the classification request."
+                            }
+                          },
+                          "required": [
+                            "classification",
+                            "metadata"
+                          ],
+                          "title": "V1ClassifyResponse",
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Present once status is ``completed``."
+                    },
+                    "status": {
+                      "enum": [
+                        "pending",
+                        "processing",
+                        "completed",
+                        "failed"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Job status / result"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not found (e.g. no such job)."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Get Classify Jobs",
+        "tags": [
+          "Classify"
+        ]
+      }
+    },
+    "/v1/ade/extract": {
+      "post": {
+        "description": "Extract structured data from a Markdown document using a JSON Schema. v1-compatible wire, running the same extraction engine as `/v2/extract`. Runs synchronously and returns the result inline.",
+        "operationId": "v1-ade-extract_run_sync",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.\n\nVTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline\nstring), ``markdown_url``, ``schema``, ``strict``. Nothing else — AIDE's own\nextras (``return_reasoning``, ``fallback_model``, ``output_save_url``) stay on\nthe R&D ``/api/extract`` contract, so the customer surface publishes the VTRA\ncontract and only that.",
+                "properties": {
+                  "markdown": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Markdown"
+                  },
+                  "markdown_url": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Markdown Url"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Model"
+                  },
+                  "schema": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Schema"
+                  },
+                  "strict": {
+                    "default": false,
+                    "title": "Strict",
+                    "type": "boolean"
+                  }
+                },
+                "title": "V1ExtractRequest",
+                "type": "object"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "markdown": {
+                    "description": "File upload.",
+                    "format": "binary",
+                    "type": "string"
+                  },
+                  "markdown_url": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "JSON-serialized string in form data.",
+                    "title": "Markdown Url"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "JSON-serialized string in form data.",
+                    "title": "Model"
+                  },
+                  "schema": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "JSON-serialized string in form data.",
+                    "title": "Schema"
+                  },
+                  "strict": {
+                    "default": false,
+                    "description": "JSON-serialized string in form data.",
+                    "title": "Strict",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "VTRA's ``ExtractResponse`` — the ``/v1/extract`` response body.\n\n``extraction`` is ALWAYS inline. The internal ``ExtractResult`` returns an\n``output_ref`` instead when the payload is too large for the Temporal wire; on\nthis route that pointer is resolved back to inline content at the render\nboundary, because VTRA always inlines and a client migrating off it has no\n``output_ref`` handling at all.",
+                  "properties": {
+                    "extraction": {
+                      "additionalProperties": true,
+                      "title": "Extraction",
+                      "type": "object"
+                    },
+                    "extraction_metadata": {
+                      "additionalProperties": true,
+                      "title": "Extraction Metadata",
+                      "type": "object"
+                    },
+                    "metadata": {
+                      "$ref": "#/components/schemas/V1ExtractMetadata"
+                    }
+                  },
+                  "title": "V1ExtractResponse",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "v1-ade-extract result"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Extract",
+        "tags": [
+          "Extract"
+        ]
+      }
+    },
+    "/v1/ade/extract/jobs": {
+      "get": {
+        "description": "List your Extract jobs, newest first.",
+        "operationId": "v1-ade-extract_list_jobs",
+        "parameters": [
+          {
+            "description": "Page number (0-indexed).",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Page number (0-indexed).",
+              "minimum": 0,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of items per page.",
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "description": "Number of items per page.",
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Page Size",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Filter by job status.",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by job status.",
+              "title": "Status"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "has_more": {
+                      "type": "boolean"
+                    },
+                    "jobs": {
+                      "items": {
+                        "properties": {
+                          "completed_at": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "created_at": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "failure_reason": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "job_id": {
+                            "description": "The unique identifier for this v1-ade-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                            "type": "string"
+                          },
+                          "model_version": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "status": {
+                            "enum": [
+                              "pending",
+                              "processing",
+                              "completed",
+                              "failed"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "page": {
+                      "type": "integer"
+                    },
+                    "page_size": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "The caller's jobs, newest first"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE List Extract Jobs",
+        "tags": [
+          "Extract"
+        ]
+      },
+      "post": {
+        "description": "Extract structured data from a Markdown document using a JSON Schema. v1-compatible wire, running the same extraction engine as `/v2/extract`. Runs asynchronously and returns a job ID; use it to poll for status and retrieve the result once processing completes.",
+        "operationId": "v1-ade-extract_create_job",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.\n\nVTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline\nstring), ``markdown_url``, ``schema``, ``strict``. Nothing else — AIDE's own\nextras (``return_reasoning``, ``fallback_model``, ``output_save_url``) stay on\nthe R&D ``/api/extract`` contract, so the customer surface publishes the VTRA\ncontract and only that.",
+                "properties": {
+                  "markdown": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Markdown"
+                  },
+                  "markdown_url": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Markdown Url"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Model"
+                  },
+                  "schema": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Schema"
+                  },
+                  "service_tier": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "standard",
+                          "priority"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
+                  },
+                  "strict": {
+                    "default": false,
+                    "title": "Strict",
+                    "type": "boolean"
+                  }
+                },
+                "title": "V1ExtractRequest",
+                "type": "object"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "markdown": {
+                    "description": "File upload.",
+                    "format": "binary",
+                    "type": "string"
+                  },
+                  "markdown_url": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "JSON-serialized string in form data.",
+                    "title": "Markdown Url"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "JSON-serialized string in form data.",
+                    "title": "Model"
+                  },
+                  "schema": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "JSON-serialized string in form data.",
+                    "title": "Schema"
+                  },
+                  "service_tier": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "standard",
+                          "priority"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
+                  },
+                  "strict": {
+                    "default": false,
+                    "description": "JSON-serialized string in form data.",
+                    "title": "Strict",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "created_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "job_id": {
+                      "description": "The unique identifier for this v1-ade-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                      "type": "string"
+                    },
+                    "status": {
+                      "enum": [
+                        "pending",
+                        "processing",
+                        "completed",
+                        "failed"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Job created"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Extract Jobs",
+        "tags": [
+          "Extract"
+        ]
+      }
+    },
+    "/v1/ade/extract/jobs/{job_id}": {
+      "get": {
+        "description": "Get the status of an async Extract job, including its result once the job has completed.",
+        "operationId": "v1-ade-extract_get_job",
+        "parameters": [
+          {
+            "description": "The identifier of the job to retrieve, as returned by the create-job request.",
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "description": "The identifier of the job to retrieve, as returned by the create-job request.",
+              "title": "Job Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "completed_at": {
+                      "description": "Present once the job is terminal.",
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "description": "Present once status is ``failed``.",
+                      "properties": {
+                        "code": {
+                          "description": "Stable error code (``internal_error`` when unmapped).",
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "job_id": {
+                      "description": "The unique identifier for this v1-ade-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                      "type": "string"
+                    },
+                    "progress": {
+                      "description": "Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.",
+                      "maximum": 1,
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    "result": {
+                      "anyOf": [
+                        {
+                          "description": "VTRA's ``ExtractResponse`` — the ``/v1/extract`` response body.\n\n``extraction`` is ALWAYS inline. The internal ``ExtractResult`` returns an\n``output_ref`` instead when the payload is too large for the Temporal wire; on\nthis route that pointer is resolved back to inline content at the render\nboundary, because VTRA always inlines and a client migrating off it has no\n``output_ref`` handling at all.",
+                          "properties": {
+                            "extraction": {
+                              "additionalProperties": true,
+                              "title": "Extraction",
+                              "type": "object"
+                            },
+                            "extraction_metadata": {
+                              "additionalProperties": true,
+                              "title": "Extraction Metadata",
+                              "type": "object"
+                            },
+                            "metadata": {
+                              "$ref": "#/components/schemas/V1ExtractMetadata"
+                            }
+                          },
+                          "title": "V1ExtractResponse",
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Present once status is ``completed``."
+                    },
+                    "status": {
+                      "enum": [
+                        "pending",
+                        "processing",
+                        "completed",
+                        "failed"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Job status / result"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not found (e.g. no such job)."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Get Extract Jobs",
+        "tags": [
+          "Extract"
+        ]
+      }
+    },
     "/v1/ade/parse": {
       "post": {
         "description": "Run synchronously and return the result inline.\n\nAccepts ``application/json`` (the request fields as the body),\n``multipart/form-data`` (file fields are staged automatically),\nor ``application/x-www-form-urlencoded`` (text fields only).\n\nReturns **504** if the work does not finish within the wait\nwindow — long-running work belongs on the async ``POST\n{path}/jobs`` route, which returns 202 immediately and is polled\nvia ``GET {path}/jobs/{job_id}``. On a 504 the workflow is\nCANCELLED (a sync caller can never collect the result); a retry\nstarts the work over as a fresh job.",
@@ -1399,9 +2930,13 @@
                     "description": "JSON-serialized string in form data.",
                     "title": "Custom Prompts"
                   },
-                  "document_ref": {
-                    "description": "File upload.",
+                  "document": {
+                    "description": "The file to process. Provide either `document` or `document_url`, not both.",
                     "format": "binary",
+                    "type": "string"
+                  },
+                  "document_url": {
+                    "description": "A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.",
                     "type": "string"
                   },
                   "filename": {
@@ -1502,7 +3037,6 @@
                   }
                 },
                 "required": [
-                  "document_ref",
                   "filename",
                   "content_type"
                 ],
@@ -1528,6 +3062,11 @@
                       "default": 0,
                       "title": "Billable Pages",
                       "type": "integer"
+                    },
+                    "billing_suppressed": {
+                      "default": false,
+                      "title": "Billing Suppressed",
+                      "type": "boolean"
                     },
                     "completion_tokens": {
                       "default": 0,
@@ -1968,9 +3507,13 @@
                     "description": "JSON-serialized string in form data.",
                     "title": "Custom Prompts"
                   },
-                  "document_ref": {
-                    "description": "File upload.",
+                  "document": {
+                    "description": "The file to process. Provide either `document` or `document_url`, not both.",
                     "format": "binary",
+                    "type": "string"
+                  },
+                  "document_url": {
+                    "description": "A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.",
                     "type": "string"
                   },
                   "filename": {
@@ -2099,7 +3642,6 @@
                   }
                 },
                 "required": [
-                  "document_ref",
                   "filename",
                   "content_type"
                 ],
@@ -2242,6 +3784,11 @@
                               "default": 0,
                               "title": "Billable Pages",
                               "type": "integer"
+                            },
+                            "billing_suppressed": {
+                              "default": false,
+                              "title": "Billing Suppressed",
+                              "type": "boolean"
                             },
                             "completion_tokens": {
                               "default": 0,
@@ -2397,39 +3944,37 @@
         ]
       }
     },
-    "/v1/extract": {
+    "/v1/classify": {
       "post": {
-        "description": "Extract structured data from a Markdown document using a JSON Schema. v1-compatible wire, running the same extraction engine as `/v2/extract`. Runs synchronously and returns the result inline.",
-        "operationId": "v1-extract_run_sync",
+        "description": "Classify each page of a document into classes you define. Accepts a PDF, an image, or an Office document, plus the list of candidate classes; returns one predicted class per page. Runs synchronously and returns the result inline.",
+        "operationId": "classify_run_sync",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "description": "Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.\n\nVTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline\nstring), ``markdown_url``, ``schema``, ``strict``. Nothing else — AIDE's own\nextras (``return_reasoning``, ``fallback_model``, ``output_save_url``) stay on\nthe R&D ``/api/extract`` contract, so the customer surface publishes the VTRA\ncontract and only that.",
+                "description": "Input to ``V1ClassifyOperationWorkflow`` (gateway) and, threaded\nunchanged, to ``ClassifyWorkflow`` (work) — the ``/v1/classify`` request\nbody. Mirrors VTRA's ``ClassifyRequest``.",
                 "properties": {
-                  "markdown": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Markdown"
+                  "classes": {
+                    "description": "The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string.",
+                    "items": {
+                      "$ref": "#/components/schemas/ClassifyClass"
+                    },
+                    "title": "Classes",
+                    "type": "array"
                   },
-                  "markdown_url": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Markdown Url"
+                  "content_type": {
+                    "default": "",
+                    "title": "Content Type",
+                    "type": "string"
+                  },
+                  "document_ref": {
+                    "title": "Document Ref",
+                    "type": "string"
+                  },
+                  "filename": {
+                    "default": "",
+                    "title": "Filename",
+                    "type": "string"
                   },
                   "model": {
                     "anyOf": [
@@ -2441,50 +3986,47 @@
                       }
                     ],
                     "default": null,
+                    "description": "Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version.",
                     "title": "Model"
-                  },
-                  "schema": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Schema"
-                  },
-                  "strict": {
-                    "default": false,
-                    "title": "Strict",
-                    "type": "boolean"
                   }
                 },
-                "title": "V1ExtractRequest",
+                "required": [
+                  "document_ref",
+                  "classes"
+                ],
+                "title": "ClassifyRequest",
                 "type": "object"
               }
             },
             "multipart/form-data": {
               "schema": {
                 "properties": {
-                  "markdown": {
-                    "description": "File upload.",
+                  "classes": {
+                    "description": "The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string. JSON-serialized string in form data.",
+                    "items": {
+                      "$ref": "#/components/schemas/ClassifyClass"
+                    },
+                    "title": "Classes",
+                    "type": "array"
+                  },
+                  "content_type": {
+                    "default": "",
+                    "title": "Content Type",
+                    "type": "string"
+                  },
+                  "document": {
+                    "description": "The file to process. Provide either `document` or `document_url`, not both.",
                     "format": "binary",
                     "type": "string"
                   },
-                  "markdown_url": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Markdown Url"
+                  "document_url": {
+                    "description": "A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.",
+                    "type": "string"
+                  },
+                  "filename": {
+                    "default": "",
+                    "title": "Filename",
+                    "type": "string"
                   },
                   "model": {
                     "anyOf": [
@@ -2496,29 +4038,13 @@
                       }
                     ],
                     "default": null,
-                    "description": "JSON-serialized string in form data.",
+                    "description": "Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version. JSON-serialized string in form data.",
                     "title": "Model"
-                  },
-                  "schema": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Schema"
-                  },
-                  "strict": {
-                    "default": false,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Strict",
-                    "type": "boolean"
                   }
                 },
+                "required": [
+                  "classes"
+                ],
                 "type": "object"
               }
             }
@@ -2530,28 +4056,62 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "description": "VTRA's ``ExtractResponse`` — the ``/v1/extract`` response body.\n\n``extraction`` is ALWAYS inline. The internal ``ExtractResult`` returns an\n``output_ref`` instead when the payload is too large for the Temporal wire; on\nthis route that pointer is resolved back to inline content at the render\nboundary, because VTRA always inlines and a client migrating off it has no\n``output_ref`` handling at all.",
+                  "description": "Result returned by ``V1ClassifyOperationWorkflow`` — the\n``/v1/classify`` response body (VTRA's ``ClassifyResponse``).",
                   "properties": {
-                    "extraction": {
-                      "additionalProperties": true,
-                      "title": "Extraction",
-                      "type": "object"
-                    },
-                    "extraction_metadata": {
-                      "additionalProperties": true,
-                      "title": "Extraction Metadata",
-                      "type": "object"
+                    "classification": {
+                      "description": "One classification result per page, in page order.",
+                      "items": {
+                        "properties": {
+                          "class": {
+                            "description": "Predicted class label, or 'unknown'.",
+                            "type": "string"
+                          },
+                          "page": {
+                            "description": "Page number, zero-indexed (the first page is 0).",
+                            "type": "integer"
+                          },
+                          "reason": {
+                            "description": "Why the page was classified this way.",
+                            "type": "string"
+                          },
+                          "suggested_class": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "description": "A class the model proposes when the prediction is 'unknown'."
+                          }
+                        },
+                        "required": [
+                          "class",
+                          "reason",
+                          "page"
+                        ],
+                        "title": "ClassificationItem",
+                        "type": "object"
+                      },
+                      "title": "Classification",
+                      "type": "array"
                     },
                     "metadata": {
-                      "$ref": "#/components/schemas/V1ExtractMetadata"
+                      "$ref": "#/components/schemas/V1ClassifyMetadata",
+                      "description": "Metadata for the classification request."
                     }
                   },
-                  "title": "V1ExtractResponse",
+                  "required": [
+                    "classification",
+                    "metadata"
+                  ],
+                  "title": "V1ClassifyResponse",
                   "type": "object"
                 }
               }
             },
-            "description": "v1-extract result"
+            "description": "classify result"
           },
           "422": {
             "content": {
@@ -2564,9 +4124,489 @@
             "description": "Request validation failed."
           }
         },
-        "summary": "ADE Extract",
+        "summary": "ADE Classify",
         "tags": [
-          "Extract"
+          "Classify"
+        ]
+      }
+    },
+    "/v1/classify/jobs": {
+      "get": {
+        "description": "List your Classify jobs, newest first.",
+        "operationId": "classify_list_jobs",
+        "parameters": [
+          {
+            "description": "Page number (0-indexed).",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Page number (0-indexed).",
+              "minimum": 0,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of items per page.",
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "description": "Number of items per page.",
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Page Size",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Filter by job status.",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by job status.",
+              "title": "Status"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "has_more": {
+                      "type": "boolean"
+                    },
+                    "jobs": {
+                      "items": {
+                        "properties": {
+                          "completed_at": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "created_at": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "failure_reason": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "job_id": {
+                            "description": "The unique identifier for this classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                            "type": "string"
+                          },
+                          "model_version": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "status": {
+                            "enum": [
+                              "pending",
+                              "processing",
+                              "completed",
+                              "failed"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "page": {
+                      "type": "integer"
+                    },
+                    "page_size": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "The caller's jobs, newest first"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE List Classify Jobs",
+        "tags": [
+          "Classify"
+        ]
+      },
+      "post": {
+        "description": "Classify each page of a document into classes you define. Accepts a PDF, an image, or an Office document, plus the list of candidate classes; returns one predicted class per page. Runs asynchronously and returns a job ID; use it to poll for status and retrieve the result once processing completes.",
+        "operationId": "classify_create_job",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Input to ``V1ClassifyOperationWorkflow`` (gateway) and, threaded\nunchanged, to ``ClassifyWorkflow`` (work) — the ``/v1/classify`` request\nbody. Mirrors VTRA's ``ClassifyRequest``.",
+                "properties": {
+                  "classes": {
+                    "description": "The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string.",
+                    "items": {
+                      "$ref": "#/components/schemas/ClassifyClass"
+                    },
+                    "title": "Classes",
+                    "type": "array"
+                  },
+                  "content_type": {
+                    "default": "",
+                    "title": "Content Type",
+                    "type": "string"
+                  },
+                  "document_ref": {
+                    "title": "Document Ref",
+                    "type": "string"
+                  },
+                  "filename": {
+                    "default": "",
+                    "title": "Filename",
+                    "type": "string"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version.",
+                    "title": "Model"
+                  },
+                  "service_tier": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "standard",
+                          "priority"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
+                  }
+                },
+                "required": [
+                  "document_ref",
+                  "classes"
+                ],
+                "title": "ClassifyRequest",
+                "type": "object"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "classes": {
+                    "description": "The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string. JSON-serialized string in form data.",
+                    "items": {
+                      "$ref": "#/components/schemas/ClassifyClass"
+                    },
+                    "title": "Classes",
+                    "type": "array"
+                  },
+                  "content_type": {
+                    "default": "",
+                    "title": "Content Type",
+                    "type": "string"
+                  },
+                  "document": {
+                    "description": "The file to process. Provide either `document` or `document_url`, not both.",
+                    "format": "binary",
+                    "type": "string"
+                  },
+                  "document_url": {
+                    "description": "A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.",
+                    "type": "string"
+                  },
+                  "filename": {
+                    "default": "",
+                    "title": "Filename",
+                    "type": "string"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version. JSON-serialized string in form data.",
+                    "title": "Model"
+                  },
+                  "service_tier": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "standard",
+                          "priority"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
+                  }
+                },
+                "required": [
+                  "classes"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "created_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "job_id": {
+                      "description": "The unique identifier for this classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                      "type": "string"
+                    },
+                    "status": {
+                      "enum": [
+                        "pending",
+                        "processing",
+                        "completed",
+                        "failed"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Job created"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Classify Jobs",
+        "tags": [
+          "Classify"
+        ]
+      }
+    },
+    "/v1/classify/jobs/{job_id}": {
+      "get": {
+        "description": "Get the status of an async Classify job, including its result once the job has completed.",
+        "operationId": "classify_get_job",
+        "parameters": [
+          {
+            "description": "The identifier of the job to retrieve, as returned by the create-job request.",
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "description": "The identifier of the job to retrieve, as returned by the create-job request.",
+              "title": "Job Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "completed_at": {
+                      "description": "Present once the job is terminal.",
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "description": "Present once status is ``failed``.",
+                      "properties": {
+                        "code": {
+                          "description": "Stable error code (``internal_error`` when unmapped).",
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "job_id": {
+                      "description": "The unique identifier for this classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                      "type": "string"
+                    },
+                    "progress": {
+                      "description": "Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.",
+                      "maximum": 1,
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    "result": {
+                      "anyOf": [
+                        {
+                          "description": "Result returned by ``V1ClassifyOperationWorkflow`` — the\n``/v1/classify`` response body (VTRA's ``ClassifyResponse``).",
+                          "properties": {
+                            "classification": {
+                              "description": "One classification result per page, in page order.",
+                              "items": {
+                                "properties": {
+                                  "class": {
+                                    "description": "Predicted class label, or 'unknown'.",
+                                    "type": "string"
+                                  },
+                                  "page": {
+                                    "description": "Page number, zero-indexed (the first page is 0).",
+                                    "type": "integer"
+                                  },
+                                  "reason": {
+                                    "description": "Why the page was classified this way.",
+                                    "type": "string"
+                                  },
+                                  "suggested_class": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ],
+                                    "description": "A class the model proposes when the prediction is 'unknown'."
+                                  }
+                                },
+                                "required": [
+                                  "class",
+                                  "reason",
+                                  "page"
+                                ],
+                                "title": "ClassificationItem",
+                                "type": "object"
+                              },
+                              "title": "Classification",
+                              "type": "array"
+                            },
+                            "metadata": {
+                              "$ref": "#/components/schemas/V1ClassifyMetadata",
+                              "description": "Metadata for the classification request."
+                            }
+                          },
+                          "required": [
+                            "classification",
+                            "metadata"
+                          ],
+                          "title": "V1ClassifyResponse",
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Present once status is ``completed``."
+                    },
+                    "status": {
+                      "enum": [
+                        "pending",
+                        "processing",
+                        "completed",
+                        "failed"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Job status / result"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not found (e.g. no such job)."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Get Classify Jobs",
+        "tags": [
+          "Classify"
         ]
       }
     },
@@ -3290,734 +5330,42 @@
         ]
       }
     },
-    "/v1/extract/jobs": {
-      "get": {
-        "description": "List your Extract jobs, newest first.",
-        "operationId": "v1-extract_list_jobs",
-        "parameters": [
-          {
-            "description": "Page number (0-indexed).",
-            "in": "query",
-            "name": "page",
-            "required": false,
-            "schema": {
-              "default": 0,
-              "description": "Page number (0-indexed).",
-              "minimum": 0,
-              "title": "Page",
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Number of items per page.",
-            "in": "query",
-            "name": "page_size",
-            "required": false,
-            "schema": {
-              "default": 10,
-              "description": "Number of items per page.",
-              "maximum": 100,
-              "minimum": 1,
-              "title": "Page Size",
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Filter by job status.",
-            "in": "query",
-            "name": "status",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Filter by job status.",
-              "title": "Status"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "has_more": {
-                      "type": "boolean"
-                    },
-                    "jobs": {
-                      "items": {
-                        "properties": {
-                          "completed_at": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "created_at": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "failure_reason": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "job_id": {
-                            "description": "The unique identifier for this v1-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
-                            "type": "string"
-                          },
-                          "model_version": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "status": {
-                            "enum": [
-                              "pending",
-                              "processing",
-                              "completed",
-                              "failed"
-                            ],
-                            "type": "string"
-                          }
-                        },
-                        "type": "object"
-                      },
-                      "type": "array"
-                    },
-                    "page": {
-                      "type": "integer"
-                    },
-                    "page_size": {
-                      "type": "integer"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "The caller's jobs, newest first"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Request validation failed."
-          }
-        },
-        "summary": "ADE List Extract Jobs",
-        "tags": [
-          "Extract"
-        ]
-      },
+    "/v1/split": {
       "post": {
-        "description": "Extract structured data from a Markdown document using a JSON Schema. v1-compatible wire, running the same extraction engine as `/v2/extract`. Runs asynchronously and returns a job ID; use it to poll for status and retrieve the result once processing completes.",
-        "operationId": "v1-extract_create_job",
+        "description": "Split a Markdown document into segments and return the split response inline.",
+        "operationId": "v1-split_run_sync",
         "requestBody": {
           "content": {
-            "application/json": {
-              "schema": {
-                "description": "Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.\n\nVTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline\nstring), ``markdown_url``, ``schema``, ``strict``. Nothing else — AIDE's own\nextras (``return_reasoning``, ``fallback_model``, ``output_save_url``) stay on\nthe R&D ``/api/extract`` contract, so the customer surface publishes the VTRA\ncontract and only that.",
-                "properties": {
-                  "markdown": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Markdown"
-                  },
-                  "markdown_url": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Markdown Url"
-                  },
-                  "model": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Model"
-                  },
-                  "schema": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Schema"
-                  },
-                  "service_tier": {
-                    "anyOf": [
-                      {
-                        "enum": [
-                          "standard",
-                          "priority"
-                        ],
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
-                  },
-                  "strict": {
-                    "default": false,
-                    "title": "Strict",
-                    "type": "boolean"
-                  }
-                },
-                "title": "V1ExtractRequest",
-                "type": "object"
-              }
-            },
             "multipart/form-data": {
               "schema": {
                 "properties": {
                   "markdown": {
-                    "description": "File upload.",
-                    "format": "binary",
-                    "type": "string"
+                    "anyOf": [
+                      {
+                        "format": "binary",
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "description": "Markdown content to split, as an inline string or an uploaded file. Provide either `markdown` or `markdown_url`, not both."
                   },
                   "markdown_url": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Markdown Url"
+                    "description": "A publicly accessible URL to the Markdown file to split. Provide either `markdown` or `markdown_url`, not both.",
+                    "type": "string"
                   },
                   "model": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Model"
-                  },
-                  "schema": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Schema"
-                  },
-                  "service_tier": {
-                    "anyOf": [
-                      {
-                        "enum": [
-                          "standard",
-                          "priority"
-                        ],
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
-                  },
-                  "strict": {
-                    "default": false,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Strict",
-                    "type": "boolean"
-                  }
-                },
-                "type": "object"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "202": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "created_at": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "job_id": {
-                      "description": "The unique identifier for this v1-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
-                      "type": "string"
-                    },
-                    "status": {
-                      "enum": [
-                        "pending",
-                        "processing",
-                        "completed",
-                        "failed"
-                      ],
-                      "type": "string"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Job created"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Request validation failed."
-          }
-        },
-        "summary": "ADE Extract Jobs",
-        "tags": [
-          "Extract"
-        ]
-      }
-    },
-    "/v1/extract/jobs/{job_id}": {
-      "get": {
-        "description": "Get the status of an async Extract job, including its result once the job has completed.",
-        "operationId": "v1-extract_get_job",
-        "parameters": [
-          {
-            "description": "The identifier of the job to retrieve, as returned by the create-job request.",
-            "in": "path",
-            "name": "job_id",
-            "required": true,
-            "schema": {
-              "description": "The identifier of the job to retrieve, as returned by the create-job request.",
-              "title": "Job Id",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "completed_at": {
-                      "description": "Present once the job is terminal.",
-                      "type": "string"
-                    },
-                    "created_at": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "error": {
-                      "description": "Present once status is ``failed``.",
-                      "properties": {
-                        "code": {
-                          "description": "Stable error code (``internal_error`` when unmapped).",
-                          "type": "string"
-                        },
-                        "message": {
-                          "type": "string"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    "job_id": {
-                      "description": "The unique identifier for this v1-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
-                      "type": "string"
-                    },
-                    "progress": {
-                      "description": "Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.",
-                      "maximum": 1,
-                      "minimum": 0,
-                      "type": "number"
-                    },
-                    "result": {
-                      "anyOf": [
-                        {
-                          "description": "VTRA's ``ExtractResponse`` — the ``/v1/extract`` response body.\n\n``extraction`` is ALWAYS inline. The internal ``ExtractResult`` returns an\n``output_ref`` instead when the payload is too large for the Temporal wire; on\nthis route that pointer is resolved back to inline content at the render\nboundary, because VTRA always inlines and a client migrating off it has no\n``output_ref`` handling at all.",
-                          "properties": {
-                            "extraction": {
-                              "additionalProperties": true,
-                              "title": "Extraction",
-                              "type": "object"
-                            },
-                            "extraction_metadata": {
-                              "additionalProperties": true,
-                              "title": "Extraction Metadata",
-                              "type": "object"
-                            },
-                            "metadata": {
-                              "$ref": "#/components/schemas/V1ExtractMetadata"
-                            }
-                          },
-                          "title": "V1ExtractResponse",
-                          "type": "object"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "description": "Present once status is ``completed``."
-                    },
-                    "status": {
-                      "enum": [
-                        "pending",
-                        "processing",
-                        "completed",
-                        "failed"
-                      ],
-                      "type": "string"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Job status / result"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Not found (e.g. no such job)."
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Request validation failed."
-          }
-        },
-        "summary": "ADE Get Extract Jobs",
-        "tags": [
-          "Extract"
-        ]
-      }
-    },
-    "/v1/parse": {
-      "post": {
-        "description": "Run synchronously and return the result inline.\n\nAccepts ``application/json`` (the request fields as the body),\n``multipart/form-data`` (file fields are staged automatically),\nor ``application/x-www-form-urlencoded`` (text fields only).\n\nReturns **504** if the work does not finish within the wait\nwindow — long-running work belongs on the async ``POST\n{path}/jobs`` route, which returns 202 immediately and is polled\nvia ``GET {path}/jobs/{job_id}``. On a 504 the workflow is\nCANCELLED (a sync caller can never collect the result); a retry\nstarts the work over as a fresh job.",
-        "operationId": "parse2_run_sync",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "description": "Input to ``Parse2OperationWorkflow`` (gateway) and ``Parse2DocumentWorkflow``\n(work). The document rides as ``document_ref`` (the gateway's multipart adapter\nstages the upload / fetches ``document_url`` → data store, runs the pdf_pages\npre-flight, then starts the operation).",
-                "properties": {
-                  "content_type": {
-                    "title": "Content Type",
+                    "description": "The split model version to use. Accepts a dated snapshot (`split-20251105`), `split-latest`, or `split` (both aliases resolve to the latest snapshot). Defaults to the latest snapshot. The resolved version is echoed back as `metadata.version`.",
                     "type": "string"
                   },
-                  "custom_prompts": {
-                    "anyOf": [
-                      {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Custom Prompts"
-                  },
-                  "document_ref": {
-                    "title": "Document Ref",
+                  "split_class": {
+                    "description": "The split classification entries, as a JSON-encoded array of objects with `name` (required), `description`, and `identifier` keys. At most 19 entries. Sent as a JSON-serialized string in form data.",
                     "type": "string"
-                  },
-                  "filename": {
-                    "title": "Filename",
-                    "type": "string"
-                  },
-                  "job_id": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Job Id"
-                  },
-                  "model_versions": {
-                    "anyOf": [
-                      {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Model Versions"
-                  },
-                  "password": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Password"
-                  },
-                  "pricing_multiplier": {
-                    "default": 1.0,
-                    "title": "Pricing Multiplier",
-                    "type": "number"
-                  },
-                  "processing_mode": {
-                    "default": "sync",
-                    "title": "Processing Mode",
-                    "type": "string"
-                  },
-                  "split": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Split"
-                  },
-                  "version": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Version"
-                  },
-                  "x_request_id": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "X Request Id"
                   }
                 },
                 "required": [
-                  "document_ref",
-                  "filename",
-                  "content_type"
-                ],
-                "title": "Parse2Request",
-                "type": "object"
-              }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "properties": {
-                  "content_type": {
-                    "title": "Content Type",
-                    "type": "string"
-                  },
-                  "custom_prompts": {
-                    "anyOf": [
-                      {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Custom Prompts"
-                  },
-                  "document_ref": {
-                    "description": "File upload.",
-                    "format": "binary",
-                    "type": "string"
-                  },
-                  "filename": {
-                    "title": "Filename",
-                    "type": "string"
-                  },
-                  "job_id": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Job Id"
-                  },
-                  "model_versions": {
-                    "anyOf": [
-                      {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Model Versions"
-                  },
-                  "password": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Password"
-                  },
-                  "pricing_multiplier": {
-                    "default": 1.0,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Pricing Multiplier",
-                    "type": "number"
-                  },
-                  "processing_mode": {
-                    "default": "sync",
-                    "title": "Processing Mode",
-                    "type": "string"
-                  },
-                  "split": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Split"
-                  },
-                  "version": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Version"
-                  },
-                  "x_request_id": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "X Request Id"
-                  }
-                },
-                "required": [
-                  "document_ref",
-                  "filename",
-                  "content_type"
+                  "split_class"
                 ],
                 "type": "object"
               }
@@ -4030,126 +5378,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "description": "Output of ``Parse2DocumentWorkflow``. Carries the customer response plus the\nbilling inputs hoisted to the top level so the gateway operation reads them\nwithout re-parsing the nested tree.\n\nBilling is worker-owned (parse-api parity): the worker finalizes the price and\nreports it on the standard ``credit_usage: CreditUsage`` shape (``credits`` =\nFINAL billed value, ``charge_unit`` = billable pages, ``breakdown`` = itemized),\nplus the record-inference enrichment (``usage`` + ``model_family``). The\ngateway's default biller reads ``credit_usage`` verbatim (a ``JobContract.billed()``\nop — no gateway recomputation).",
-                  "properties": {
-                    "base_credit": {
-                      "default": 0.0,
-                      "title": "Base Credit",
-                      "type": "number"
-                    },
-                    "billable_pages": {
-                      "default": 0,
-                      "title": "Billable Pages",
-                      "type": "integer"
-                    },
-                    "completion_tokens": {
-                      "default": 0,
-                      "title": "Completion Tokens",
-                      "type": "integer"
-                    },
-                    "credit_usage": {
-                      "$ref": "#/components/schemas/CreditUsage"
-                    },
-                    "duration_ms": {
-                      "default": 0,
-                      "title": "Duration Ms",
-                      "type": "integer"
-                    },
-                    "failed_pages": {
-                      "items": {
-                        "type": "integer"
-                      },
-                      "title": "Failed Pages",
-                      "type": "array"
-                    },
-                    "model_family": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Model Family"
-                    },
-                    "output_ref": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Output Ref"
-                    },
-                    "page_count": {
-                      "default": 0,
-                      "title": "Page Count",
-                      "type": "integer"
-                    },
-                    "prompt_tokens": {
-                      "default": 0,
-                      "title": "Prompt Tokens",
-                      "type": "integer"
-                    },
-                    "response": {
-                      "additionalProperties": true,
-                      "title": "Response",
-                      "type": "object"
-                    },
-                    "status_code": {
-                      "default": 200,
-                      "title": "Status Code",
-                      "type": "integer"
-                    },
-                    "token_steps": {
-                      "anyOf": [
-                        {
-                          "items": {
-                            "additionalProperties": true,
-                            "type": "object"
-                          },
-                          "type": "array"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Token Steps"
-                    },
-                    "total_tokens": {
-                      "default": 0,
-                      "title": "Total Tokens",
-                      "type": "integer"
-                    },
-                    "usage": {
-                      "anyOf": [
-                        {
-                          "additionalProperties": true,
-                          "type": "object"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Usage"
-                    }
-                  },
-                  "required": [
-                    "response"
-                  ],
-                  "title": "Parse2Result",
-                  "type": "object"
+                  "$ref": "#/components/schemas/SplitResponse"
                 }
               }
             },
-            "description": "parse2 result"
+            "description": "The split response"
           },
           "422": {
             "content": {
@@ -4162,751 +5395,9 @@
             "description": "Request validation failed."
           }
         },
-        "summary": "ADE Parse v1",
+        "summary": "ADE Split",
         "tags": [
-          "Parse v1"
-        ]
-      }
-    },
-    "/v1/parse/jobs": {
-      "get": {
-        "operationId": "parse2_list_jobs",
-        "parameters": [
-          {
-            "description": "Page number (0-indexed).",
-            "in": "query",
-            "name": "page",
-            "required": false,
-            "schema": {
-              "default": 0,
-              "description": "Page number (0-indexed).",
-              "minimum": 0,
-              "title": "Page",
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Number of items per page.",
-            "in": "query",
-            "name": "page_size",
-            "required": false,
-            "schema": {
-              "default": 10,
-              "description": "Number of items per page.",
-              "maximum": 100,
-              "minimum": 1,
-              "title": "Page Size",
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Filter by job status.",
-            "in": "query",
-            "name": "status",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Filter by job status.",
-              "title": "Status"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "has_more": {
-                      "type": "boolean"
-                    },
-                    "jobs": {
-                      "items": {
-                        "properties": {
-                          "completed_at": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "created_at": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "failure_reason": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "job_id": {
-                            "description": "The unique identifier for this parse2 job. Format: ``parse2-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
-                            "type": "string"
-                          },
-                          "model_version": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "status": {
-                            "enum": [
-                              "pending",
-                              "processing",
-                              "completed",
-                              "failed"
-                            ],
-                            "type": "string"
-                          }
-                        },
-                        "type": "object"
-                      },
-                      "type": "array"
-                    },
-                    "page": {
-                      "type": "integer"
-                    },
-                    "page_size": {
-                      "type": "integer"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "The caller's jobs, newest first"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Request validation failed."
-          }
-        },
-        "summary": "ADE List Parse v1 Jobs",
-        "tags": [
-          "Parse v1"
-        ]
-      },
-      "post": {
-        "operationId": "parse2_create_job",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "description": "Input to ``Parse2OperationWorkflow`` (gateway) and ``Parse2DocumentWorkflow``\n(work). The document rides as ``document_ref`` (the gateway's multipart adapter\nstages the upload / fetches ``document_url`` → data store, runs the pdf_pages\npre-flight, then starts the operation).",
-                "properties": {
-                  "content_type": {
-                    "title": "Content Type",
-                    "type": "string"
-                  },
-                  "custom_prompts": {
-                    "anyOf": [
-                      {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Custom Prompts"
-                  },
-                  "document_ref": {
-                    "title": "Document Ref",
-                    "type": "string"
-                  },
-                  "filename": {
-                    "title": "Filename",
-                    "type": "string"
-                  },
-                  "job_id": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Job Id"
-                  },
-                  "model_versions": {
-                    "anyOf": [
-                      {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Model Versions"
-                  },
-                  "output_save_url": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Output Save Url"
-                  },
-                  "password": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Password"
-                  },
-                  "pricing_multiplier": {
-                    "default": 1.0,
-                    "title": "Pricing Multiplier",
-                    "type": "number"
-                  },
-                  "processing_mode": {
-                    "default": "sync",
-                    "title": "Processing Mode",
-                    "type": "string"
-                  },
-                  "service_tier": {
-                    "anyOf": [
-                      {
-                        "enum": [
-                          "standard",
-                          "priority"
-                        ],
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
-                  },
-                  "split": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Split"
-                  },
-                  "version": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Version"
-                  },
-                  "x_request_id": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "X Request Id"
-                  }
-                },
-                "required": [
-                  "document_ref",
-                  "filename",
-                  "content_type"
-                ],
-                "title": "Parse2Request",
-                "type": "object"
-              }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "properties": {
-                  "content_type": {
-                    "title": "Content Type",
-                    "type": "string"
-                  },
-                  "custom_prompts": {
-                    "anyOf": [
-                      {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Custom Prompts"
-                  },
-                  "document_ref": {
-                    "description": "File upload.",
-                    "format": "binary",
-                    "type": "string"
-                  },
-                  "filename": {
-                    "title": "Filename",
-                    "type": "string"
-                  },
-                  "job_id": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Job Id"
-                  },
-                  "model_versions": {
-                    "anyOf": [
-                      {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Model Versions"
-                  },
-                  "output_save_url": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Output Save Url"
-                  },
-                  "password": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Password"
-                  },
-                  "pricing_multiplier": {
-                    "default": 1.0,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Pricing Multiplier",
-                    "type": "number"
-                  },
-                  "processing_mode": {
-                    "default": "sync",
-                    "title": "Processing Mode",
-                    "type": "string"
-                  },
-                  "service_tier": {
-                    "anyOf": [
-                      {
-                        "enum": [
-                          "standard",
-                          "priority"
-                        ],
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
-                  },
-                  "split": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Split"
-                  },
-                  "version": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Version"
-                  },
-                  "x_request_id": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "X Request Id"
-                  }
-                },
-                "required": [
-                  "document_ref",
-                  "filename",
-                  "content_type"
-                ],
-                "type": "object"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "202": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "created_at": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "job_id": {
-                      "description": "The unique identifier for this parse2 job. Format: ``parse2-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
-                      "type": "string"
-                    },
-                    "status": {
-                      "enum": [
-                        "pending",
-                        "processing",
-                        "completed",
-                        "failed"
-                      ],
-                      "type": "string"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Job created"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Request validation failed."
-          }
-        },
-        "summary": "ADE Parse v1 Jobs",
-        "tags": [
-          "Parse v1"
-        ]
-      }
-    },
-    "/v1/parse/jobs/{job_id}": {
-      "get": {
-        "description": "Poll a job.\n\nReturns ``{job_id, status, created_at}`` plus ``completed_at`` and\n``result`` (on ``completed``) or ``error: {code, message}`` (on\n``failed``). Statuses: ``pending`` → ``processing`` →\n``completed`` | ``failed``.",
-        "operationId": "parse2_get_job",
-        "parameters": [
-          {
-            "description": "The identifier of the job to retrieve, as returned by the create-job request.",
-            "in": "path",
-            "name": "job_id",
-            "required": true,
-            "schema": {
-              "description": "The identifier of the job to retrieve, as returned by the create-job request.",
-              "title": "Job Id",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "completed_at": {
-                      "description": "Present once the job is terminal.",
-                      "type": "string"
-                    },
-                    "created_at": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "error": {
-                      "description": "Present once status is ``failed``.",
-                      "properties": {
-                        "code": {
-                          "description": "Stable error code (``internal_error`` when unmapped).",
-                          "type": "string"
-                        },
-                        "message": {
-                          "type": "string"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    "job_id": {
-                      "description": "The unique identifier for this parse2 job. Format: ``parse2-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
-                      "type": "string"
-                    },
-                    "metadata": {
-                      "description": "The result's metadata block (billing included), present alongside ``output_url`` once a job with ``output_save_url`` has ``completed`` — the delivery moves the content, not the receipt. Same shape as the inline ``result``'s ``metadata``; inline jobs carry it there instead.",
-                      "type": [
-                        "object",
-                        "null"
-                      ]
-                    },
-                    "output_url": {
-                      "description": "The URL the result was delivered to. Present once the job has ``completed`` and ``output_save_url`` was set, instead of inline ``result``.",
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "progress": {
-                      "description": "Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.",
-                      "maximum": 1,
-                      "minimum": 0,
-                      "type": "number"
-                    },
-                    "result": {
-                      "anyOf": [
-                        {
-                          "description": "Output of ``Parse2DocumentWorkflow``. Carries the customer response plus the\nbilling inputs hoisted to the top level so the gateway operation reads them\nwithout re-parsing the nested tree.\n\nBilling is worker-owned (parse-api parity): the worker finalizes the price and\nreports it on the standard ``credit_usage: CreditUsage`` shape (``credits`` =\nFINAL billed value, ``charge_unit`` = billable pages, ``breakdown`` = itemized),\nplus the record-inference enrichment (``usage`` + ``model_family``). The\ngateway's default biller reads ``credit_usage`` verbatim (a ``JobContract.billed()``\nop — no gateway recomputation).",
-                          "properties": {
-                            "base_credit": {
-                              "default": 0.0,
-                              "title": "Base Credit",
-                              "type": "number"
-                            },
-                            "billable_pages": {
-                              "default": 0,
-                              "title": "Billable Pages",
-                              "type": "integer"
-                            },
-                            "completion_tokens": {
-                              "default": 0,
-                              "title": "Completion Tokens",
-                              "type": "integer"
-                            },
-                            "credit_usage": {
-                              "$ref": "#/components/schemas/CreditUsage"
-                            },
-                            "duration_ms": {
-                              "default": 0,
-                              "title": "Duration Ms",
-                              "type": "integer"
-                            },
-                            "failed_pages": {
-                              "items": {
-                                "type": "integer"
-                              },
-                              "title": "Failed Pages",
-                              "type": "array"
-                            },
-                            "model_family": {
-                              "anyOf": [
-                                {
-                                  "type": "string"
-                                },
-                                {
-                                  "type": "null"
-                                }
-                              ],
-                              "default": null,
-                              "title": "Model Family"
-                            },
-                            "output_ref": {
-                              "anyOf": [
-                                {
-                                  "type": "string"
-                                },
-                                {
-                                  "type": "null"
-                                }
-                              ],
-                              "default": null,
-                              "title": "Output Ref"
-                            },
-                            "page_count": {
-                              "default": 0,
-                              "title": "Page Count",
-                              "type": "integer"
-                            },
-                            "prompt_tokens": {
-                              "default": 0,
-                              "title": "Prompt Tokens",
-                              "type": "integer"
-                            },
-                            "response": {
-                              "additionalProperties": true,
-                              "title": "Response",
-                              "type": "object"
-                            },
-                            "status_code": {
-                              "default": 200,
-                              "title": "Status Code",
-                              "type": "integer"
-                            },
-                            "token_steps": {
-                              "anyOf": [
-                                {
-                                  "items": {
-                                    "additionalProperties": true,
-                                    "type": "object"
-                                  },
-                                  "type": "array"
-                                },
-                                {
-                                  "type": "null"
-                                }
-                              ],
-                              "default": null,
-                              "title": "Token Steps"
-                            },
-                            "total_tokens": {
-                              "default": 0,
-                              "title": "Total Tokens",
-                              "type": "integer"
-                            },
-                            "usage": {
-                              "anyOf": [
-                                {
-                                  "additionalProperties": true,
-                                  "type": "object"
-                                },
-                                {
-                                  "type": "null"
-                                }
-                              ],
-                              "default": null,
-                              "title": "Usage"
-                            }
-                          },
-                          "required": [
-                            "response"
-                          ],
-                          "title": "Parse2Result",
-                          "type": "object"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "description": "Present once status is ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead."
-                    },
-                    "status": {
-                      "enum": [
-                        "pending",
-                        "processing",
-                        "completed",
-                        "failed"
-                      ],
-                      "type": "string"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Job status / result"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Not found (e.g. no such job)."
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Request validation failed."
-          }
-        },
-        "summary": "ADE Get Parse v1 Jobs",
-        "tags": [
-          "Parse v1"
+          "Split"
         ]
       }
     },
@@ -5961,7 +6452,7 @@
                           }
                         ],
                         "default": null,
-                        "description": "Password for encrypted PDFs. Not currently supported — providing a value returns a 422 error; decrypt the file before uploading.",
+                        "description": "Password for an encrypted PDF. The document is decrypted once at the start of processing; the password is not retained with the result. PDFs only — supplying one for an image or Office document returns a 422 (`password_unsupported_content_type`). A wrong password returns a 422 (`encrypted_pdf_wrong_password`); omitting it for a locked PDF returns a 422 (`encrypted_pdf_password_required`).",
                         "title": "Password"
                       }
                     },
@@ -6220,7 +6711,7 @@
                           }
                         ],
                         "default": null,
-                        "description": "Password for encrypted PDFs. Not currently supported — providing a value returns a 422 error; decrypt the file before uploading.",
+                        "description": "Password for an encrypted PDF. The document is decrypted once at the start of processing; the password is not retained with the result. PDFs only — supplying one for an image or Office document returns a 422 (`password_unsupported_content_type`). A wrong password returns a 422 (`encrypted_pdf_wrong_password`); omitting it for a locked PDF returns a 422 (`encrypted_pdf_password_required`).",
                         "title": "Password"
                       }
                     },

--- a/src/landingai_ade/_base_client.py
+++ b/src/landingai_ade/_base_client.py
@@ -388,9 +388,7 @@ def _redact_binary_for_logging(value: object) -> object:
     if isinstance(value, list):
         return [_redact_binary_for_logging(item) for item in cast("list[object]", value)]
     if isinstance(value, dict):
-        return {
-            key: _redact_binary_for_logging(item) for key, item in cast("dict[object, object]", value).items()
-        }
+        return {key: _redact_binary_for_logging(item) for key, item in cast("dict[object, object]", value).items()}
     return value
 
 

--- a/src/landingai_ade/resources/v2/parse.py
+++ b/src/landingai_ade/resources/v2/parse.py
@@ -96,9 +96,15 @@ class ParseResource(V2ResourceMixin, SyncAPIResource):
           options: Additional parsing options. Sent to the server as a JSON-encoded string form
               field.
 
-          password: Password for encrypted document files. Sent to the server as
-              `options.password` (an explicit `options["password"]` takes precedence) and,
-              for older gateways, as a top-level form field.
+          password: Password for an encrypted PDF. Sent to the server as `options.password`
+              (an explicit `options["password"]` takes precedence) and, for older
+              gateways, as a top-level form field. The document is decrypted once at the
+              start of processing and the password is not retained with the result. PDFs
+              only -- the server answers 422 with a documented `code`: supplying a
+              password for an image or an Office document gives
+              `password_unsupported_content_type`, a wrong password gives
+              `encrypted_pdf_wrong_password`, and a locked PDF sent without one gives
+              `encrypted_pdf_password_required`.
 
           save_to: Optional output path. If a directory, auto-generates the filename
               (e.g. {input_file}_parse_output.json, or parse_output.json when no
@@ -227,9 +233,15 @@ class ParseJobsResource(V2ResourceMixin, SyncAPIResource):
           options: Additional parsing options. Sent to the server as a JSON-encoded string form
               field.
 
-          password: Password for encrypted document files. Sent to the server as
-              `options.password` (an explicit `options["password"]` takes precedence) and,
-              for older gateways, as a top-level form field.
+          password: Password for an encrypted PDF. Sent to the server as `options.password`
+              (an explicit `options["password"]` takes precedence) and, for older
+              gateways, as a top-level form field. The document is decrypted once at the
+              start of processing and the password is not retained with the result. PDFs
+              only -- the server answers 422 with a documented `code`: supplying a
+              password for an image or an Office document gives
+              `password_unsupported_content_type`, a wrong password gives
+              `encrypted_pdf_wrong_password`, and a locked PDF sent without one gives
+              `encrypted_pdf_password_required`.
 
           output_save_url: If zero data retention (ZDR) is enabled, a URL the parsed output should be
               saved to instead of being returned in the job result.

--- a/tests/api_resources/v2/test_parse.py
+++ b/tests/api_resources/v2/test_parse.py
@@ -8,7 +8,7 @@ import httpx
 import respx
 import pytest
 
-from landingai_ade import LandingAIADE
+from landingai_ade import LandingAIADE, UnprocessableEntityError
 from landingai_ade.types.v2 import Job, JobStatus, V2ParseResponse
 from landingai_ade.lib.v2_errors import V2SyncTimeoutError
 
@@ -226,6 +226,40 @@ def test_parse_sync_merges_password_into_existing_options() -> None:
     client.v2.parse(document=b"pdf", options={"password": "explicit"}, password="pw")
     sent = route.calls.last.request.content
     assert b'"password": "explicit"' in sent
+
+
+@pytest.mark.parametrize(
+    "code",
+    ["password_unsupported_content_type", "encrypted_pdf_wrong_password", "encrypted_pdf_password_required"],
+)
+@respx.mock
+def test_parse_sync_surfaces_encrypted_pdf_error_code(code: str) -> None:
+    # `options.password` is a genuinely supported option (an earlier snapshot
+    # documented it as unimplemented, so ANY value 422'd). The three documented
+    # password failures each come back as a 422 whose `ErrorResponse` body carries
+    # a stable snake_case `code`; the SDK must surface both, not flatten the body.
+    # Live coverage can only assert the status (see tests/contract/test_v2_smoke.py),
+    # so the code itself is pinned here against a controlled response.
+    client = LandingAIADE(apikey=APIKEY, environment="production")
+    body: Dict[str, Any] = {"code": code, "message": "the document could not be decrypted"}
+    respx.post("https://api.ade.landing.ai/v2/parse").mock(return_value=httpx.Response(422, json=body))
+    # `UnprocessableEntityError` pins the 422 (its `status_code` is `Literal[422]`).
+    with pytest.raises(UnprocessableEntityError) as excinfo:
+        client.v2.parse(document=b"pdf", password="hunter2")
+    assert excinfo.value.response.json() == body
+
+
+@respx.mock
+def test_parse_job_create_surfaces_encrypted_pdf_error_code() -> None:
+    # `/v2/parse/jobs` carries the same `options.password` contract, including the
+    # omitted-password case for a locked PDF, so the documented code must surface
+    # identically on the async route.
+    client = LandingAIADE(apikey=APIKEY, environment="production")
+    body: Dict[str, Any] = {"code": "encrypted_pdf_password_required", "message": "password required"}
+    respx.post("https://api.ade.landing.ai/v2/parse/jobs").mock(return_value=httpx.Response(422, json=body))
+    with pytest.raises(UnprocessableEntityError) as excinfo:
+        client.v2.parse_jobs.create(document=b"pdf")
+    assert excinfo.value.response.json() == body
 
 
 def test_parse_job_create_omits_explicit_none_extra_fields(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/contract/test_v2_smoke.py
+++ b/tests/contract/test_v2_smoke.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 from pydantic import Field, BaseModel
 
-from landingai_ade import LandingAIADE
+from landingai_ade import LandingAIADE, APIStatusError
 from landingai_ade.types.v2 import (
     JobStatus,
     V2GroundResult,
@@ -152,6 +152,24 @@ def test_parse_atomic_grounding_confidence(staging_client: LandingAIADE) -> None
     for page in resp.structure.children:
         _check_node(page.grounding)
         _walk(page.children)
+
+
+def test_parse_sync_password_requires_pdf(staging_client: LandingAIADE) -> None:
+    # `options.password` is now a supported parse option (an earlier snapshot
+    # documented it as unimplemented). The one half of its contract staging is
+    # guaranteed to honor is the rejection: the option is PDF-only, and
+    # `/v2/parse` declares only 200/206/422, so a non-PDF payload carrying a
+    # password can only come back as a 422. Assert the status and nothing more --
+    # the specific `code` (`password_unsupported_content_type`) needs a controlled
+    # response body and is pinned in tests/api_resources/v2/test_parse.py, and the
+    # success path would need an encrypted-PDF fixture plus a guarantee that this
+    # cluster runs the snapshot's gateway, which is an environment property.
+    with pytest.raises(APIStatusError) as excinfo:
+        staging_client.v2.parse(
+            document=("notes.txt", b"plain text, not a PDF", "text/plain"),
+            password="hunter2",
+        )
+    assert excinfo.value.status_code == 422
 
 
 def test_ground_sync(staging_client: LandingAIADE) -> None:


### PR DESCRIPTION
Automated V2 spec-sync PR (`client.v2`).

- **Commit 1 (mechanical):** normalized V2 spec snapshot + regenerated reference models.
- **Commit 2 (AI, only if the spec diff needs SDK changes):** client.v2 resources/methods/tests/docs wired from the diff, added after this PR opened. Workflow-only drift is excluded and an AI no-op is skipped, so some drifts produce a **mechanical-only PR with no second commit**.

Gates (surface-lock, V2 contract tests, lint/test/typecheck) must pass. When present, the AI commit is a **draft a human finishes** (the V2 ergonomic layer — unified Job, dual-host, schema coercion — is not in the spec). **Human review required before merge.**

<!-- what-changed:start -->
## What changed
_AI-generated from the PR diff — verify against the actual changes._

This PR adds documented support for the `password` parse option (encrypted PDF handling) shared by `parse` and `parse_jobs.create`, alongside an updated spec snapshot that also introduces server-side `/v1/ade/classify` and split/classify schema additions not wired into the client.

**Changes:**
- `client.v2.parse()` and `client.v2.parse_jobs.create()` now document `password` as a supported option (previously undocumented/unimplemented), sent as `options.password` with an explicit `options["password"]` taking precedence, plus a top-level form field for older gateways.
- Documents that the password is PDF-only and is not retained with the result, with three new documented 422 error codes: `password_unsupported_content_type`, `encrypted_pdf_wrong_password`, and `encrypted_pdf_password_required`.
- `api.md` gains a paragraph documenting this `password` behavior for `client.v2.parse`.
- The spec snapshot also adds `/v1/ade/classify` and `Split`/`SplitResponse`/`ClassifyClass` schemas and other server-side additions, but these are not exposed as client/SDK surface in this PR.
<!-- what-changed:end -->