### PR TITLE
spec-sync(v2): send job list page_size as pageSize query param on the wire

### DIFF
--- a/api.md
+++ b/api.md
@@ -129,7 +129,7 @@ Methods:
 - <code title="get /v2/extract/jobs">client.v2.extract_jobs.<a href="./src/landingai_ade/resources/v2/extract.py">list</a>(\*, page=..., page_size=..., status=...) -> JobList[<a href="./src/landingai_ade/types/v2/job.py">Job</a>]</code>
 - <code>client.v2.extract_jobs.<a href="./src/landingai_ade/resources/v2/extract.py">wait</a>(job_id, \*, timeout=600, poll_interval=None, raise_on_failure=False) -> <a href="./src/landingai_ade/types/v2/job.py">Job</a></code>
 
-  Same polling/timeout semantics as `parse_jobs.wait`. Extract jobs have no `cancelled` status, so `raise_on_failure` only ever triggers on `failed`.
+  Same polling/timeout semantics as `parse_jobs.wait`. `cancelled` joined the extract job statuses in the current spec snapshot, so -- as for parse -- `raise_on_failure` can trigger on a `failed` or a `cancelled` job that carries an `error`.
 
 - <code title="post /v2/ground">client.v2.<a href="./src/landingai_ade/resources/v2/v2.py">ground</a>(\*, extraction_metadata, structure) -> <a href="./src/landingai_ade/types/v2/ground_response.py">V2GroundResult</a></code>
 
@@ -138,4 +138,5 @@ Methods:
 Notes:
 
 - `parse_jobs.list` and `extract_jobs.list` both return a `JobList` (a `list[Job]` subclass) carrying pagination metadata: `.has_more`, `.org_id`, `.page`, `.page_size`.
+- The `page_size=` keyword on both `list` methods is sent as the `pageSize` query parameter, which is the name the spec now gives it on every `*/jobs` list route. Only the wire name changed: the keyword and the `JobList.page_size` attribute read back off the response envelope both keep the snake_case spelling.
 - All `client.v2.*` methods accept the usual `extra_headers`, `extra_query`, `extra_body`, and `timeout` overrides; sync methods additionally accept `save_to` (parse/extract only, not the job-creation methods) to write the response to disk, mirroring V1's `save_to`.

--- a/docs/v2-testing.md
+++ b/docs/v2-testing.md
@@ -151,6 +151,36 @@ each extracted field back to the `structure` blocks it was quoted from:
 accepts a plain `dict` or a pydantic model (so a parse response's `.structure` can
 be passed directly). `/v2/ground` is synchronous-only (no async jobs route).
 
+## Listing jobs (`parse_jobs.list` / `extract_jobs.list`)
+
+Both list routes (`GET /v2/parse/jobs`, `GET /v2/extract/jobs`) take `page`,
+`page_size` and `status`, and return a `JobList` — a `list[Job]` subclass carrying
+`.has_more`, `.org_id`, `.page` and `.page_size`.
+
+- **The per-page query parameter is `pageSize` on the wire.** The spec renamed it
+  from `page_size` on every `*/jobs` list route; the SDK keyword stays `page_size`
+  (renaming it would break callers, and the surface is release-locked), so the
+  rename is only visible in the request URL. The **response** envelope's own
+  `page_size` field was *not* renamed and is read back as-is into
+  `JobList.page_size` — do not "fix" that to camelCase.
+  Sending the old spelling is not an error the gateway reports: the parameter is
+  optional, so an unrecognized name is ignored and the page silently comes back at
+  the default size of 10. That is why the rename is pinned on the request URL in
+  `tests/api_resources/v2/test_parse.py` and `test_extract.py`
+  (`test_*_job_list_sends_page_size_as_pagesize`), on both async mirrors in
+  `test_async_smoke.py` (they build their own query dict), and live in
+  `tests/contract/test_v2_smoke.py` (`test_job_lists_honor_page_size`, which asks
+  for one item and asserts at most one comes back).
+- **`cancelled` is a status the extract job list can return.** It joined
+  `GET /v2/extract/jobs` in the current snapshot; `GET /v2/parse/jobs` still
+  documents only `pending`/`processing`/`completed`/`failed`. No code change was
+  needed — `JobStatus` has carried `CANCELLED` all along and `Job.is_terminal`
+  already treats it as terminal alongside `completed`/`failed` — but the extract
+  waiter's docs no longer claim extract jobs cannot be cancelled.
+- The `/v2/*/jobs/{job_id}` poll and the `POST` create responses do **not** list
+  `cancelled`; only the list envelopes do. The unified `Job` accepts it from any of
+  them regardless, since `_status()` is tolerant by design.
+
 ## Async job envelopes
 
 `normalize_parse_job`, `normalize_extract_job`, and `normalize_build_schema_job`
@@ -174,6 +204,9 @@ field-name drift:
 2. Additive **request** fields become new optional keyword params on the
    corresponding `run` / `create` method (parse forwards free-form `options`
    through as a JSON string, so most parse-option additions need no code change).
+   A renamed **query parameter** is a wire-only change: update the key the resource
+   puts in its `query` dict and leave the Python keyword alone, since the surface is
+   release-locked (see the `pageSize` note above).
 3. Additive **response** fields are added to the matching model under
    `src/landingai_ade/types/v2/`. Keep removed/renamed fields in place as optional
    for backward compatibility — the surface is release-locked and response parsing

--- a/specs/_generated/v2_models.py
+++ b/specs/_generated/v2_models.py
@@ -285,7 +285,7 @@ class SplitMetadata(BaseModel):
     )
     filename: str = Field(
         ...,
-        description="Display name of the split document: the URL path's file name for `markdown_url` inputs, or a generated name for inline and uploaded Markdown.",
+        description="Display name of the split document: the uploaded file's name for `markdown` file uploads (`.md` is appended when the name has no suffix), the URL path's file name for `markdown_url` inputs, or a generated name for inline Markdown.",
         title='Filename',
     )
     job_id: str = Field(
@@ -742,8 +742,8 @@ class V1AdeClassifyJobsGetParametersQuery(BaseModel):
     page: Optional[int] = Field(
         0, description='Page number (0-indexed).', ge=0, title='Page'
     )
-    page_size: Optional[int] = Field(
-        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    pageSize: Optional[int] = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Pagesize'
     )
     status: Optional[str] = Field(
         None, description='Filter by job status.', title='Status'
@@ -755,6 +755,7 @@ class Status1(Enum):
     processing = 'processing'
     completed = 'completed'
     failed = 'failed'
+    cancelled = 'cancelled'
 
 
 class Job(BaseModel):
@@ -838,13 +839,20 @@ class V1AdeClassifyJobsPostRequest1(BaseModel):
     )
 
 
+class Status2(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+
+
 class V1AdeClassifyJobsPostResponse(BaseModel):
     created_at: Optional[str] = None
     job_id: Optional[str] = Field(
         None,
         description='The unique identifier for this v1-ade-classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
-    status: Optional[Status1] = None
+    status: Optional[Status2] = None
 
 
 class Error(BaseModel):
@@ -895,7 +903,7 @@ class V1AdeClassifyJobsJobIdGetResponse(BaseModel):
     result: Optional[Result] = Field(
         None, description='Present once status is ``completed``.'
     )
-    status: Optional[Status1] = None
+    status: Optional[Status2] = None
 
 
 class V1AdeExtractPostRequest(BaseModel):
@@ -903,10 +911,13 @@ class V1AdeExtractPostRequest(BaseModel):
     Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.
 
     VTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline
-    string), ``markdown_url``, ``schema``, ``strict``. Nothing else — AIDE's own
-    extras (``return_reasoning``, ``fallback_model``, ``output_save_url``) stay on
-    the R&D ``/api/extract`` contract, so the customer surface publishes the VTRA
-    contract and only that.
+    string), ``markdown_url``, ``schema``, ``strict``, ``output_save_url``. AIDE's
+    own extras (``return_reasoning``, ``fallback_model``) stay on the R&D
+    ``/api/extract`` contract — only ``output_save_url`` is shared with it, because
+    it is also on VTRA's async wire (aide#2053, the extract half of the
+    ``output_save_url``/ZDR parity pair that started with parse in #2056's
+    predecessor) — so the customer surface publishes the VTRA contract and only
+    that.
     """
 
     markdown: Optional[str] = Field(None, title='Markdown')
@@ -957,12 +968,20 @@ class V1AdeExtractJobsGetParametersQuery(BaseModel):
     page: Optional[int] = Field(
         0, description='Page number (0-indexed).', ge=0, title='Page'
     )
-    page_size: Optional[int] = Field(
-        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    pageSize: Optional[int] = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Pagesize'
     )
     status: Optional[str] = Field(
         None, description='Filter by job status.', title='Status'
     )
+
+
+class Status4(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+    cancelled = 'cancelled'
 
 
 class Job1(BaseModel):
@@ -974,7 +993,7 @@ class Job1(BaseModel):
         description='The unique identifier for this v1-ade-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
     model_version: Optional[str] = None
-    status: Optional[Status1] = None
+    status: Optional[Status4] = None
 
 
 class V1AdeExtractJobsGetResponse(BaseModel):
@@ -989,15 +1008,19 @@ class V1AdeExtractJobsPostRequest(BaseModel):
     Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.
 
     VTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline
-    string), ``markdown_url``, ``schema``, ``strict``. Nothing else — AIDE's own
-    extras (``return_reasoning``, ``fallback_model``, ``output_save_url``) stay on
-    the R&D ``/api/extract`` contract, so the customer surface publishes the VTRA
-    contract and only that.
+    string), ``markdown_url``, ``schema``, ``strict``, ``output_save_url``. AIDE's
+    own extras (``return_reasoning``, ``fallback_model``) stay on the R&D
+    ``/api/extract`` contract — only ``output_save_url`` is shared with it, because
+    it is also on VTRA's async wire (aide#2053, the extract half of the
+    ``output_save_url``/ZDR parity pair that started with parse in #2056's
+    predecessor) — so the customer surface publishes the VTRA contract and only
+    that.
     """
 
     markdown: Optional[str] = Field(None, title='Markdown')
     markdown_url: Optional[str] = Field(None, title='Markdown Url')
     model: Optional[str] = Field(None, title='Model')
+    output_save_url: Optional[str] = Field(None, title='Output Save Url')
     schema_: Optional[str] = Field(None, alias='schema', title='Schema')
     service_tier: Optional[ServiceTier2] = Field(
         None,
@@ -1014,6 +1037,11 @@ class V1AdeExtractJobsPostRequest1(BaseModel):
     model: Optional[str] = Field(
         None, description='JSON-serialized string in form data.', title='Model'
     )
+    output_save_url: Optional[str] = Field(
+        None,
+        description='JSON-serialized string in form data.',
+        title='Output Save Url',
+    )
     schema_: Optional[str] = Field(
         None,
         alias='schema',
@@ -1029,13 +1057,20 @@ class V1AdeExtractJobsPostRequest1(BaseModel):
     )
 
 
+class Status5(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+
+
 class V1AdeExtractJobsPostResponse(BaseModel):
     created_at: Optional[str] = None
     job_id: Optional[str] = Field(
         None,
         description='The unique identifier for this v1-ade-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
-    status: Optional[Status1] = None
+    status: Optional[Status5] = None
 
 
 class Result1(BaseModel):
@@ -1068,6 +1103,14 @@ class V1AdeExtractJobsJobIdGetResponse(BaseModel):
         None,
         description='The unique identifier for this v1-ade-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
+    metadata: Optional[dict[str, Any]] = Field(
+        None,
+        description="The result's metadata block (billing included), present alongside ``output_url`` once a job with ``output_save_url`` has ``completed`` — the delivery moves the content, not the receipt. Same shape as the inline ``result``'s ``metadata``; inline jobs carry it there instead.",
+    )
+    output_url: Optional[str] = Field(
+        None,
+        description='The URL the result was delivered to. Present once the job has ``completed`` and ``output_save_url`` was set, instead of inline ``result``.',
+    )
     progress: Optional[float] = Field(
         None,
         description='Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.',
@@ -1075,9 +1118,10 @@ class V1AdeExtractJobsJobIdGetResponse(BaseModel):
         le=1.0,
     )
     result: Optional[Result1] = Field(
-        None, description='Present once status is ``completed``.'
+        None,
+        description='Present once status is ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead.',
     )
-    status: Optional[Status1] = None
+    status: Optional[Status5] = None
 
 
 class V1AdeParsePostRequest(BaseModel):
@@ -1178,12 +1222,20 @@ class V1AdeParseJobsGetParametersQuery(BaseModel):
     page: Optional[int] = Field(
         0, description='Page number (0-indexed).', ge=0, title='Page'
     )
-    page_size: Optional[int] = Field(
-        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    pageSize: Optional[int] = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Pagesize'
     )
     status: Optional[str] = Field(
         None, description='Filter by job status.', title='Status'
     )
+
+
+class Status7(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+    cancelled = 'cancelled'
 
 
 class Job2(BaseModel):
@@ -1195,7 +1247,7 @@ class Job2(BaseModel):
         description='The unique identifier for this v1-ade-parse job. Format: ``parse2-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
     model_version: Optional[str] = None
-    status: Optional[Status1] = None
+    status: Optional[Status7] = None
 
 
 class V1AdeParseJobsGetResponse(BaseModel):
@@ -1281,13 +1333,20 @@ class V1AdeParseJobsPostRequest1(BaseModel):
     )
 
 
+class Status8(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+
+
 class V1AdeParseJobsPostResponse(BaseModel):
     created_at: Optional[str] = None
     job_id: Optional[str] = Field(
         None,
         description='The unique identifier for this v1-ade-parse job. Format: ``parse2-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
-    status: Optional[Status1] = None
+    status: Optional[Status8] = None
 
 
 class Result2(BaseModel):
@@ -1352,7 +1411,7 @@ class V1AdeParseJobsJobIdGetResponse(BaseModel):
         None,
         description='Present once status is ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead.',
     )
-    status: Optional[Status1] = None
+    status: Optional[Status8] = None
 
 
 class V1ClassifyPostRequest(BaseModel):
@@ -1420,12 +1479,20 @@ class V1ClassifyJobsGetParametersQuery(BaseModel):
     page: Optional[int] = Field(
         0, description='Page number (0-indexed).', ge=0, title='Page'
     )
-    page_size: Optional[int] = Field(
-        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    pageSize: Optional[int] = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Pagesize'
     )
     status: Optional[str] = Field(
         None, description='Filter by job status.', title='Status'
     )
+
+
+class Status10(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+    cancelled = 'cancelled'
 
 
 class Job3(BaseModel):
@@ -1437,7 +1504,7 @@ class Job3(BaseModel):
         description='The unique identifier for this classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
     model_version: Optional[str] = None
-    status: Optional[Status1] = None
+    status: Optional[Status10] = None
 
 
 class V1ClassifyJobsGetResponse(BaseModel):
@@ -1500,13 +1567,20 @@ class V1ClassifyJobsPostRequest1(BaseModel):
     )
 
 
+class Status11(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+
+
 class V1ClassifyJobsPostResponse(BaseModel):
     created_at: Optional[str] = None
     job_id: Optional[str] = Field(
         None,
         description='The unique identifier for this classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
-    status: Optional[Status1] = None
+    status: Optional[Status11] = None
 
 
 class Result3(BaseModel):
@@ -1546,7 +1620,7 @@ class V1ClassifyJobsJobIdGetResponse(BaseModel):
     result: Optional[Result3] = Field(
         None, description='Present once status is ``completed``.'
     )
-    status: Optional[Status1] = None
+    status: Optional[Status11] = None
 
 
 class V1ExtractBuildSchemaPostRequest(BaseModel):
@@ -1650,12 +1724,20 @@ class V1ExtractBuildSchemaJobsGetParametersQuery(BaseModel):
     page: Optional[int] = Field(
         0, description='Page number (0-indexed).', ge=0, title='Page'
     )
-    page_size: Optional[int] = Field(
-        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    pageSize: Optional[int] = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Pagesize'
     )
     status: Optional[str] = Field(
         None, description='Filter by job status.', title='Status'
     )
+
+
+class Status13(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+    cancelled = 'cancelled'
 
 
 class Job4(BaseModel):
@@ -1667,7 +1749,7 @@ class Job4(BaseModel):
         description='The unique identifier for this v1-build-schema job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
     model_version: Optional[str] = None
-    status: Optional[Status1] = None
+    status: Optional[Status13] = None
 
 
 class V1ExtractBuildSchemaJobsGetResponse(BaseModel):
@@ -1764,13 +1846,20 @@ class V1ExtractBuildSchemaJobsPostRequest1(BaseModel):
     )
 
 
+class Status14(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+
+
 class V1ExtractBuildSchemaJobsPostResponse(BaseModel):
     created_at: Optional[str] = None
     job_id: Optional[str] = Field(
         None,
         description='The unique identifier for this v1-build-schema job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
-    status: Optional[Status1] = None
+    status: Optional[Status14] = None
 
 
 class Result4(BaseModel):
@@ -1812,7 +1901,7 @@ class V1ExtractBuildSchemaJobsJobIdGetResponse(BaseModel):
     result: Optional[Result4] = Field(
         None, description='Present once status is ``completed``.'
     )
-    status: Optional[Status1] = None
+    status: Optional[Status14] = None
 
 
 class V1SplitPostRequest(BaseModel):
@@ -1953,12 +2042,20 @@ class V2ExtractJobsGetParametersQuery(BaseModel):
     page: Optional[int] = Field(
         0, description='Page number (0-indexed).', ge=0, title='Page'
     )
-    page_size: Optional[int] = Field(
-        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    pageSize: Optional[int] = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Pagesize'
     )
     status: Optional[str] = Field(
         None, description='Filter by job status.', title='Status'
     )
+
+
+class Status16(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+    cancelled = 'cancelled'
 
 
 class Job5(BaseModel):
@@ -1970,7 +2067,7 @@ class Job5(BaseModel):
         description='The unique identifier for this v2-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
     model_version: Optional[str] = None
-    status: Optional[Status1] = None
+    status: Optional[Status16] = None
 
 
 class V2ExtractJobsGetResponse(BaseModel):
@@ -2076,13 +2173,20 @@ class V2ExtractJobsPostRequest1(BaseModel):
     )
 
 
+class Status17(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+
+
 class V2ExtractJobsPostResponse(BaseModel):
     created_at: Optional[str] = None
     job_id: Optional[str] = Field(
         None,
         description='The unique identifier for this v2-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
-    status: Optional[Status1] = None
+    status: Optional[Status17] = None
 
 
 class Result5(BaseModel):
@@ -2152,7 +2256,7 @@ class V2ExtractJobsJobIdGetResponse(BaseModel):
         None,
         description='Present once status is ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead.',
     )
-    status: Optional[Status1] = None
+    status: Optional[Status17] = None
 
 
 class V2GroundPostRequest(BaseModel):
@@ -2256,8 +2360,8 @@ class V2ParseJobsGetParametersQuery(BaseModel):
     page: Optional[int] = Field(
         0, description='Page number (0-indexed).', ge=0, title='Page'
     )
-    page_size: Optional[int] = Field(
-        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    pageSize: Optional[int] = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Pagesize'
     )
     status: Optional[str] = Field(
         None, description='Filter by job status.', title='Status'
@@ -2405,8 +2509,8 @@ class V2WorkflowJobsGetParametersQuery(BaseModel):
     page: Optional[int] = Field(
         0, description='Page number (0-indexed).', ge=0, title='Page'
     )
-    page_size: Optional[int] = Field(
-        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    pageSize: Optional[int] = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Pagesize'
     )
     status: Optional[str] = Field(
         None, description='Filter by job status.', title='Status'
@@ -2418,6 +2522,7 @@ class Status22(Enum):
     processing = 'processing'
     completed = 'completed'
     failed = 'failed'
+    cancelled = 'cancelled'
 
 
 class Job7(BaseModel):
@@ -2448,13 +2553,20 @@ class ServiceTier15(Enum):
     priority = 'priority'
 
 
+class Status23(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+
+
 class V2WorkflowJobsPostResponse(BaseModel):
     created_at: Optional[str] = None
     job_id: Optional[str] = Field(
         None,
         description='The unique identifier for this v2-workflow job. Format: ``v2-workflow-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
-    status: Optional[Status22] = None
+    status: Optional[Status23] = None
 
 
 class Error7(BaseModel):
@@ -2525,7 +2637,7 @@ class V2WorkflowJobsJobIdGetResponse(BaseModel):
     result: Optional[Result6] = Field(
         None, description='Present once status is ``completed``.'
     )
-    status: Optional[Status22] = None
+    status: Optional[Status23] = None
 
 
 class BlocksOptions(BaseModel):

--- a/specs/v2-aide.json
+++ b/specs/v2-aide.json
@@ -763,7 +763,7 @@
             "type": "integer"
           },
           "filename": {
-            "description": "Display name of the split document: the URL path's file name for `markdown_url` inputs, or a generated name for inline and uploaded Markdown.",
+            "description": "Display name of the split document: the uploaded file's name for `markdown` file uploads (`.md` is appended when the name has no suffix), the URL path's file name for `markdown_url` inputs, or a generated name for inline Markdown.",
             "title": "Filename",
             "type": "string"
           },
@@ -1676,14 +1676,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -1751,7 +1751,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }
@@ -2143,7 +2144,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "description": "Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.\n\nVTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline\nstring), ``markdown_url``, ``schema``, ``strict``. Nothing else — AIDE's own\nextras (``return_reasoning``, ``fallback_model``, ``output_save_url``) stay on\nthe R&D ``/api/extract`` contract, so the customer surface publishes the VTRA\ncontract and only that.",
+                "description": "Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.\n\nVTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline\nstring), ``markdown_url``, ``schema``, ``strict``, ``output_save_url``. AIDE's\nown extras (``return_reasoning``, ``fallback_model``) stay on the R&D\n``/api/extract`` contract — only ``output_save_url`` is shared with it, because\nit is also on VTRA's async wire (aide#2053, the extract half of the\n``output_save_url``/ZDR parity pair that started with parse in #2056's\npredecessor) — so the customer surface publishes the VTRA contract and only\nthat.",
                 "properties": {
                   "markdown": {
                     "anyOf": [
@@ -2329,14 +2330,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -2404,7 +2405,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }
@@ -2449,7 +2451,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "description": "Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.\n\nVTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline\nstring), ``markdown_url``, ``schema``, ``strict``. Nothing else — AIDE's own\nextras (``return_reasoning``, ``fallback_model``, ``output_save_url``) stay on\nthe R&D ``/api/extract`` contract, so the customer surface publishes the VTRA\ncontract and only that.",
+                "description": "Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.\n\nVTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline\nstring), ``markdown_url``, ``schema``, ``strict``, ``output_save_url``. AIDE's\nown extras (``return_reasoning``, ``fallback_model``) stay on the R&D\n``/api/extract`` contract — only ``output_save_url`` is shared with it, because\nit is also on VTRA's async wire (aide#2053, the extract half of the\n``output_save_url``/ZDR parity pair that started with parse in #2056's\npredecessor) — so the customer surface publishes the VTRA contract and only\nthat.",
                 "properties": {
                   "markdown": {
                     "anyOf": [
@@ -2486,6 +2488,18 @@
                     ],
                     "default": null,
                     "title": "Model"
+                  },
+                  "output_save_url": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Output Save Url"
                   },
                   "schema": {
                     "anyOf": [
@@ -2557,6 +2571,19 @@
                     "default": null,
                     "description": "JSON-serialized string in form data.",
                     "title": "Model"
+                  },
+                  "output_save_url": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "JSON-serialized string in form data.",
+                    "title": "Output Save Url"
                   },
                   "schema": {
                     "anyOf": [
@@ -2698,6 +2725,20 @@
                       "description": "The unique identifier for this v1-ade-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
                       "type": "string"
                     },
+                    "metadata": {
+                      "description": "The result's metadata block (billing included), present alongside ``output_url`` once a job with ``output_save_url`` has ``completed`` — the delivery moves the content, not the receipt. Same shape as the inline ``result``'s ``metadata``; inline jobs carry it there instead.",
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    },
+                    "output_url": {
+                      "description": "The URL the result was delivered to. Present once the job has ``completed`` and ``output_save_url`` was set, instead of inline ``result``.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
                     "progress": {
                       "description": "Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.",
                       "maximum": 1,
@@ -2730,7 +2771,7 @@
                           "type": "null"
                         }
                       ],
-                      "description": "Present once status is ``completed``."
+                      "description": "Present once status is ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead."
                     },
                     "status": {
                       "enum": [
@@ -3214,14 +3255,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -3289,7 +3330,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }
@@ -4151,14 +4193,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -4226,7 +4268,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }
@@ -4844,14 +4887,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -4919,7 +4962,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }
@@ -5674,14 +5718,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -5749,7 +5793,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }
@@ -6524,14 +6569,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -7130,14 +7175,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -7205,7 +7250,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }

--- a/src/landingai_ade/resources/v2/extract.py
+++ b/src/landingai_ade/resources/v2/extract.py
@@ -267,10 +267,18 @@ class ExtractJobsResource(V2ResourceMixin, SyncAPIResource):
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> JobList:
-        """List async extract jobs associated with your API key, newest first."""
+        """List async extract jobs associated with your API key, newest first.
+
+        A listed job's `status` may be `cancelled` as well as
+        `pending`/`processing`/`completed`/`failed`.
+        """
+        # `pageSize` is the wire name of the per-page query parameter on every V2
+        # `*/jobs` list route; the spec renamed it from `page_size`. Only the query
+        # parameter moved -- the Python keyword and the response envelope's own
+        # `page_size` field (read back below) both keep the snake_case spelling.
         query = {
             key: value
-            for key, value in {"page": page, "page_size": page_size, "status": status}.items()
+            for key, value in {"page": page, "pageSize": page_size, "status": status}.items()
             if is_given(value) and value is not None
         }
         raw = self._get(
@@ -301,8 +309,9 @@ class ExtractJobsResource(V2ResourceMixin, SyncAPIResource):
 
         Raises `JobWaitTimeoutError` if `timeout` seconds elapse before the job
         reaches a terminal state, and `JobFailedError` if `raise_on_failure` is
-        set and the job ends failed with an error attached. Extract jobs have no
-        `cancelled` status.
+        set and the job ends failed/cancelled with an error attached. `cancelled`
+        joined the extract job statuses in the current spec snapshot; it is
+        terminal like `completed`/`failed`.
 
         `_monotonic` is a test seam for injecting a fake clock; production
         callers should leave it unset (defaults to `time.monotonic`).
@@ -382,9 +391,10 @@ class AsyncExtractJobsResource(V2ResourceMixin, AsyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> JobList:
         """Async mirror of `ExtractJobsResource.list`. See there for full documentation."""
+        # `pageSize` on the wire; see `ExtractJobsResource.list`.
         query = {
             key: value
-            for key, value in {"page": page, "page_size": page_size, "status": status}.items()
+            for key, value in {"page": page, "pageSize": page_size, "status": status}.items()
             if is_given(value) and value is not None
         }
         raw = await self._get(

--- a/src/landingai_ade/resources/v2/parse.py
+++ b/src/landingai_ade/resources/v2/parse.py
@@ -345,9 +345,13 @@ class ParseJobsResource(V2ResourceMixin, SyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> JobList:
         """List async parse jobs associated with your API key, newest first."""
+        # `pageSize` is the wire name of the per-page query parameter on every V2
+        # `*/jobs` list route; the spec renamed it from `page_size`. Only the query
+        # parameter moved -- the Python keyword and the response envelope's own
+        # `page_size` field (read back below) both keep the snake_case spelling.
         query = {
             key: value
-            for key, value in {"page": page, "page_size": page_size, "status": status}.items()
+            for key, value in {"page": page, "pageSize": page_size, "status": status}.items()
             if is_given(value) and value is not None
         }
         raw = self._get(
@@ -470,9 +474,10 @@ class AsyncParseJobsResource(V2ResourceMixin, AsyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> JobList:
         """Async mirror of `ParseJobsResource.list`. See there for full documentation."""
+        # `pageSize` on the wire; see `ParseJobsResource.list`.
         query = {
             key: value
-            for key, value in {"page": page, "page_size": page_size, "status": status}.items()
+            for key, value in {"page": page, "pageSize": page_size, "status": status}.items()
             if is_given(value) and value is not None
         }
         raw = await self._get(

--- a/tests/api_resources/v2/test_async_smoke.py
+++ b/tests/api_resources/v2/test_async_smoke.py
@@ -72,3 +72,30 @@ async def test_async_extract_jobs_create_get_and_wait() -> None:
     waited = await client.v2.extract_jobs.wait("e1", timeout=30, poll_interval=0.01, _monotonic=lambda: next(ticks))
     assert waited.status is JobStatus.COMPLETED
     assert isinstance(waited.result, V2ExtractResult)
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_async_job_lists_send_page_size_as_pagesize() -> None:
+    """The `page_size` -> `pageSize` query-parameter rename has to reach the async
+    list mirrors too; they build their own query dict rather than sharing the sync
+    one, so a rename applied to only half the resource would go unnoticed."""
+    client = AsyncLandingAIADE(apikey=APIKEY)
+
+    parse_route = respx.get("https://api.ade.landing.ai/v2/parse/jobs").mock(
+        return_value=httpx.Response(200, json={"jobs": [], "has_more": False})
+    )
+    await client.v2.parse_jobs.list(page=0, page_size=3)
+    assert parse_route.calls.last.request.url.params["pageSize"] == "3"
+    assert "page_size" not in parse_route.calls.last.request.url.params
+
+    extract_route = respx.get("https://api.ade.landing.ai/v2/extract/jobs").mock(
+        return_value=httpx.Response(
+            200,
+            json={"jobs": [{"job_id": "e2", "status": "cancelled"}], "has_more": False},
+        )
+    )
+    jobs = await client.v2.extract_jobs.list(page=0, page_size=3)
+    assert extract_route.calls.last.request.url.params["pageSize"] == "3"
+    assert "page_size" not in extract_route.calls.last.request.url.params
+    assert jobs[0].status is JobStatus.CANCELLED and jobs[0].is_terminal is True

--- a/tests/api_resources/v2/test_extract.py
+++ b/tests/api_resources/v2/test_extract.py
@@ -274,3 +274,41 @@ def test_extract_job_list_carries_envelope() -> None:
     assert jobs.has_more is True
     assert jobs.page == 0
     assert jobs.page_size == 10
+
+
+@respx.mock
+def test_extract_job_list_sends_page_size_as_pagesize() -> None:
+    # The spec renamed the per-page query parameter to `pageSize` on every V2
+    # `*/jobs` list route. The Python keyword stays `page_size`, so the rename is
+    # only observable on the wire -- and sending the old `page_size` would be
+    # silently ignored by the gateway, which is exactly what this pins.
+    client = LandingAIADE(apikey=APIKEY)
+    route = respx.get("https://api.ade.landing.ai/v2/extract/jobs").mock(
+        return_value=httpx.Response(200, json={"jobs": [], "has_more": False})
+    )
+    client.v2.extract_jobs.list(page=2, page_size=5)
+    params = route.calls.last.request.url.params
+    assert params["pageSize"] == "5"
+    assert params["page"] == "2"
+    assert "page_size" not in params
+
+
+@respx.mock
+def test_extract_job_list_normalizes_cancelled_status() -> None:
+    # `cancelled` joined the status enum on the extract job *list* response; it is
+    # terminal, so a waiter that sees it stops rather than polling forever.
+    client = LandingAIADE(apikey=APIKEY)
+    respx.get("https://api.ade.landing.ai/v2/extract/jobs").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "jobs": [{"job_id": "e9", "status": "cancelled", "failure_reason": "cancelled by user"}],
+                "has_more": False,
+            },
+        )
+    )
+    jobs = client.v2.extract_jobs.list()
+    assert len(jobs) == 1
+    assert jobs[0].status is JobStatus.CANCELLED
+    assert jobs[0].is_terminal is True
+    assert jobs[0].error is not None and jobs[0].error.message == "cancelled by user"

--- a/tests/api_resources/v2/test_parse.py
+++ b/tests/api_resources/v2/test_parse.py
@@ -570,6 +570,25 @@ def test_parse_job_list_carries_page_envelope() -> None:
 
 
 @respx.mock
+def test_parse_job_list_sends_page_size_as_pagesize() -> None:
+    # The spec renamed the per-page query parameter to `pageSize` on every V2
+    # `*/jobs` list route. The Python keyword stays `page_size`, so the rename is
+    # only observable on the wire -- and sending the old `page_size` would be
+    # silently ignored by the gateway, which is exactly what this pins. The
+    # response envelope's `page_size` field was NOT renamed; it is read back as-is.
+    client = LandingAIADE(apikey=APIKEY)
+    route = respx.get("https://api.ade.landing.ai/v2/parse/jobs").mock(
+        return_value=httpx.Response(200, json={"jobs": [], "page": 1, "page_size": 5, "has_more": False})
+    )
+    jobs = client.v2.parse_jobs.list(page=1, page_size=5)
+    params = route.calls.last.request.url.params
+    assert params["pageSize"] == "5"
+    assert params["page"] == "1"
+    assert "page_size" not in params
+    assert jobs.page_size == 5
+
+
+@respx.mock
 def test_parse_sync_tolerates_unknown_element_type_and_extra_keys() -> None:
     # Novel element `type` values and extra keys must not break deserialization
     # (`type` is a permissive str; BaseModel retains extra keys).

--- a/tests/contract/test_v2_smoke.py
+++ b/tests/contract/test_v2_smoke.py
@@ -187,6 +187,33 @@ def test_ground_sync(staging_client: LandingAIADE) -> None:
     assert grounded.metadata.job_id
 
 
+def test_job_lists_honor_page_size(staging_client: LandingAIADE) -> None:
+    # The per-page query parameter is `pageSize` on the wire (the spec renamed it
+    # from `page_size` on every V2 `*/jobs` list route). Staging defaults to 10
+    # items per page, so asking for 1 and getting at most 1 back is the live
+    # evidence that the gateway actually read the parameter under its new name --
+    # the old spelling would be ignored and this page could come back with 10.
+    #
+    # Everything else here is absent-or-valid: a fresh key's job history may be
+    # empty, so nothing asserts that any job exists or that it has any particular
+    # status. Concrete statuses -- `cancelled` included, which joined the extract
+    # list enum in this snapshot -- are pinned against controlled response bodies in
+    # the mocked tests under tests/api_resources/v2/ instead.
+    for jobs in (
+        staging_client.v2.parse_jobs.list(page=0, page_size=1),
+        staging_client.v2.extract_jobs.list(page=0, page_size=1),
+    ):
+        assert len(jobs) <= 1
+        for job in jobs:
+            assert job.job_id
+            # `_status()` downgrades a status it does not recognize to `pending`
+            # instead of raising, so a new gateway status would otherwise pass here
+            # unnoticed. Compare against the raw envelope to catch that.
+            raw_status = job.raw.get("status")
+            if raw_status is not None:
+                assert raw_status == job.status.value
+
+
 def test_parse_jobs(staging_client: LandingAIADE) -> None:
     pdf = Path(__file__).parent / "sample.pdf"
     job = staging_client.v2.parse_jobs.create(document=pdf)


### PR DESCRIPTION
Automated V2 spec-sync PR (`client.v2`).

- **Commit 1 (mechanical):** normalized V2 spec snapshot + regenerated reference models.
- **Commit 2 (AI, only if the spec diff needs SDK changes):** client.v2 resources/methods/tests/docs wired from the diff, added after this PR opened. Workflow-only drift is excluded and an AI no-op is skipped, so some drifts produce a **mechanical-only PR with no second commit**.

Gates (surface-lock, V2 contract tests, lint/test/typecheck) must pass. When present, the AI commit is a **draft a human finishes** (the V2 ergonomic layer — unified Job, dual-host, schema coercion — is not in the spec). **Human review required before merge.**

<!-- what-changed:start -->
## What changed
_AI-generated from the PR diff — verify against the actual changes._

This PR updates the `parse_jobs.list` / `extract_jobs.list` query parameter to match a spec rename, adds `cancelled` as a valid extract job status, and adds `output_save_url` support to extract requests, without changing any public method signatures.

**Changes:**
- `parse_jobs.list` and `extract_jobs.list` (sync and async) now send the per-page limit as the `pageSize` query parameter on the wire while keeping the `page_size` Python keyword and response field unchanged.
- Extract job `wait`/`list` now document and support `cancelled` as a terminal extract job status, so `raise_on_failure` can trigger on a cancelled job with an error attached, matching parse's existing behavior.
- `extract` requests gain an `output_save_url` parameter, mirroring the existing parse behavior, with results delivered via a returned `output_url`/`metadata` instead of inline `result` when set.
- Documented that uploaded `markdown` files for the split-document filename derivation now use the uploaded file's name (appending `.md` if missing) instead of a generated name.
<!-- what-changed:end -->