### PR TITLE
spec-sync(v1): add 415 response for non-multipart request bodies

### DIFF
--- a/specs/v1-ade.json
+++ b/specs/v1-ade.json
@@ -2267,6 +2267,9 @@
             },
             "description": "Extraction completed with success but there was a schema validation error."
           },
+          "415": {
+            "description": "The request body was not form-encoded. Send multipart/form-data."
+          },
           "422": {
             "content": {
               "application/json": {
@@ -2440,6 +2443,9 @@
               }
             },
             "description": "Job queued successfully"
+          },
+          "415": {
+            "description": "The request body was not form-encoded. Send multipart/form-data."
           },
           "422": {
             "content": {


### PR DESCRIPTION
Automated spec-sync PR.

- **Commit 1 (mechanical):** normalized spec snapshot + regenerated reference models.
- **Commit 2 (AI):** resources/methods/tests/docs wired from the spec diff (added after this PR opened).

Gates (surface-lock, contract tests, lint/test/typecheck) must pass. **Human review required before merge.**

<!-- what-changed:start -->
## What changed
_AI-generated from the PR diff — verify against the actual changes._

This PR documents a new 415 error response for endpoints requiring multipart/form-data request bodies.

**Changes:**
- Added a documented 415 response ("The request body was not form-encoded. Send multipart/form-data.") to the synchronous extraction endpoint.
- Added the same documented 415 response to the async job submission endpoint.
<!-- what-changed:end -->
<!-- spec-sync-nudged: 20711 -->
