### PR TITLE
spec-sync(v2): send jobs-list page_size as pageSize on the wire

### DIFF
--- a/api.md
+++ b/api.md
@@ -129,7 +129,7 @@ Methods:
 - <code title="get /v2/extract/jobs">client.v2.extract_jobs.<a href="./src/landingai_ade/resources/v2/extract.py">list</a>(\*, page=..., page_size=..., status=...) -> JobList[<a href="./src/landingai_ade/types/v2/job.py">Job</a>]</code>
 - <code>client.v2.extract_jobs.<a href="./src/landingai_ade/resources/v2/extract.py">wait</a>(job_id, \*, timeout=600, poll_interval=None, raise_on_failure=False) -> <a href="./src/landingai_ade/types/v2/job.py">Job</a></code>
 
-  Same polling/timeout semantics as `parse_jobs.wait`. Extract jobs have no `cancelled` status, so `raise_on_failure` only ever triggers on `failed`.
+  Same polling/timeout semantics as `parse_jobs.wait`. `cancelled` is a documented extract-job status as of the current snapshot (it was not in earlier ones) and counts as terminal, so `wait` returns a cancelled job rather than polling to the deadline.
 
 - <code title="post /v2/ground">client.v2.<a href="./src/landingai_ade/resources/v2/v2.py">ground</a>(\*, extraction_metadata, structure) -> <a href="./src/landingai_ade/types/v2/ground_response.py">V2GroundResult</a></code>
 
@@ -138,4 +138,5 @@ Methods:
 Notes:
 
 - `parse_jobs.list` and `extract_jobs.list` both return a `JobList` (a `list[Job]` subclass) carrying pagination metadata: `.has_more`, `.org_id`, `.page`, `.page_size`.
+- Both `list` methods take `page_size=` and send it on the wire as `pageSize`, which is the name `GET /v2/parse/jobs` and `GET /v2/extract/jobs` declare (V1's `client.parse_jobs.list` / `client.extract_jobs.list` alias it the same way). The keyword itself stays snake_case, as does the `page_size` field the response envelope echoes back on `JobList`. An unset `page`/`page_size`/`status` is omitted from the query rather than sent empty, so the gateway's own defaults (`page=0`, `pageSize=10`) apply.
 - All `client.v2.*` methods accept the usual `extra_headers`, `extra_query`, `extra_body`, and `timeout` overrides; sync methods additionally accept `save_to` (parse/extract only, not the job-creation methods) to write the response to disk, mirroring V1's `save_to`.

--- a/docs/v2-testing.md
+++ b/docs/v2-testing.md
@@ -10,11 +10,13 @@ what to check when the upstream spec (`specs/v2-aide.json`) changes.
 | --- | --- | --- |
 | Response models | `tests/test_v2_types.py` | Deserialization of `V2ParseResponse` / `V2ExtractResult` / `V2BuildSchemaResponse` / `V2GroundResult` and their nested models from plain dicts, including unknown-key tolerance. |
 | Job normalization | `tests/test_v2_normalize.py` | `normalize_parse_job` / `normalize_extract_job` / `normalize_build_schema_job`: envelope → unified `Job` (status, timestamps, `result`, `error`). |
-| Resource wiring | `tests/api_resources/v2/` | `respx`-mocked HTTP: host routing, multipart/JSON bodies, options serialization, job polling. No network. |
+| Shared job helpers | `tests/test_v2_waiter.py` | `resources/v2/_base.py` in isolation: `poll_until_terminal` (fake clock, no real sleeping), `JobList.build`, `build_jobs_list_query`. |
+| Resource wiring | `tests/api_resources/v2/` | `respx`-mocked HTTP: host routing, multipart/JSON bodies, query serialization, job polling. No network. |
 | Live smoke | `tests/contract/test_v2_smoke.py` | End-to-end calls against staging (marked `contract`; skipped unless `LANDINGAI_ADE_STAGING_APIKEY` is set). |
 
 Run the offline suites with `rye run pytest tests/test_v2_types.py
-tests/test_v2_normalize.py tests/api_resources/v2` (no credentials needed).
+tests/test_v2_normalize.py tests/test_v2_waiter.py tests/api_resources/v2` (no
+credentials needed).
 
 The live smoke suite runs only when `LANDINGAI_ADE_STAGING_APIKEY` is exported:
 
@@ -166,6 +168,67 @@ field-name drift:
 - Unknown / renamed `status` values fall back to `pending` rather than raising;
   the raw envelope is always preserved on `Job.raw`.
 
+### `cancelled` job status
+
+`cancelled` is now a documented status on the jobs-**list** routes — the current
+snapshot added it to `GET /v2/extract/jobs` (and to every V1-compat jobs-list
+route). The `202` create response and the `GET .../jobs/{job_id}` poll response
+still declare only `pending` / `processing` / `completed` / `failed`, so a job
+observed as cancelled surfaces through the list route.
+
+No model change was needed: `JobStatus` (`types/v2/job.py`) has always carried
+`CANCELLED`, and `Job.is_terminal` already counts it alongside `completed` /
+`failed`, so `.wait()` returns a cancelled job instead of polling to the
+deadline. `raise_on_failure` keys off an attached `error`, not off the status, so
+a cancellation only raises `JobFailedError` when the envelope carries an `error`
+(or a `failure_reason`, which the normalizers fold into `Job.error`).
+
+The regression guard for this is that normalization must **round-trip** the
+status rather than land on the `pending` fallback — that fallback is what would
+silently swallow a status the enum is missing:
+
+- Mocked: `test_extract_job_list_normalizes_cancelled_status` and
+  `test_extract_job_wait_stops_on_cancelled` in
+  `tests/api_resources/v2/test_extract.py`.
+- Live: `_check_job_list` in `tests/contract/test_v2_smoke.py` asserts
+  `job.status.value == job.raw["status"]` for every listed job, which fails if
+  the enum ever falls behind the gateway. It cannot assert a cancelled job is
+  *present* — whether the account has one is not a contract.
+
+## Jobs-list pagination (`pageSize` on the wire)
+
+`GET /v2/parse/jobs` and `GET /v2/extract/jobs` declare their per-page query
+parameter as **`pageSize`** (renamed from `page_size` upstream; V1's generated
+`parse_job_list_params` / `extract_job_list_params` alias it the same way). The
+SDK keyword stays `page_size=` — the public surface is release-locked, only the
+wire name moved:
+
+```python
+client.v2.parse_jobs.list(page=0, page_size=25)  # -> ?page=0&pageSize=25
+```
+
+`build_jobs_list_query` in `resources/v2/_base.py` owns that mapping for all
+three jobs resources (parse, extract, and the hidden build-schema), so the wire
+name lives in exactly one place. It also drops unset parameters instead of
+serializing them empty, letting the gateway apply its own `page=0` / `pageSize=10`
+defaults.
+
+The **response** envelope was *not* renamed and still returns `page_size`, which
+is what `JobList.build` reads onto `JobList.page_size`. Don't "fix" one to match
+the other.
+
+Testing it: the wire name is only assertable where the request is inspectable, so
+it is pinned in the mocked tests —
+`test_parse_job_list_sends_page_size_as_camel_case`,
+`test_extract_job_list_sends_page_size_as_camel_case`,
+`test_async_job_lists_send_page_size_as_camel_case`, plus dict-level cases on the
+helper in `tests/test_v2_waiter.py`. The live checks
+(`test_parse_jobs_list` / `test_extract_jobs_list`) deliberately do **not** assert
+that staging honored the page size: whether a given cluster runs the snapshot's
+gateway is an environment property, not an SDK contract. They assert only
+envelope-relative consistency (`len(jobs) <= jobs.page_size`) and absent-or-valid
+bounds on the echoed `page` / `page_size`.
+
 ## When the spec changes
 
 1. Read the mechanical diff (`git diff` on `specs/v2-aide.json` and
@@ -178,5 +241,18 @@ field-name drift:
    `src/landingai_ade/types/v2/`. Keep removed/renamed fields in place as optional
    for backward compatibility — the surface is release-locked and response parsing
    is lenient (missing fields default to `None`).
-4. Add or extend `respx` tests in `tests/api_resources/v2/` and a live assertion
+4. A **renamed request field or query parameter** changes the wire name only. The
+   Python keyword is release-locked, so map the old keyword onto the new wire name
+   (as `build_jobs_list_query` does for `page_size` → `pageSize`) rather than
+   renaming the parameter, and check whether the *response* was renamed too — the
+   two moved independently for `page_size`.
+5. A **widened enum** usually needs no model change, because the V2 job statuses
+   are normalized through the permissive `JobStatus` / `_status()` path. Confirm
+   the new member is already in `JobStatus` (and, if terminal, in
+   `Job.is_terminal`) instead of assuming it is, since an unlisted value silently
+   degrades to `pending` rather than raising.
+6. Add or extend `respx` tests in `tests/api_resources/v2/` and a live assertion
    in `tests/contract/test_v2_smoke.py`, then update `api.md` and this guide.
+   Anything environment-dependent (a model family, whether a cluster runs the
+   snapshot's gateway) belongs only in the mocked tests — see the `pageSize`
+   section above for how that line is drawn.

--- a/specs/_generated/v2_models.py
+++ b/specs/_generated/v2_models.py
@@ -742,8 +742,8 @@ class V1AdeClassifyJobsGetParametersQuery(BaseModel):
     page: Optional[int] = Field(
         0, description='Page number (0-indexed).', ge=0, title='Page'
     )
-    page_size: Optional[int] = Field(
-        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    pageSize: Optional[int] = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Pagesize'
     )
     status: Optional[str] = Field(
         None, description='Filter by job status.', title='Status'
@@ -755,6 +755,7 @@ class Status1(Enum):
     processing = 'processing'
     completed = 'completed'
     failed = 'failed'
+    cancelled = 'cancelled'
 
 
 class Job(BaseModel):
@@ -838,13 +839,20 @@ class V1AdeClassifyJobsPostRequest1(BaseModel):
     )
 
 
+class Status2(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+
+
 class V1AdeClassifyJobsPostResponse(BaseModel):
     created_at: Optional[str] = None
     job_id: Optional[str] = Field(
         None,
         description='The unique identifier for this v1-ade-classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
-    status: Optional[Status1] = None
+    status: Optional[Status2] = None
 
 
 class Error(BaseModel):
@@ -895,7 +903,7 @@ class V1AdeClassifyJobsJobIdGetResponse(BaseModel):
     result: Optional[Result] = Field(
         None, description='Present once status is ``completed``.'
     )
-    status: Optional[Status1] = None
+    status: Optional[Status2] = None
 
 
 class V1AdeExtractPostRequest(BaseModel):
@@ -957,12 +965,20 @@ class V1AdeExtractJobsGetParametersQuery(BaseModel):
     page: Optional[int] = Field(
         0, description='Page number (0-indexed).', ge=0, title='Page'
     )
-    page_size: Optional[int] = Field(
-        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    pageSize: Optional[int] = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Pagesize'
     )
     status: Optional[str] = Field(
         None, description='Filter by job status.', title='Status'
     )
+
+
+class Status4(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+    cancelled = 'cancelled'
 
 
 class Job1(BaseModel):
@@ -974,7 +990,7 @@ class Job1(BaseModel):
         description='The unique identifier for this v1-ade-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
     model_version: Optional[str] = None
-    status: Optional[Status1] = None
+    status: Optional[Status4] = None
 
 
 class V1AdeExtractJobsGetResponse(BaseModel):
@@ -1029,13 +1045,20 @@ class V1AdeExtractJobsPostRequest1(BaseModel):
     )
 
 
+class Status5(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+
+
 class V1AdeExtractJobsPostResponse(BaseModel):
     created_at: Optional[str] = None
     job_id: Optional[str] = Field(
         None,
         description='The unique identifier for this v1-ade-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
-    status: Optional[Status1] = None
+    status: Optional[Status5] = None
 
 
 class Result1(BaseModel):
@@ -1077,7 +1100,7 @@ class V1AdeExtractJobsJobIdGetResponse(BaseModel):
     result: Optional[Result1] = Field(
         None, description='Present once status is ``completed``.'
     )
-    status: Optional[Status1] = None
+    status: Optional[Status5] = None
 
 
 class V1AdeParsePostRequest(BaseModel):
@@ -1178,12 +1201,20 @@ class V1AdeParseJobsGetParametersQuery(BaseModel):
     page: Optional[int] = Field(
         0, description='Page number (0-indexed).', ge=0, title='Page'
     )
-    page_size: Optional[int] = Field(
-        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    pageSize: Optional[int] = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Pagesize'
     )
     status: Optional[str] = Field(
         None, description='Filter by job status.', title='Status'
     )
+
+
+class Status7(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+    cancelled = 'cancelled'
 
 
 class Job2(BaseModel):
@@ -1195,7 +1226,7 @@ class Job2(BaseModel):
         description='The unique identifier for this v1-ade-parse job. Format: ``parse2-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
     model_version: Optional[str] = None
-    status: Optional[Status1] = None
+    status: Optional[Status7] = None
 
 
 class V1AdeParseJobsGetResponse(BaseModel):
@@ -1281,13 +1312,20 @@ class V1AdeParseJobsPostRequest1(BaseModel):
     )
 
 
+class Status8(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+
+
 class V1AdeParseJobsPostResponse(BaseModel):
     created_at: Optional[str] = None
     job_id: Optional[str] = Field(
         None,
         description='The unique identifier for this v1-ade-parse job. Format: ``parse2-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
-    status: Optional[Status1] = None
+    status: Optional[Status8] = None
 
 
 class Result2(BaseModel):
@@ -1352,7 +1390,7 @@ class V1AdeParseJobsJobIdGetResponse(BaseModel):
         None,
         description='Present once status is ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead.',
     )
-    status: Optional[Status1] = None
+    status: Optional[Status8] = None
 
 
 class V1ClassifyPostRequest(BaseModel):
@@ -1420,12 +1458,20 @@ class V1ClassifyJobsGetParametersQuery(BaseModel):
     page: Optional[int] = Field(
         0, description='Page number (0-indexed).', ge=0, title='Page'
     )
-    page_size: Optional[int] = Field(
-        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    pageSize: Optional[int] = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Pagesize'
     )
     status: Optional[str] = Field(
         None, description='Filter by job status.', title='Status'
     )
+
+
+class Status10(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+    cancelled = 'cancelled'
 
 
 class Job3(BaseModel):
@@ -1437,7 +1483,7 @@ class Job3(BaseModel):
         description='The unique identifier for this classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
     model_version: Optional[str] = None
-    status: Optional[Status1] = None
+    status: Optional[Status10] = None
 
 
 class V1ClassifyJobsGetResponse(BaseModel):
@@ -1500,13 +1546,20 @@ class V1ClassifyJobsPostRequest1(BaseModel):
     )
 
 
+class Status11(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+
+
 class V1ClassifyJobsPostResponse(BaseModel):
     created_at: Optional[str] = None
     job_id: Optional[str] = Field(
         None,
         description='The unique identifier for this classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
-    status: Optional[Status1] = None
+    status: Optional[Status11] = None
 
 
 class Result3(BaseModel):
@@ -1546,7 +1599,7 @@ class V1ClassifyJobsJobIdGetResponse(BaseModel):
     result: Optional[Result3] = Field(
         None, description='Present once status is ``completed``.'
     )
-    status: Optional[Status1] = None
+    status: Optional[Status11] = None
 
 
 class V1ExtractBuildSchemaPostRequest(BaseModel):
@@ -1650,12 +1703,20 @@ class V1ExtractBuildSchemaJobsGetParametersQuery(BaseModel):
     page: Optional[int] = Field(
         0, description='Page number (0-indexed).', ge=0, title='Page'
     )
-    page_size: Optional[int] = Field(
-        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    pageSize: Optional[int] = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Pagesize'
     )
     status: Optional[str] = Field(
         None, description='Filter by job status.', title='Status'
     )
+
+
+class Status13(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+    cancelled = 'cancelled'
 
 
 class Job4(BaseModel):
@@ -1667,7 +1728,7 @@ class Job4(BaseModel):
         description='The unique identifier for this v1-build-schema job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
     model_version: Optional[str] = None
-    status: Optional[Status1] = None
+    status: Optional[Status13] = None
 
 
 class V1ExtractBuildSchemaJobsGetResponse(BaseModel):
@@ -1764,13 +1825,20 @@ class V1ExtractBuildSchemaJobsPostRequest1(BaseModel):
     )
 
 
+class Status14(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+
+
 class V1ExtractBuildSchemaJobsPostResponse(BaseModel):
     created_at: Optional[str] = None
     job_id: Optional[str] = Field(
         None,
         description='The unique identifier for this v1-build-schema job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
-    status: Optional[Status1] = None
+    status: Optional[Status14] = None
 
 
 class Result4(BaseModel):
@@ -1812,7 +1880,7 @@ class V1ExtractBuildSchemaJobsJobIdGetResponse(BaseModel):
     result: Optional[Result4] = Field(
         None, description='Present once status is ``completed``.'
     )
-    status: Optional[Status1] = None
+    status: Optional[Status14] = None
 
 
 class V1SplitPostRequest(BaseModel):
@@ -1953,12 +2021,20 @@ class V2ExtractJobsGetParametersQuery(BaseModel):
     page: Optional[int] = Field(
         0, description='Page number (0-indexed).', ge=0, title='Page'
     )
-    page_size: Optional[int] = Field(
-        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    pageSize: Optional[int] = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Pagesize'
     )
     status: Optional[str] = Field(
         None, description='Filter by job status.', title='Status'
     )
+
+
+class Status16(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+    cancelled = 'cancelled'
 
 
 class Job5(BaseModel):
@@ -1970,7 +2046,7 @@ class Job5(BaseModel):
         description='The unique identifier for this v2-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
     model_version: Optional[str] = None
-    status: Optional[Status1] = None
+    status: Optional[Status16] = None
 
 
 class V2ExtractJobsGetResponse(BaseModel):
@@ -2076,13 +2152,20 @@ class V2ExtractJobsPostRequest1(BaseModel):
     )
 
 
+class Status17(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+
+
 class V2ExtractJobsPostResponse(BaseModel):
     created_at: Optional[str] = None
     job_id: Optional[str] = Field(
         None,
         description='The unique identifier for this v2-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
-    status: Optional[Status1] = None
+    status: Optional[Status17] = None
 
 
 class Result5(BaseModel):
@@ -2152,7 +2235,7 @@ class V2ExtractJobsJobIdGetResponse(BaseModel):
         None,
         description='Present once status is ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead.',
     )
-    status: Optional[Status1] = None
+    status: Optional[Status17] = None
 
 
 class V2GroundPostRequest(BaseModel):
@@ -2256,8 +2339,8 @@ class V2ParseJobsGetParametersQuery(BaseModel):
     page: Optional[int] = Field(
         0, description='Page number (0-indexed).', ge=0, title='Page'
     )
-    page_size: Optional[int] = Field(
-        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    pageSize: Optional[int] = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Pagesize'
     )
     status: Optional[str] = Field(
         None, description='Filter by job status.', title='Status'
@@ -2405,8 +2488,8 @@ class V2WorkflowJobsGetParametersQuery(BaseModel):
     page: Optional[int] = Field(
         0, description='Page number (0-indexed).', ge=0, title='Page'
     )
-    page_size: Optional[int] = Field(
-        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    pageSize: Optional[int] = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Pagesize'
     )
     status: Optional[str] = Field(
         None, description='Filter by job status.', title='Status'
@@ -2418,6 +2501,7 @@ class Status22(Enum):
     processing = 'processing'
     completed = 'completed'
     failed = 'failed'
+    cancelled = 'cancelled'
 
 
 class Job7(BaseModel):
@@ -2448,13 +2532,20 @@ class ServiceTier15(Enum):
     priority = 'priority'
 
 
+class Status23(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+
+
 class V2WorkflowJobsPostResponse(BaseModel):
     created_at: Optional[str] = None
     job_id: Optional[str] = Field(
         None,
         description='The unique identifier for this v2-workflow job. Format: ``v2-workflow-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
-    status: Optional[Status22] = None
+    status: Optional[Status23] = None
 
 
 class Error7(BaseModel):
@@ -2525,7 +2616,7 @@ class V2WorkflowJobsJobIdGetResponse(BaseModel):
     result: Optional[Result6] = Field(
         None, description='Present once status is ``completed``.'
     )
-    status: Optional[Status22] = None
+    status: Optional[Status23] = None
 
 
 class BlocksOptions(BaseModel):

--- a/specs/v2-aide.json
+++ b/specs/v2-aide.json
@@ -1676,14 +1676,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -1751,7 +1751,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }
@@ -2329,14 +2330,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -2404,7 +2405,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }
@@ -3214,14 +3216,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -3289,7 +3291,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }
@@ -4151,14 +4154,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -4226,7 +4229,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }
@@ -4844,14 +4848,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -4919,7 +4923,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }
@@ -5674,14 +5679,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -5749,7 +5754,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }
@@ -6524,14 +6530,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -7130,14 +7136,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -7205,7 +7211,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }

--- a/src/landingai_ade/resources/v2/_base.py
+++ b/src/landingai_ade/resources/v2/_base.py
@@ -1,16 +1,19 @@
 # src/landingai_ade/resources/v2/_base.py
 from __future__ import annotations
 
-from typing import Any, List, Callable, Optional, Awaitable
+from typing import Any, Dict, List, Union, Callable, Optional, Awaitable
 
 import anyio
 
+from ..._types import Omit
+from ..._utils import is_given
 from ...types.v2 import Job
 from ...lib.v2_errors import JobFailedError, JobWaitTimeoutError
 
 __all__ = [
     "V2ResourceMixin",
     "JobList",
+    "build_jobs_list_query",
     "poll_until_terminal",
     "apoll_until_terminal",
     "DEFAULT_POLL_INITIAL",
@@ -37,6 +40,29 @@ class V2ResourceMixin:
 
     def _v2_url(self, path: str) -> str:
         return f"{self._client._v2_base_url}{path}"
+
+
+def build_jobs_list_query(
+    *,
+    page: Union[int, Omit],
+    page_size: Union[int, Omit],
+    status: Union[str, None, Omit],
+) -> Dict[str, Union[int, str]]:
+    """Build the query string for a V2 ``.../jobs`` list request.
+
+    The per-page parameter goes on the wire as ``pageSize``: the spec renamed it
+    from ``page_size``, and every jobs-list route in the snapshot now declares the
+    camelCase name (V1's generated list params alias it the same way). The Python
+    keyword stays ``page_size`` -- the SDK surface is unchanged, only the wire
+    name moved. Note the *response* envelope was NOT renamed and still returns
+    ``page_size``, which is what ``JobList.build`` reads.
+
+    Unset parameters are dropped rather than serialized: the gateway supplies its
+    own defaults (``page=0``, ``pageSize=10``), so sending nothing is not the same
+    as sending an empty value.
+    """
+    raw: Dict[str, Union[int, str, None, Omit]] = {"page": page, "pageSize": page_size, "status": status}
+    return {key: value for key, value in raw.items() if is_given(value) and value is not None}
 
 
 def _next_delay(current: float, poll_interval: Optional[float]) -> float:

--- a/src/landingai_ade/resources/v2/build_schema.py
+++ b/src/landingai_ade/resources/v2/build_schema.py
@@ -8,7 +8,14 @@ from typing_extensions import Literal
 import httpx
 from pydantic import BaseModel
 
-from ._base import DEFAULT_WAIT_TIMEOUT, JobList, V2ResourceMixin, poll_until_terminal, apoll_until_terminal
+from ._base import (
+    DEFAULT_WAIT_TIMEOUT,
+    JobList,
+    V2ResourceMixin,
+    poll_until_terminal,
+    apoll_until_terminal,
+    build_jobs_list_query,
+)
 from ..._types import Body, Omit, Query, Headers, NotGiven, FileTypes, omit, not_given
 from ..._utils import is_given
 from ...types.v2 import Job, V2BuildSchemaResponse
@@ -347,11 +354,12 @@ class BuildSchemaJobsResource(V2ResourceMixin, SyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> JobList:
         """List async build-schema jobs associated with your API key, newest first."""
-        query = {
-            key: value
-            for key, value in {"page": page, "page_size": page_size, "status": status}.items()
-            if is_given(value) and value is not None
-        }
+        # Same `pageSize` wire name as the parse/extract lists. This route is stripped
+        # from the snapshot (the surface is hidden), so it carries no spec evidence of
+        # its own -- but it is the same gateway, the rename landed on all eight
+        # jobs-list routes the snapshot does document (build-schema's own V1 twin
+        # `/v1/extract/build-schema/jobs` included), and nothing public reaches here.
+        query = build_jobs_list_query(page=page, page_size=page_size, status=status)
         raw = self._get(
             self._v2_url("/v2/extract/build-schema/jobs"),
             options=make_request_options(
@@ -380,8 +388,8 @@ class BuildSchemaJobsResource(V2ResourceMixin, SyncAPIResource):
 
         Raises `JobWaitTimeoutError` if `timeout` seconds elapse before the job
         reaches a terminal state, and `JobFailedError` if `raise_on_failure` is
-        set and the job ends failed with an error attached. Build-schema jobs have
-        no `cancelled` status.
+        set and the job ends failed/cancelled with an error attached. `cancelled`
+        counts as terminal.
 
         `_monotonic` is a test seam for injecting a fake clock; production
         callers should leave it unset (defaults to `time.monotonic`).
@@ -473,11 +481,7 @@ class AsyncBuildSchemaJobsResource(V2ResourceMixin, AsyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> JobList:
         """Async mirror of `BuildSchemaJobsResource.list`. See there for full documentation."""
-        query = {
-            key: value
-            for key, value in {"page": page, "page_size": page_size, "status": status}.items()
-            if is_given(value) and value is not None
-        }
+        query = build_jobs_list_query(page=page, page_size=page_size, status=status)
         raw = await self._get(
             self._v2_url("/v2/extract/build-schema/jobs"),
             options=make_request_options(

--- a/src/landingai_ade/resources/v2/extract.py
+++ b/src/landingai_ade/resources/v2/extract.py
@@ -8,7 +8,14 @@ from typing_extensions import Literal
 import httpx
 from pydantic import BaseModel
 
-from ._base import DEFAULT_WAIT_TIMEOUT, JobList, V2ResourceMixin, poll_until_terminal, apoll_until_terminal
+from ._base import (
+    DEFAULT_WAIT_TIMEOUT,
+    JobList,
+    V2ResourceMixin,
+    poll_until_terminal,
+    apoll_until_terminal,
+    build_jobs_list_query,
+)
 from ..._types import Body, Omit, Query, Headers, NotGiven, omit, not_given
 from ..._utils import is_given
 from ...types.v2 import Job, V2ExtractResult
@@ -268,11 +275,7 @@ class ExtractJobsResource(V2ResourceMixin, SyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> JobList:
         """List async extract jobs associated with your API key, newest first."""
-        query = {
-            key: value
-            for key, value in {"page": page, "page_size": page_size, "status": status}.items()
-            if is_given(value) and value is not None
-        }
+        query = build_jobs_list_query(page=page, page_size=page_size, status=status)
         raw = self._get(
             self._v2_url("/v2/extract/jobs"),
             options=make_request_options(
@@ -301,8 +304,9 @@ class ExtractJobsResource(V2ResourceMixin, SyncAPIResource):
 
         Raises `JobWaitTimeoutError` if `timeout` seconds elapse before the job
         reaches a terminal state, and `JobFailedError` if `raise_on_failure` is
-        set and the job ends failed with an error attached. Extract jobs have no
-        `cancelled` status.
+        set and the job ends failed/cancelled with an error attached. `cancelled`
+        is now a documented extract-job status (it was not in earlier snapshots),
+        and it counts as terminal.
 
         `_monotonic` is a test seam for injecting a fake clock; production
         callers should leave it unset (defaults to `time.monotonic`).
@@ -382,11 +386,7 @@ class AsyncExtractJobsResource(V2ResourceMixin, AsyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> JobList:
         """Async mirror of `ExtractJobsResource.list`. See there for full documentation."""
-        query = {
-            key: value
-            for key, value in {"page": page, "page_size": page_size, "status": status}.items()
-            if is_given(value) and value is not None
-        }
+        query = build_jobs_list_query(page=page, page_size=page_size, status=status)
         raw = await self._get(
             self._v2_url("/v2/extract/jobs"),
             options=make_request_options(

--- a/src/landingai_ade/resources/v2/parse.py
+++ b/src/landingai_ade/resources/v2/parse.py
@@ -9,7 +9,14 @@ from typing_extensions import Literal
 
 import httpx
 
-from ._base import DEFAULT_WAIT_TIMEOUT, JobList, V2ResourceMixin, poll_until_terminal, apoll_until_terminal
+from ._base import (
+    DEFAULT_WAIT_TIMEOUT,
+    JobList,
+    V2ResourceMixin,
+    poll_until_terminal,
+    apoll_until_terminal,
+    build_jobs_list_query,
+)
 from ..._files import deepcopy_with_paths
 from ..._types import Body, Omit, Query, Headers, NotGiven, FileTypes, omit, not_given
 from ..._utils import is_given, extract_files
@@ -314,11 +321,7 @@ class ParseJobsResource(V2ResourceMixin, SyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> JobList:
         """List async parse jobs associated with your API key, newest first."""
-        query = {
-            key: value
-            for key, value in {"page": page, "page_size": page_size, "status": status}.items()
-            if is_given(value) and value is not None
-        }
+        query = build_jobs_list_query(page=page, page_size=page_size, status=status)
         raw = self._get(
             self._v2_url("/v2/parse/jobs"),
             options=make_request_options(
@@ -439,11 +442,7 @@ class AsyncParseJobsResource(V2ResourceMixin, AsyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> JobList:
         """Async mirror of `ParseJobsResource.list`. See there for full documentation."""
-        query = {
-            key: value
-            for key, value in {"page": page, "page_size": page_size, "status": status}.items()
-            if is_given(value) and value is not None
-        }
+        query = build_jobs_list_query(page=page, page_size=page_size, status=status)
         raw = await self._get(
             self._v2_url("/v2/parse/jobs"),
             options=make_request_options(

--- a/tests/api_resources/v2/test_async_smoke.py
+++ b/tests/api_resources/v2/test_async_smoke.py
@@ -72,3 +72,27 @@ async def test_async_extract_jobs_create_get_and_wait() -> None:
     waited = await client.v2.extract_jobs.wait("e1", timeout=30, poll_interval=0.01, _monotonic=lambda: next(ticks))
     assert waited.status is JobStatus.COMPLETED
     assert isinstance(waited.result, V2ExtractResult)
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_async_job_lists_send_page_size_as_camel_case() -> None:
+    """Both async list methods must send the spec's `pageSize` wire name, not the
+    `page_size` keyword they expose. Mirrors the sync cases in test_parse.py /
+    test_extract.py."""
+    client = AsyncLandingAIADE(apikey=APIKEY)
+
+    parse_route = respx.get("https://api.ade.landing.ai/v2/parse/jobs").mock(
+        return_value=httpx.Response(200, json={"jobs": [], "has_more": False})
+    )
+    extract_route = respx.get("https://api.ade.landing.ai/v2/extract/jobs").mock(
+        return_value=httpx.Response(200, json={"jobs": [], "has_more": False})
+    )
+
+    await client.v2.parse_jobs.list(page=0, page_size=3)
+    await client.v2.extract_jobs.list(page=0, page_size=3)
+
+    for route in (parse_route, extract_route):
+        params = route.calls.last.request.url.params
+        assert params["pageSize"] == "3"
+        assert "page_size" not in params

--- a/tests/api_resources/v2/test_extract.py
+++ b/tests/api_resources/v2/test_extract.py
@@ -274,3 +274,62 @@ def test_extract_job_list_carries_envelope() -> None:
     assert jobs.has_more is True
     assert jobs.page == 0
     assert jobs.page_size == 10
+
+
+@respx.mock
+def test_extract_job_list_sends_page_size_as_camel_case() -> None:
+    # `GET /v2/extract/jobs` declares the per-page parameter as `pageSize`; the
+    # `page_size=` keyword is the SDK surface and must not reach the wire under
+    # its snake_case name, or the gateway silently falls back to its default 10.
+    # The *response* envelope keeps `page_size` -- see the test above.
+    client = LandingAIADE(apikey=APIKEY)
+    route = respx.get("https://api.ade.landing.ai/v2/extract/jobs").mock(
+        return_value=httpx.Response(200, json={"jobs": [], "has_more": False})
+    )
+    client.v2.extract_jobs.list(page=1, page_size=25, status="pending")
+    params = route.calls.last.request.url.params
+    assert params["pageSize"] == "25"
+    assert params["page"] == "1"
+    assert params["status"] == "pending"
+    assert "page_size" not in params
+
+
+@respx.mock
+def test_extract_job_list_normalizes_cancelled_status() -> None:
+    # `cancelled` is a documented extract-job list status as of this snapshot. It
+    # must map to `JobStatus.CANCELLED` rather than falling into the unknown-status
+    # `pending` fallback, and it must read as terminal so `.wait()` stops polling.
+    client = LandingAIADE(apikey=APIKEY)
+    respx.get("https://api.ade.landing.ai/v2/extract/jobs").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "jobs": [
+                    {"job_id": "e1", "status": "cancelled", "failure_reason": "cancelled by user"},
+                    {"job_id": "e2", "status": "processing"},
+                ],
+                "has_more": False,
+            },
+        )
+    )
+    jobs = client.v2.extract_jobs.list()
+    cancelled, running = jobs[0], jobs[1]
+    assert cancelled.status is JobStatus.CANCELLED
+    assert cancelled.is_terminal is True
+    # `failure_reason` is the list envelope's flat error form; the normalizer folds
+    # it into `Job.error`, which is what `raise_on_failure` keys off.
+    assert cancelled.error is not None and cancelled.error.message == "cancelled by user"
+    assert running.status is JobStatus.PROCESSING and running.is_terminal is False
+
+
+@respx.mock
+def test_extract_job_wait_stops_on_cancelled() -> None:
+    # A cancelled job is terminal, so `.wait()` returns it instead of polling until
+    # the deadline. `raise_on_failure` still keys off an attached `error`.
+    client = LandingAIADE(apikey=APIKEY)
+    respx.get("https://api.ade.landing.ai/v2/extract/jobs/e9").mock(
+        return_value=httpx.Response(200, json={"job_id": "e9", "status": "cancelled"})
+    )
+    waited = client.v2.extract_jobs.wait("e9", timeout=30, poll_interval=0.01)
+    assert waited.status is JobStatus.CANCELLED
+    assert waited.result is None

--- a/tests/api_resources/v2/test_parse.py
+++ b/tests/api_resources/v2/test_parse.py
@@ -507,6 +507,33 @@ def test_parse_job_list_carries_page_envelope() -> None:
 
 
 @respx.mock
+def test_parse_job_list_sends_page_size_as_camel_case() -> None:
+    # `GET /v2/parse/jobs` declares the per-page parameter as `pageSize`; the
+    # `page_size=` keyword is the SDK surface and must not reach the wire under
+    # its snake_case name, or the gateway silently falls back to its default 10.
+    client = LandingAIADE(apikey=APIKEY)
+    route = respx.get("https://api.ade.landing.ai/v2/parse/jobs").mock(
+        return_value=httpx.Response(200, json={"jobs": [], "has_more": False})
+    )
+    client.v2.parse_jobs.list(page=2, page_size=5)
+    params = route.calls.last.request.url.params
+    assert params["pageSize"] == "5"
+    assert params["page"] == "2"
+    assert "page_size" not in params
+
+
+@respx.mock
+def test_parse_job_list_omits_unset_pagination_params() -> None:
+    client = LandingAIADE(apikey=APIKEY)
+    route = respx.get("https://api.ade.landing.ai/v2/parse/jobs").mock(
+        return_value=httpx.Response(200, json={"jobs": [], "has_more": False})
+    )
+    client.v2.parse_jobs.list()
+    params = route.calls.last.request.url.params
+    assert "pageSize" not in params and "page" not in params and "status" not in params
+
+
+@respx.mock
 def test_parse_sync_tolerates_unknown_element_type_and_extra_keys() -> None:
     # Novel element `type` values and extra keys must not break deserialization
     # (`type` is a permissive str; BaseModel retains extra keys).

--- a/tests/contract/test_v2_smoke.py
+++ b/tests/contract/test_v2_smoke.py
@@ -16,6 +16,7 @@ from landingai_ade.types.v2 import (
     V2ParseResponse,
     V2ParseNodeGrounding,
 )
+from landingai_ade.resources.v2._base import JobList
 
 pytestmark = pytest.mark.contract
 
@@ -201,3 +202,40 @@ def test_parse_jobs(staging_client: LandingAIADE) -> None:
     # `Job.metadata` receipt (set only for `output_save_url` deliveries) is absent.
     assert done.metadata is None
     assert done.result.metadata is not None
+
+
+def _check_job_list(jobs: JobList) -> None:
+    """Assert a live jobs-list page, using only what staging is guaranteed to return.
+
+    The account may legitimately have zero jobs, and every field of the pagination
+    envelope is optional in the spec, so everything here is absent-or-valid.
+    """
+    # Absent-or-valid on the echoed envelope: `page` is 0-indexed, and the
+    # effective page size can only be one the route accepts (min 1, max 100).
+    if jobs.page is not None:
+        assert jobs.page >= 0
+    if jobs.page_size is not None:
+        assert 1 <= jobs.page_size <= 100
+        # Envelope-relative, not request-relative: whether this cluster's gateway
+        # honors the `pageSize` we sent is an environment property, so only the
+        # page's self-consistency is assertable live. The wire name itself is
+        # pinned in the mocked tests under tests/api_resources/v2/.
+        assert len(jobs) <= jobs.page_size
+    for job in jobs:
+        assert job.job_id
+        # The list route's `status` enum is closed in the spec and `JobStatus`
+        # covers every member of it, so normalization must round-trip the value
+        # exactly. A status `JobStatus` lacked would instead land on the `pending`
+        # fallback and fail here -- which is the guard that matters now that the
+        # spec's list enum has grown `cancelled`.
+        raw_status: object = job.raw.get("status")
+        if isinstance(raw_status, str):
+            assert job.status.value == raw_status
+
+
+def test_parse_jobs_list(staging_client: LandingAIADE) -> None:
+    _check_job_list(staging_client.v2.parse_jobs.list(page=0, page_size=5))
+
+
+def test_extract_jobs_list(staging_client: LandingAIADE) -> None:
+    _check_job_list(staging_client.v2.extract_jobs.list(page=0, page_size=5))

--- a/tests/test_v2_waiter.py
+++ b/tests/test_v2_waiter.py
@@ -4,6 +4,7 @@ from typing import List, Callable, Optional
 
 import pytest
 
+from landingai_ade._types import omit
 from landingai_ade.types.v2 import Job, JobError, JobStatus
 from landingai_ade.resources.v2 import _base
 from landingai_ade.lib.v2_errors import JobFailedError, JobWaitTimeoutError
@@ -289,3 +290,31 @@ def test_joblist_build_has_more_accepts_real_bool() -> None:
     result = JobList.build([], has_more=True)
 
     assert result.has_more is True
+
+
+# --------------------------------------------------------------------------
+# build_jobs_list_query
+# --------------------------------------------------------------------------
+
+
+def test_build_jobs_list_query_renames_page_size_to_camel_case() -> None:
+    # The jobs-list routes declare the per-page parameter as `pageSize`. Assert at
+    # the dict level, not through the URL, since the querystring encoder would
+    # happily serialize either name.
+    assert _base.build_jobs_list_query(page=1, page_size=25, status="failed") == {
+        "page": 1,
+        "pageSize": 25,
+        "status": "failed",
+    }
+
+
+def test_build_jobs_list_query_drops_unset_and_none() -> None:
+    # `omit` and an explicit `None` both mean "let the gateway default apply", so
+    # neither may be serialized -- an empty `pageSize=` is a 422, not a default.
+    assert _base.build_jobs_list_query(page=omit, page_size=omit, status=None) == {}
+    assert _base.build_jobs_list_query(page=0, page_size=omit, status=omit) == {"page": 0}
+
+
+def test_build_jobs_list_query_keeps_page_zero() -> None:
+    # Page 0 is the first page, not a missing value: it must survive the filter.
+    assert _base.build_jobs_list_query(page=0, page_size=10, status=omit) == {"page": 0, "pageSize": 10}


### PR DESCRIPTION
Automated V2 spec-sync PR (`client.v2`).

- **Commit 1 (mechanical):** normalized V2 spec snapshot + regenerated reference models.
- **Commit 2 (AI, only if the spec diff needs SDK changes):** client.v2 resources/methods/tests/docs wired from the diff, added after this PR opened. Workflow-only drift is excluded and an AI no-op is skipped, so some drifts produce a **mechanical-only PR with no second commit**.

Gates (surface-lock, V2 contract tests, lint/test/typecheck) must pass. When present, the AI commit is a **draft a human finishes** (the V2 ergonomic layer — unified Job, dual-host, schema coercion — is not in the spec). **Human review required before merge.**

<!-- what-changed:start -->
## What changed
_AI-generated from the PR diff — verify against the actual changes._

This PR updates the V2 jobs-list wire format to use `pageSize` as the query parameter name and adds `cancelled` as a recognized terminal status for extract jobs.

**Changes:**
- `client.v2.parse_jobs.list` and `client.v2.extract_jobs.list` now send the `page_size=` keyword on the wire as `pageSize` (response envelope still returns `page_size` unchanged).
- Unset `page`/`page_size`/`status` on jobs-list calls are now omitted from the query entirely instead of sent empty, deferring to gateway defaults (`page=0`, `pageSize=10`).
- `extract_jobs.wait` now treats `cancelled` as a documented, terminal extract-job status and returns the cancelled job instead of polling to the timeout.
- Added `build_jobs_list_query` shared helper centralizing the `page_size` → `pageSize` wire mapping used by parse, extract, and build-schema jobs-list requests.
<!-- what-changed:end -->