### PR TITLE
spec-sync(v2): send `pageSize` query param and support cancelled extract status

### DIFF
--- a/api.md
+++ b/api.md
@@ -129,7 +129,7 @@ Methods:
 - <code title="get /v2/extract/jobs">client.v2.extract_jobs.<a href="./src/landingai_ade/resources/v2/extract.py">list</a>(\*, page=..., page_size=..., status=...) -> JobList[<a href="./src/landingai_ade/types/v2/job.py">Job</a>]</code>
 - <code>client.v2.extract_jobs.<a href="./src/landingai_ade/resources/v2/extract.py">wait</a>(job_id, \*, timeout=600, poll_interval=None, raise_on_failure=False) -> <a href="./src/landingai_ade/types/v2/job.py">Job</a></code>
 
-  Same polling/timeout semantics as `parse_jobs.wait`. Extract jobs have no `cancelled` status, so `raise_on_failure` only ever triggers on `failed`.
+  Same polling/timeout semantics as `parse_jobs.wait`. `cancelled` is a terminal extract status (the list-jobs envelope reports it alongside `pending` / `processing` / `completed` / `failed`), so waiting stops on it like any other terminal state.
 
 - <code title="post /v2/ground">client.v2.<a href="./src/landingai_ade/resources/v2/v2.py">ground</a>(\*, extraction_metadata, structure) -> <a href="./src/landingai_ade/types/v2/ground_response.py">V2GroundResult</a></code>
 
@@ -138,4 +138,5 @@ Methods:
 Notes:
 
 - `parse_jobs.list` and `extract_jobs.list` both return a `JobList` (a `list[Job]` subclass) carrying pagination metadata: `.has_more`, `.org_id`, `.page`, `.page_size`.
+- The `page_size` keyword on both `list` methods is sent to the gateway as the query parameter `pageSize`; the SDK keeps the snake_case spelling, and the response envelope's own `page_size` field is unchanged.
 - All `client.v2.*` methods accept the usual `extra_headers`, `extra_query`, `extra_body`, and `timeout` overrides; sync methods additionally accept `save_to` (parse/extract only, not the job-creation methods) to write the response to disk, mirroring V1's `save_to`.

--- a/docs/v2-testing.md
+++ b/docs/v2-testing.md
@@ -166,6 +166,47 @@ field-name drift:
 - Unknown / renamed `status` values fall back to `pending` rather than raising;
   the raw envelope is always preserved on `Job.raw`.
 
+### Terminal statuses
+
+`JobStatus` covers `pending` / `processing` / `completed` / `failed` /
+`cancelled`, and `Job.is_terminal` is true for the last three. The gateway does
+not offer the same set on every route: as of the 2026-09-10 snapshot the
+`/v2/extract/jobs` list envelope reports `cancelled`, while `/v2/parse/jobs`
+does not, and neither *get-job* envelope does. The unified `Job` deliberately
+does not model that per-route split — a status the route never emits simply
+never arrives, and `_status()` already folds anything unrecognized back to
+`pending`. So a route gaining a status needs no SDK change; it needs a test
+(`test_extract_job_list_normalizes_cancelled_status` in
+`tests/api_resources/v2/test_extract.py`) proving the value survives
+normalization and counts as terminal, so `wait()` stops on it instead of polling
+to its deadline.
+
+## Listing jobs (`pageSize` on the wire)
+
+`parse_jobs.list` / `extract_jobs.list` (and the hidden `build_schema_jobs.list`)
+take `page`, `page_size` and `status`. The gateway names the page size
+**`pageSize`** as a query parameter, so `build_list_query` in
+`resources/v2/_base.py` translates the SDK's snake_case kwarg once for all three
+resources. Only the parameter is camelCase — the *response* envelope still
+reports `page_size`, which is what `JobList.build` reads and what `.page_size`
+exposes.
+
+This is the failure mode worth testing for: an unrecognized query parameter is
+ignored rather than rejected, so a wrong name yields a valid-looking response
+carrying the default page of 10. Coverage is split accordingly:
+
+- Deterministic, in `tests/api_resources/v2/`: assert `pageSize` is on the
+  request URL, that `page_size` is *not*, and — at the query-dict level, since
+  the URL encoder drops `None` and would mask it — that an unset `page_size` is
+  sent under neither spelling. `tests/api_resources/v2/test_async_smoke.py`
+  repeats the check on the async mirrors, which is where a wire-name fix
+  typically lands only half.
+- Live, in `tests/contract/test_v2_smoke.py`
+  (`test_job_list_honors_page_size`): request `page_size=1` and assert the page
+  came back capped at one entry. Do not assert a job count — the staging key may
+  have no jobs — and do not assert that the response echoes the requested
+  `page_size`; that field is optional, so treat it absent-or-valid.
+
 ## When the spec changes
 
 1. Read the mechanical diff (`git diff` on `specs/v2-aide.json` and
@@ -174,9 +215,12 @@ field-name drift:
 2. Additive **request** fields become new optional keyword params on the
    corresponding `run` / `create` method (parse forwards free-form `options`
    through as a JSON string, so most parse-option additions need no code change).
-3. Additive **response** fields are added to the matching model under
+3. A renamed **query parameter** changes the wire name only. The public kwarg is
+   surface-locked, so translate at the call site (see `build_list_query`) rather
+   than renaming the parameter.
+4. Additive **response** fields are added to the matching model under
    `src/landingai_ade/types/v2/`. Keep removed/renamed fields in place as optional
    for backward compatibility — the surface is release-locked and response parsing
    is lenient (missing fields default to `None`).
-4. Add or extend `respx` tests in `tests/api_resources/v2/` and a live assertion
+5. Add or extend `respx` tests in `tests/api_resources/v2/` and a live assertion
    in `tests/contract/test_v2_smoke.py`, then update `api.md` and this guide.

--- a/specs/_generated/v2_models.py
+++ b/specs/_generated/v2_models.py
@@ -285,7 +285,7 @@ class SplitMetadata(BaseModel):
     )
     filename: str = Field(
         ...,
-        description="Display name of the split document: the URL path's file name for `markdown_url` inputs, or a generated name for inline and uploaded Markdown.",
+        description="Display name of the split document: the uploaded file's name for `markdown` file uploads (`.md` is appended when the name has no suffix), the URL path's file name for `markdown_url` inputs, or a generated name for inline Markdown.",
         title='Filename',
     )
     job_id: str = Field(
@@ -742,8 +742,8 @@ class V1AdeClassifyJobsGetParametersQuery(BaseModel):
     page: Optional[int] = Field(
         0, description='Page number (0-indexed).', ge=0, title='Page'
     )
-    page_size: Optional[int] = Field(
-        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    pageSize: Optional[int] = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Pagesize'
     )
     status: Optional[str] = Field(
         None, description='Filter by job status.', title='Status'
@@ -755,6 +755,7 @@ class Status1(Enum):
     processing = 'processing'
     completed = 'completed'
     failed = 'failed'
+    cancelled = 'cancelled'
 
 
 class Job(BaseModel):
@@ -838,13 +839,20 @@ class V1AdeClassifyJobsPostRequest1(BaseModel):
     )
 
 
+class Status2(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+
+
 class V1AdeClassifyJobsPostResponse(BaseModel):
     created_at: Optional[str] = None
     job_id: Optional[str] = Field(
         None,
         description='The unique identifier for this v1-ade-classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
-    status: Optional[Status1] = None
+    status: Optional[Status2] = None
 
 
 class Error(BaseModel):
@@ -895,7 +903,7 @@ class V1AdeClassifyJobsJobIdGetResponse(BaseModel):
     result: Optional[Result] = Field(
         None, description='Present once status is ``completed``.'
     )
-    status: Optional[Status1] = None
+    status: Optional[Status2] = None
 
 
 class V1AdeExtractPostRequest(BaseModel):
@@ -903,10 +911,13 @@ class V1AdeExtractPostRequest(BaseModel):
     Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.
 
     VTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline
-    string), ``markdown_url``, ``schema``, ``strict``. Nothing else — AIDE's own
-    extras (``return_reasoning``, ``fallback_model``, ``output_save_url``) stay on
-    the R&D ``/api/extract`` contract, so the customer surface publishes the VTRA
-    contract and only that.
+    string), ``markdown_url``, ``schema``, ``strict``, ``output_save_url``. AIDE's
+    own extras (``return_reasoning``, ``fallback_model``) stay on the R&D
+    ``/api/extract`` contract — only ``output_save_url`` is shared with it, because
+    it is also on VTRA's async wire (aide#2053, the extract half of the
+    ``output_save_url``/ZDR parity pair that started with parse in #2056's
+    predecessor) — so the customer surface publishes the VTRA contract and only
+    that.
     """
 
     markdown: Optional[str] = Field(None, title='Markdown')
@@ -957,12 +968,20 @@ class V1AdeExtractJobsGetParametersQuery(BaseModel):
     page: Optional[int] = Field(
         0, description='Page number (0-indexed).', ge=0, title='Page'
     )
-    page_size: Optional[int] = Field(
-        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    pageSize: Optional[int] = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Pagesize'
     )
     status: Optional[str] = Field(
         None, description='Filter by job status.', title='Status'
     )
+
+
+class Status4(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+    cancelled = 'cancelled'
 
 
 class Job1(BaseModel):
@@ -974,7 +993,7 @@ class Job1(BaseModel):
         description='The unique identifier for this v1-ade-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
     model_version: Optional[str] = None
-    status: Optional[Status1] = None
+    status: Optional[Status4] = None
 
 
 class V1AdeExtractJobsGetResponse(BaseModel):
@@ -989,20 +1008,20 @@ class V1AdeExtractJobsPostRequest(BaseModel):
     Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.
 
     VTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline
-    string), ``markdown_url``, ``schema``, ``strict``. Nothing else — AIDE's own
-    extras (``return_reasoning``, ``fallback_model``, ``output_save_url``) stay on
-    the R&D ``/api/extract`` contract, so the customer surface publishes the VTRA
-    contract and only that.
+    string), ``markdown_url``, ``schema``, ``strict``, ``output_save_url``. AIDE's
+    own extras (``return_reasoning``, ``fallback_model``) stay on the R&D
+    ``/api/extract`` contract — only ``output_save_url`` is shared with it, because
+    it is also on VTRA's async wire (aide#2053, the extract half of the
+    ``output_save_url``/ZDR parity pair that started with parse in #2056's
+    predecessor) — so the customer surface publishes the VTRA contract and only
+    that.
     """
 
     markdown: Optional[str] = Field(None, title='Markdown')
     markdown_url: Optional[str] = Field(None, title='Markdown Url')
     model: Optional[str] = Field(None, title='Model')
+    output_save_url: Optional[str] = Field(None, title='Output Save Url')
     schema_: Optional[str] = Field(None, alias='schema', title='Schema')
-    service_tier: Optional[ServiceTier2] = Field(
-        None,
-        description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
-    )
     strict: Optional[bool] = Field(False, title='Strict')
 
 
@@ -1014,19 +1033,27 @@ class V1AdeExtractJobsPostRequest1(BaseModel):
     model: Optional[str] = Field(
         None, description='JSON-serialized string in form data.', title='Model'
     )
+    output_save_url: Optional[str] = Field(
+        None,
+        description='JSON-serialized string in form data.',
+        title='Output Save Url',
+    )
     schema_: Optional[str] = Field(
         None,
         alias='schema',
         description='JSON-serialized string in form data.',
         title='Schema',
     )
-    service_tier: Optional[ServiceTier2] = Field(
-        None,
-        description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
-    )
     strict: Optional[bool] = Field(
         False, description='JSON-serialized string in form data.', title='Strict'
     )
+
+
+class Status5(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
 
 
 class V1AdeExtractJobsPostResponse(BaseModel):
@@ -1035,7 +1062,7 @@ class V1AdeExtractJobsPostResponse(BaseModel):
         None,
         description='The unique identifier for this v1-ade-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
-    status: Optional[Status1] = None
+    status: Optional[Status5] = None
 
 
 class Result1(BaseModel):
@@ -1068,6 +1095,14 @@ class V1AdeExtractJobsJobIdGetResponse(BaseModel):
         None,
         description='The unique identifier for this v1-ade-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
+    metadata: Optional[dict[str, Any]] = Field(
+        None,
+        description="The result's metadata block (billing included), present alongside ``output_url`` once a job with ``output_save_url`` has ``completed`` — the delivery moves the content, not the receipt. Same shape as the inline ``result``'s ``metadata``; inline jobs carry it there instead.",
+    )
+    output_url: Optional[str] = Field(
+        None,
+        description='The URL the result was delivered to. Present once the job has ``completed`` and ``output_save_url`` was set, instead of inline ``result``.',
+    )
     progress: Optional[float] = Field(
         None,
         description='Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.',
@@ -1075,9 +1110,10 @@ class V1AdeExtractJobsJobIdGetResponse(BaseModel):
         le=1.0,
     )
     result: Optional[Result1] = Field(
-        None, description='Present once status is ``completed``.'
+        None,
+        description='Present once status is ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead.',
     )
-    status: Optional[Status1] = None
+    status: Optional[Status5] = None
 
 
 class V1AdeParsePostRequest(BaseModel):
@@ -1092,14 +1128,9 @@ class V1AdeParsePostRequest(BaseModel):
     custom_prompts: Optional[dict[str, str]] = Field(None, title='Custom Prompts')
     document_ref: str = Field(..., title='Document Ref')
     filename: str = Field(..., title='Filename')
-    job_id: Optional[str] = Field(None, title='Job Id')
-    model_versions: Optional[dict[str, str]] = Field(None, title='Model Versions')
+    model: Optional[str] = Field(None, title='Version')
     password: Optional[str] = Field(None, title='Password')
-    pricing_multiplier: Optional[float] = Field(1.0, title='Pricing Multiplier')
-    processing_mode: Optional[str] = Field('sync', title='Processing Mode')
     split: Optional[str] = Field(None, title='Split')
-    version: Optional[str] = Field(None, title='Version')
-    x_request_id: Optional[str] = Field(None, title='X Request Id')
 
 
 class V1AdeParsePostRequest1(BaseModel):
@@ -1116,29 +1147,14 @@ class V1AdeParsePostRequest1(BaseModel):
         description='A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.',
     )
     filename: str = Field(..., title='Filename')
-    job_id: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='Job Id'
-    )
-    model_versions: Optional[dict[str, str]] = Field(
-        None, description='JSON-serialized string in form data.', title='Model Versions'
+    model: Optional[str] = Field(
+        None, description='JSON-serialized string in form data.', title='Version'
     )
     password: Optional[str] = Field(
         None, description='JSON-serialized string in form data.', title='Password'
     )
-    pricing_multiplier: Optional[float] = Field(
-        1.0,
-        description='JSON-serialized string in form data.',
-        title='Pricing Multiplier',
-    )
-    processing_mode: Optional[str] = Field('sync', title='Processing Mode')
     split: Optional[str] = Field(
         None, description='JSON-serialized string in form data.', title='Split'
-    )
-    version: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='Version'
-    )
-    x_request_id: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='X Request Id'
     )
 
 
@@ -1178,12 +1194,20 @@ class V1AdeParseJobsGetParametersQuery(BaseModel):
     page: Optional[int] = Field(
         0, description='Page number (0-indexed).', ge=0, title='Page'
     )
-    page_size: Optional[int] = Field(
-        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    pageSize: Optional[int] = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Pagesize'
     )
     status: Optional[str] = Field(
         None, description='Filter by job status.', title='Status'
     )
+
+
+class Status7(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+    cancelled = 'cancelled'
 
 
 class Job2(BaseModel):
@@ -1195,7 +1219,7 @@ class Job2(BaseModel):
         description='The unique identifier for this v1-ade-parse job. Format: ``parse2-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
     model_version: Optional[str] = None
-    status: Optional[Status1] = None
+    status: Optional[Status7] = None
 
 
 class V1AdeParseJobsGetResponse(BaseModel):
@@ -1217,19 +1241,10 @@ class V1AdeParseJobsPostRequest(BaseModel):
     custom_prompts: Optional[dict[str, str]] = Field(None, title='Custom Prompts')
     document_ref: str = Field(..., title='Document Ref')
     filename: str = Field(..., title='Filename')
-    job_id: Optional[str] = Field(None, title='Job Id')
-    model_versions: Optional[dict[str, str]] = Field(None, title='Model Versions')
+    model: Optional[str] = Field(None, title='Version')
     output_save_url: Optional[str] = Field(None, title='Output Save Url')
     password: Optional[str] = Field(None, title='Password')
-    pricing_multiplier: Optional[float] = Field(1.0, title='Pricing Multiplier')
-    processing_mode: Optional[str] = Field('sync', title='Processing Mode')
-    service_tier: Optional[ServiceTier2] = Field(
-        None,
-        description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
-    )
     split: Optional[str] = Field(None, title='Split')
-    version: Optional[str] = Field(None, title='Version')
-    x_request_id: Optional[str] = Field(None, title='X Request Id')
 
 
 class V1AdeParseJobsPostRequest1(BaseModel):
@@ -1246,11 +1261,8 @@ class V1AdeParseJobsPostRequest1(BaseModel):
         description='A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.',
     )
     filename: str = Field(..., title='Filename')
-    job_id: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='Job Id'
-    )
-    model_versions: Optional[dict[str, str]] = Field(
-        None, description='JSON-serialized string in form data.', title='Model Versions'
+    model: Optional[str] = Field(
+        None, description='JSON-serialized string in form data.', title='Version'
     )
     output_save_url: Optional[str] = Field(
         None,
@@ -1260,25 +1272,16 @@ class V1AdeParseJobsPostRequest1(BaseModel):
     password: Optional[str] = Field(
         None, description='JSON-serialized string in form data.', title='Password'
     )
-    pricing_multiplier: Optional[float] = Field(
-        1.0,
-        description='JSON-serialized string in form data.',
-        title='Pricing Multiplier',
-    )
-    processing_mode: Optional[str] = Field('sync', title='Processing Mode')
-    service_tier: Optional[ServiceTier2] = Field(
-        None,
-        description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
-    )
     split: Optional[str] = Field(
         None, description='JSON-serialized string in form data.', title='Split'
     )
-    version: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='Version'
-    )
-    x_request_id: Optional[str] = Field(
-        None, description='JSON-serialized string in form data.', title='X Request Id'
-    )
+
+
+class Status8(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
 
 
 class V1AdeParseJobsPostResponse(BaseModel):
@@ -1287,7 +1290,7 @@ class V1AdeParseJobsPostResponse(BaseModel):
         None,
         description='The unique identifier for this v1-ade-parse job. Format: ``parse2-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
-    status: Optional[Status1] = None
+    status: Optional[Status8] = None
 
 
 class Result2(BaseModel):
@@ -1352,7 +1355,7 @@ class V1AdeParseJobsJobIdGetResponse(BaseModel):
         None,
         description='Present once status is ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead.',
     )
-    status: Optional[Status1] = None
+    status: Optional[Status8] = None
 
 
 class V1ClassifyPostRequest(BaseModel):
@@ -1420,12 +1423,20 @@ class V1ClassifyJobsGetParametersQuery(BaseModel):
     page: Optional[int] = Field(
         0, description='Page number (0-indexed).', ge=0, title='Page'
     )
-    page_size: Optional[int] = Field(
-        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    pageSize: Optional[int] = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Pagesize'
     )
     status: Optional[str] = Field(
         None, description='Filter by job status.', title='Status'
     )
+
+
+class Status10(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+    cancelled = 'cancelled'
 
 
 class Job3(BaseModel):
@@ -1437,7 +1448,7 @@ class Job3(BaseModel):
         description='The unique identifier for this classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
     model_version: Optional[str] = None
-    status: Optional[Status1] = None
+    status: Optional[Status10] = None
 
 
 class V1ClassifyJobsGetResponse(BaseModel):
@@ -1500,13 +1511,20 @@ class V1ClassifyJobsPostRequest1(BaseModel):
     )
 
 
+class Status11(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+
+
 class V1ClassifyJobsPostResponse(BaseModel):
     created_at: Optional[str] = None
     job_id: Optional[str] = Field(
         None,
         description='The unique identifier for this classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
-    status: Optional[Status1] = None
+    status: Optional[Status11] = None
 
 
 class Result3(BaseModel):
@@ -1546,7 +1564,7 @@ class V1ClassifyJobsJobIdGetResponse(BaseModel):
     result: Optional[Result3] = Field(
         None, description='Present once status is ``completed``.'
     )
-    status: Optional[Status1] = None
+    status: Optional[Status11] = None
 
 
 class V1ExtractBuildSchemaPostRequest(BaseModel):
@@ -1650,12 +1668,20 @@ class V1ExtractBuildSchemaJobsGetParametersQuery(BaseModel):
     page: Optional[int] = Field(
         0, description='Page number (0-indexed).', ge=0, title='Page'
     )
-    page_size: Optional[int] = Field(
-        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    pageSize: Optional[int] = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Pagesize'
     )
     status: Optional[str] = Field(
         None, description='Filter by job status.', title='Status'
     )
+
+
+class Status13(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+    cancelled = 'cancelled'
 
 
 class Job4(BaseModel):
@@ -1667,7 +1693,7 @@ class Job4(BaseModel):
         description='The unique identifier for this v1-build-schema job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
     model_version: Optional[str] = None
-    status: Optional[Status1] = None
+    status: Optional[Status13] = None
 
 
 class V1ExtractBuildSchemaJobsGetResponse(BaseModel):
@@ -1764,13 +1790,20 @@ class V1ExtractBuildSchemaJobsPostRequest1(BaseModel):
     )
 
 
+class Status14(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+
+
 class V1ExtractBuildSchemaJobsPostResponse(BaseModel):
     created_at: Optional[str] = None
     job_id: Optional[str] = Field(
         None,
         description='The unique identifier for this v1-build-schema job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
-    status: Optional[Status1] = None
+    status: Optional[Status14] = None
 
 
 class Result4(BaseModel):
@@ -1812,7 +1845,7 @@ class V1ExtractBuildSchemaJobsJobIdGetResponse(BaseModel):
     result: Optional[Result4] = Field(
         None, description='Present once status is ``completed``.'
     )
-    status: Optional[Status1] = None
+    status: Optional[Status14] = None
 
 
 class V1SplitPostRequest(BaseModel):
@@ -1953,12 +1986,20 @@ class V2ExtractJobsGetParametersQuery(BaseModel):
     page: Optional[int] = Field(
         0, description='Page number (0-indexed).', ge=0, title='Page'
     )
-    page_size: Optional[int] = Field(
-        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    pageSize: Optional[int] = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Pagesize'
     )
     status: Optional[str] = Field(
         None, description='Filter by job status.', title='Status'
     )
+
+
+class Status16(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+    cancelled = 'cancelled'
 
 
 class Job5(BaseModel):
@@ -1970,7 +2011,7 @@ class Job5(BaseModel):
         description='The unique identifier for this v2-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
     model_version: Optional[str] = None
-    status: Optional[Status1] = None
+    status: Optional[Status16] = None
 
 
 class V2ExtractJobsGetResponse(BaseModel):
@@ -2076,13 +2117,20 @@ class V2ExtractJobsPostRequest1(BaseModel):
     )
 
 
+class Status17(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+
+
 class V2ExtractJobsPostResponse(BaseModel):
     created_at: Optional[str] = None
     job_id: Optional[str] = Field(
         None,
         description='The unique identifier for this v2-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
-    status: Optional[Status1] = None
+    status: Optional[Status17] = None
 
 
 class Result5(BaseModel):
@@ -2152,7 +2200,7 @@ class V2ExtractJobsJobIdGetResponse(BaseModel):
         None,
         description='Present once status is ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead.',
     )
-    status: Optional[Status1] = None
+    status: Optional[Status17] = None
 
 
 class V2GroundPostRequest(BaseModel):
@@ -2256,8 +2304,8 @@ class V2ParseJobsGetParametersQuery(BaseModel):
     page: Optional[int] = Field(
         0, description='Page number (0-indexed).', ge=0, title='Page'
     )
-    page_size: Optional[int] = Field(
-        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    pageSize: Optional[int] = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Pagesize'
     )
     status: Optional[str] = Field(
         None, description='Filter by job status.', title='Status'
@@ -2311,7 +2359,7 @@ class V2ParseJobsGetResponse(BaseModel):
     page_size: Optional[int] = Field(None, description='Items per page.')
 
 
-class ServiceTier14(Enum):
+class ServiceTier10(Enum):
     """
     Async service tier (``POST /jobs`` only). ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.
     """
@@ -2405,8 +2453,8 @@ class V2WorkflowJobsGetParametersQuery(BaseModel):
     page: Optional[int] = Field(
         0, description='Page number (0-indexed).', ge=0, title='Page'
     )
-    page_size: Optional[int] = Field(
-        10, description='Number of items per page.', ge=1, le=100, title='Page Size'
+    pageSize: Optional[int] = Field(
+        10, description='Number of items per page.', ge=1, le=100, title='Pagesize'
     )
     status: Optional[str] = Field(
         None, description='Filter by job status.', title='Status'
@@ -2418,6 +2466,7 @@ class Status22(Enum):
     processing = 'processing'
     completed = 'completed'
     failed = 'failed'
+    cancelled = 'cancelled'
 
 
 class Job7(BaseModel):
@@ -2439,7 +2488,7 @@ class V2WorkflowJobsGetResponse(BaseModel):
     page_size: Optional[int] = None
 
 
-class ServiceTier15(Enum):
+class ServiceTier11(Enum):
     """
     Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.
     """
@@ -2448,13 +2497,20 @@ class ServiceTier15(Enum):
     priority = 'priority'
 
 
+class Status23(Enum):
+    pending = 'pending'
+    processing = 'processing'
+    completed = 'completed'
+    failed = 'failed'
+
+
 class V2WorkflowJobsPostResponse(BaseModel):
     created_at: Optional[str] = None
     job_id: Optional[str] = Field(
         None,
         description='The unique identifier for this v2-workflow job. Format: ``v2-workflow-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.',
     )
-    status: Optional[Status22] = None
+    status: Optional[Status23] = None
 
 
 class Error7(BaseModel):
@@ -2525,7 +2581,7 @@ class V2WorkflowJobsJobIdGetResponse(BaseModel):
     result: Optional[Result6] = Field(
         None, description='Present once status is ``completed``.'
     )
-    status: Optional[Status22] = None
+    status: Optional[Status23] = None
 
 
 class BlocksOptions(BaseModel):
@@ -2672,7 +2728,7 @@ class V2ParseJobsPostRequest(BaseModel):
         None,
         description="Public URL the full response is delivered to; the API response then carries ``output_url`` instead of inline data. A presigned URL must stay valid until the job COMPLETES, not just past submit: an already-expired URL, or one whose remaining validity is too short for the document's page count, is rejected at submit (422). By default the URL must retain at least 15 minutes of validity at submit, plus 3 seconds per document page; the 422 message names the exact window required. Sign with credentials that outlive the expected job duration — a URL signed with temporary (assumed-role/session) credentials dies when that session expires, regardless of the URL's stated expiry.",
     )
-    service_tier: Optional[ServiceTier14] = Field(
+    service_tier: Optional[ServiceTier10] = Field(
         None,
         description='Async service tier (``POST /jobs`` only). ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
     )
@@ -2822,7 +2878,7 @@ class V2WorkflowJobsPostRequest(BaseModel):
         ],
         title='Output',
     )
-    service_tier: Optional[ServiceTier15] = Field(
+    service_tier: Optional[ServiceTier11] = Field(
         None,
         description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
     )
@@ -2863,7 +2919,7 @@ class V2WorkflowJobsPostRequest1(BaseModel):
         ],
         title='Output',
     )
-    service_tier: Optional[ServiceTier15] = Field(
+    service_tier: Optional[ServiceTier11] = Field(
         None,
         description='Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.',
     )

--- a/specs/v2-aide.json
+++ b/specs/v2-aide.json
@@ -763,7 +763,7 @@
             "type": "integer"
           },
           "filename": {
-            "description": "Display name of the split document: the URL path's file name for `markdown_url` inputs, or a generated name for inline and uploaded Markdown.",
+            "description": "Display name of the split document: the uploaded file's name for `markdown` file uploads (`.md` is appended when the name has no suffix), the URL path's file name for `markdown_url` inputs, or a generated name for inline Markdown.",
             "title": "Filename",
             "type": "string"
           },
@@ -1676,14 +1676,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -1751,7 +1751,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }
@@ -2143,7 +2144,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "description": "Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.\n\nVTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline\nstring), ``markdown_url``, ``schema``, ``strict``. Nothing else — AIDE's own\nextras (``return_reasoning``, ``fallback_model``, ``output_save_url``) stay on\nthe R&D ``/api/extract`` contract, so the customer surface publishes the VTRA\ncontract and only that.",
+                "description": "Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.\n\nVTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline\nstring), ``markdown_url``, ``schema``, ``strict``, ``output_save_url``. AIDE's\nown extras (``return_reasoning``, ``fallback_model``) stay on the R&D\n``/api/extract`` contract — only ``output_save_url`` is shared with it, because\nit is also on VTRA's async wire (aide#2053, the extract half of the\n``output_save_url``/ZDR parity pair that started with parse in #2056's\npredecessor) — so the customer surface publishes the VTRA contract and only\nthat.",
                 "properties": {
                   "markdown": {
                     "anyOf": [
@@ -2329,14 +2330,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -2404,7 +2405,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }
@@ -2449,7 +2451,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "description": "Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.\n\nVTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline\nstring), ``markdown_url``, ``schema``, ``strict``. Nothing else — AIDE's own\nextras (``return_reasoning``, ``fallback_model``, ``output_save_url``) stay on\nthe R&D ``/api/extract`` contract, so the customer surface publishes the VTRA\ncontract and only that.",
+                "description": "Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.\n\nVTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline\nstring), ``markdown_url``, ``schema``, ``strict``, ``output_save_url``. AIDE's\nown extras (``return_reasoning``, ``fallback_model``) stay on the R&D\n``/api/extract`` contract — only ``output_save_url`` is shared with it, because\nit is also on VTRA's async wire (aide#2053, the extract half of the\n``output_save_url``/ZDR parity pair that started with parse in #2056's\npredecessor) — so the customer surface publishes the VTRA contract and only\nthat.",
                 "properties": {
                   "markdown": {
                     "anyOf": [
@@ -2487,6 +2489,18 @@
                     "default": null,
                     "title": "Model"
                   },
+                  "output_save_url": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Output Save Url"
+                  },
                   "schema": {
                     "anyOf": [
                       {
@@ -2498,21 +2512,6 @@
                     ],
                     "default": null,
                     "title": "Schema"
-                  },
-                  "service_tier": {
-                    "anyOf": [
-                      {
-                        "enum": [
-                          "standard",
-                          "priority"
-                        ],
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
                   },
                   "strict": {
                     "default": false,
@@ -2558,6 +2557,19 @@
                     "description": "JSON-serialized string in form data.",
                     "title": "Model"
                   },
+                  "output_save_url": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "JSON-serialized string in form data.",
+                    "title": "Output Save Url"
+                  },
                   "schema": {
                     "anyOf": [
                       {
@@ -2570,21 +2582,6 @@
                     "default": null,
                     "description": "JSON-serialized string in form data.",
                     "title": "Schema"
-                  },
-                  "service_tier": {
-                    "anyOf": [
-                      {
-                        "enum": [
-                          "standard",
-                          "priority"
-                        ],
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
                   },
                   "strict": {
                     "default": false,
@@ -2698,6 +2695,20 @@
                       "description": "The unique identifier for this v1-ade-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
                       "type": "string"
                     },
+                    "metadata": {
+                      "description": "The result's metadata block (billing included), present alongside ``output_url`` once a job with ``output_save_url`` has ``completed`` — the delivery moves the content, not the receipt. Same shape as the inline ``result``'s ``metadata``; inline jobs carry it there instead.",
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    },
+                    "output_url": {
+                      "description": "The URL the result was delivered to. Present once the job has ``completed`` and ``output_save_url`` was set, instead of inline ``result``.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
                     "progress": {
                       "description": "Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.",
                       "maximum": 1,
@@ -2730,7 +2741,7 @@
                           "type": "null"
                         }
                       ],
-                      "description": "Present once status is ``completed``."
+                      "description": "Present once status is ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead."
                     },
                     "status": {
                       "enum": [
@@ -2812,7 +2823,7 @@
                     "title": "Filename",
                     "type": "string"
                   },
-                  "job_id": {
+                  "model": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -2822,22 +2833,7 @@
                       }
                     ],
                     "default": null,
-                    "title": "Job Id"
-                  },
-                  "model_versions": {
-                    "anyOf": [
-                      {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Model Versions"
+                    "title": "Version"
                   },
                   "password": {
                     "anyOf": [
@@ -2851,16 +2847,6 @@
                     "default": null,
                     "title": "Password"
                   },
-                  "pricing_multiplier": {
-                    "default": 1.0,
-                    "title": "Pricing Multiplier",
-                    "type": "number"
-                  },
-                  "processing_mode": {
-                    "default": "sync",
-                    "title": "Processing Mode",
-                    "type": "string"
-                  },
                   "split": {
                     "anyOf": [
                       {
@@ -2872,30 +2858,6 @@
                     ],
                     "default": null,
                     "title": "Split"
-                  },
-                  "version": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Version"
-                  },
-                  "x_request_id": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "X Request Id"
                   }
                 },
                 "required": [
@@ -2943,7 +2905,7 @@
                     "title": "Filename",
                     "type": "string"
                   },
-                  "job_id": {
+                  "model": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -2954,23 +2916,7 @@
                     ],
                     "default": null,
                     "description": "JSON-serialized string in form data.",
-                    "title": "Job Id"
-                  },
-                  "model_versions": {
-                    "anyOf": [
-                      {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Model Versions"
+                    "title": "Version"
                   },
                   "password": {
                     "anyOf": [
@@ -2985,17 +2931,6 @@
                     "description": "JSON-serialized string in form data.",
                     "title": "Password"
                   },
-                  "pricing_multiplier": {
-                    "default": 1.0,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Pricing Multiplier",
-                    "type": "number"
-                  },
-                  "processing_mode": {
-                    "default": "sync",
-                    "title": "Processing Mode",
-                    "type": "string"
-                  },
                   "split": {
                     "anyOf": [
                       {
@@ -3008,32 +2943,6 @@
                     "default": null,
                     "description": "JSON-serialized string in form data.",
                     "title": "Split"
-                  },
-                  "version": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Version"
-                  },
-                  "x_request_id": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "X Request Id"
                   }
                 },
                 "required": [
@@ -3214,14 +3123,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -3289,7 +3198,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }
@@ -3362,7 +3272,7 @@
                     "title": "Filename",
                     "type": "string"
                   },
-                  "job_id": {
+                  "model": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -3372,22 +3282,7 @@
                       }
                     ],
                     "default": null,
-                    "title": "Job Id"
-                  },
-                  "model_versions": {
-                    "anyOf": [
-                      {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Model Versions"
+                    "title": "Version"
                   },
                   "output_save_url": {
                     "anyOf": [
@@ -3413,31 +3308,6 @@
                     "default": null,
                     "title": "Password"
                   },
-                  "pricing_multiplier": {
-                    "default": 1.0,
-                    "title": "Pricing Multiplier",
-                    "type": "number"
-                  },
-                  "processing_mode": {
-                    "default": "sync",
-                    "title": "Processing Mode",
-                    "type": "string"
-                  },
-                  "service_tier": {
-                    "anyOf": [
-                      {
-                        "enum": [
-                          "standard",
-                          "priority"
-                        ],
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
-                  },
                   "split": {
                     "anyOf": [
                       {
@@ -3449,30 +3319,6 @@
                     ],
                     "default": null,
                     "title": "Split"
-                  },
-                  "version": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Version"
-                  },
-                  "x_request_id": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "X Request Id"
                   }
                 },
                 "required": [
@@ -3520,7 +3366,7 @@
                     "title": "Filename",
                     "type": "string"
                   },
-                  "job_id": {
+                  "model": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -3531,23 +3377,7 @@
                     ],
                     "default": null,
                     "description": "JSON-serialized string in form data.",
-                    "title": "Job Id"
-                  },
-                  "model_versions": {
-                    "anyOf": [
-                      {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Model Versions"
+                    "title": "Version"
                   },
                   "output_save_url": {
                     "anyOf": [
@@ -3575,32 +3405,6 @@
                     "description": "JSON-serialized string in form data.",
                     "title": "Password"
                   },
-                  "pricing_multiplier": {
-                    "default": 1.0,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Pricing Multiplier",
-                    "type": "number"
-                  },
-                  "processing_mode": {
-                    "default": "sync",
-                    "title": "Processing Mode",
-                    "type": "string"
-                  },
-                  "service_tier": {
-                    "anyOf": [
-                      {
-                        "enum": [
-                          "standard",
-                          "priority"
-                        ],
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
-                  },
                   "split": {
                     "anyOf": [
                       {
@@ -3613,32 +3417,6 @@
                     "default": null,
                     "description": "JSON-serialized string in form data.",
                     "title": "Split"
-                  },
-                  "version": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Version"
-                  },
-                  "x_request_id": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "X Request Id"
                   }
                 },
                 "required": [
@@ -4151,14 +3929,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -4226,7 +4004,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }
@@ -4844,14 +4623,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -4919,7 +4698,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }
@@ -5674,14 +5454,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -5749,7 +5529,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }
@@ -6524,14 +6305,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -7130,14 +6911,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -7205,7 +6986,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }

--- a/src/landingai_ade/resources/v2/_base.py
+++ b/src/landingai_ade/resources/v2/_base.py
@@ -1,16 +1,19 @@
 # src/landingai_ade/resources/v2/_base.py
 from __future__ import annotations
 
-from typing import Any, List, Callable, Optional, Awaitable
+from typing import Any, Dict, List, Union, Callable, Optional, Awaitable
 
 import anyio
 
+from ..._types import Omit
+from ..._utils import is_given
 from ...types.v2 import Job
 from ...lib.v2_errors import JobFailedError, JobWaitTimeoutError
 
 __all__ = [
     "V2ResourceMixin",
     "JobList",
+    "build_list_query",
     "poll_until_terminal",
     "apoll_until_terminal",
     "DEFAULT_POLL_INITIAL",
@@ -37,6 +40,25 @@ class V2ResourceMixin:
 
     def _v2_url(self, path: str) -> str:
         return f"{self._client._v2_base_url}{path}"
+
+
+def build_list_query(
+    *,
+    page: Union[int, Omit],
+    page_size: Union[int, Omit],
+    status: Union[str, None, Omit],
+) -> Dict[str, object]:
+    """Query params for a V2 list-jobs route, dropping unset and ``None`` values.
+
+    The gateway spells the page size ``pageSize`` on the wire, so the snake_case
+    ``page_size`` kwarg every list method exposes is translated here -- once, rather
+    than at each of the three call sites, since getting the name wrong fails silently
+    (an unrecognized query param is ignored and the default page size comes back).
+    Only the *parameter* is camelCase: the response envelope still reports
+    ``page_size``, which is what ``JobList.build`` reads.
+    """
+    raw: Dict[str, object] = {"page": page, "pageSize": page_size, "status": status}
+    return {key: value for key, value in raw.items() if is_given(value) and value is not None}
 
 
 def _next_delay(current: float, poll_interval: Optional[float]) -> float:

--- a/src/landingai_ade/resources/v2/build_schema.py
+++ b/src/landingai_ade/resources/v2/build_schema.py
@@ -8,7 +8,14 @@ from typing_extensions import Literal
 import httpx
 from pydantic import BaseModel
 
-from ._base import DEFAULT_WAIT_TIMEOUT, JobList, V2ResourceMixin, poll_until_terminal, apoll_until_terminal
+from ._base import (
+    DEFAULT_WAIT_TIMEOUT,
+    JobList,
+    V2ResourceMixin,
+    build_list_query,
+    poll_until_terminal,
+    apoll_until_terminal,
+)
 from ..._types import Body, Omit, Query, Headers, NotGiven, FileTypes, omit, not_given
 from ..._utils import is_given
 from ...types.v2 import Job, V2BuildSchemaResponse
@@ -347,11 +354,7 @@ class BuildSchemaJobsResource(V2ResourceMixin, SyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> JobList:
         """List async build-schema jobs associated with your API key, newest first."""
-        query = {
-            key: value
-            for key, value in {"page": page, "page_size": page_size, "status": status}.items()
-            if is_given(value) and value is not None
-        }
+        query = build_list_query(page=page, page_size=page_size, status=status)
         raw = self._get(
             self._v2_url("/v2/extract/build-schema/jobs"),
             options=make_request_options(
@@ -473,11 +476,7 @@ class AsyncBuildSchemaJobsResource(V2ResourceMixin, AsyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> JobList:
         """Async mirror of `BuildSchemaJobsResource.list`. See there for full documentation."""
-        query = {
-            key: value
-            for key, value in {"page": page, "page_size": page_size, "status": status}.items()
-            if is_given(value) and value is not None
-        }
+        query = build_list_query(page=page, page_size=page_size, status=status)
         raw = await self._get(
             self._v2_url("/v2/extract/build-schema/jobs"),
             options=make_request_options(

--- a/src/landingai_ade/resources/v2/extract.py
+++ b/src/landingai_ade/resources/v2/extract.py
@@ -8,7 +8,14 @@ from typing_extensions import Literal
 import httpx
 from pydantic import BaseModel
 
-from ._base import DEFAULT_WAIT_TIMEOUT, JobList, V2ResourceMixin, poll_until_terminal, apoll_until_terminal
+from ._base import (
+    DEFAULT_WAIT_TIMEOUT,
+    JobList,
+    V2ResourceMixin,
+    build_list_query,
+    poll_until_terminal,
+    apoll_until_terminal,
+)
 from ..._types import Body, Omit, Query, Headers, NotGiven, omit, not_given
 from ..._utils import is_given
 from ...types.v2 import Job, V2ExtractResult
@@ -268,11 +275,7 @@ class ExtractJobsResource(V2ResourceMixin, SyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> JobList:
         """List async extract jobs associated with your API key, newest first."""
-        query = {
-            key: value
-            for key, value in {"page": page, "page_size": page_size, "status": status}.items()
-            if is_given(value) and value is not None
-        }
+        query = build_list_query(page=page, page_size=page_size, status=status)
         raw = self._get(
             self._v2_url("/v2/extract/jobs"),
             options=make_request_options(
@@ -301,8 +304,9 @@ class ExtractJobsResource(V2ResourceMixin, SyncAPIResource):
 
         Raises `JobWaitTimeoutError` if `timeout` seconds elapse before the job
         reaches a terminal state, and `JobFailedError` if `raise_on_failure` is
-        set and the job ends failed with an error attached. Extract jobs have no
-        `cancelled` status.
+        set and the job ends failed/cancelled with an error attached. `cancelled`
+        is a terminal extract status (the spec added it to the list-jobs envelope
+        on 2026-09-10), so waiting stops on it like any other terminal state.
 
         `_monotonic` is a test seam for injecting a fake clock; production
         callers should leave it unset (defaults to `time.monotonic`).
@@ -382,11 +386,7 @@ class AsyncExtractJobsResource(V2ResourceMixin, AsyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> JobList:
         """Async mirror of `ExtractJobsResource.list`. See there for full documentation."""
-        query = {
-            key: value
-            for key, value in {"page": page, "page_size": page_size, "status": status}.items()
-            if is_given(value) and value is not None
-        }
+        query = build_list_query(page=page, page_size=page_size, status=status)
         raw = await self._get(
             self._v2_url("/v2/extract/jobs"),
             options=make_request_options(

--- a/src/landingai_ade/resources/v2/parse.py
+++ b/src/landingai_ade/resources/v2/parse.py
@@ -9,7 +9,14 @@ from typing_extensions import Literal
 
 import httpx
 
-from ._base import DEFAULT_WAIT_TIMEOUT, JobList, V2ResourceMixin, poll_until_terminal, apoll_until_terminal
+from ._base import (
+    DEFAULT_WAIT_TIMEOUT,
+    JobList,
+    V2ResourceMixin,
+    build_list_query,
+    poll_until_terminal,
+    apoll_until_terminal,
+)
 from ..._files import deepcopy_with_paths
 from ..._types import Body, Omit, Query, Headers, NotGiven, FileTypes, omit, not_given
 from ..._utils import is_given, extract_files
@@ -345,11 +352,7 @@ class ParseJobsResource(V2ResourceMixin, SyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> JobList:
         """List async parse jobs associated with your API key, newest first."""
-        query = {
-            key: value
-            for key, value in {"page": page, "page_size": page_size, "status": status}.items()
-            if is_given(value) and value is not None
-        }
+        query = build_list_query(page=page, page_size=page_size, status=status)
         raw = self._get(
             self._v2_url("/v2/parse/jobs"),
             options=make_request_options(
@@ -470,11 +473,7 @@ class AsyncParseJobsResource(V2ResourceMixin, AsyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> JobList:
         """Async mirror of `ParseJobsResource.list`. See there for full documentation."""
-        query = {
-            key: value
-            for key, value in {"page": page, "page_size": page_size, "status": status}.items()
-            if is_given(value) and value is not None
-        }
+        query = build_list_query(page=page, page_size=page_size, status=status)
         raw = await self._get(
             self._v2_url("/v2/parse/jobs"),
             options=make_request_options(

--- a/tests/api_resources/v2/test_async_smoke.py
+++ b/tests/api_resources/v2/test_async_smoke.py
@@ -72,3 +72,26 @@ async def test_async_extract_jobs_create_get_and_wait() -> None:
     waited = await client.v2.extract_jobs.wait("e1", timeout=30, poll_interval=0.01, _monotonic=lambda: next(ticks))
     assert waited.status is JobStatus.COMPLETED
     assert isinstance(waited.result, V2ExtractResult)
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_async_job_lists_send_page_size_as_camel_case() -> None:
+    """The async list mirrors must translate `page_size` to the wire's `pageSize`
+    too -- the sync/async pair is the usual place a wire-name fix lands only half."""
+    client = AsyncLandingAIADE(apikey=APIKEY)
+    empty: Dict[str, Any] = {"jobs": [], "has_more": False}
+
+    parse_route = respx.get("https://api.ade.landing.ai/v2/parse/jobs").mock(
+        return_value=httpx.Response(200, json=empty)
+    )
+    await client.v2.parse_jobs.list(page=0, page_size=3)
+    assert parse_route.calls.last.request.url.params["pageSize"] == "3"
+    assert "page_size" not in parse_route.calls.last.request.url.params
+
+    extract_route = respx.get("https://api.ade.landing.ai/v2/extract/jobs").mock(
+        return_value=httpx.Response(200, json=empty)
+    )
+    await client.v2.extract_jobs.list(page=0, page_size=3)
+    assert extract_route.calls.last.request.url.params["pageSize"] == "3"
+    assert "page_size" not in extract_route.calls.last.request.url.params

--- a/tests/api_resources/v2/test_extract.py
+++ b/tests/api_resources/v2/test_extract.py
@@ -274,3 +274,65 @@ def test_extract_job_list_carries_envelope() -> None:
     assert jobs.has_more is True
     assert jobs.page == 0
     assert jobs.page_size == 10
+
+
+@respx.mock
+def test_extract_job_list_sends_page_size_as_camel_case() -> None:
+    # `GET /v2/extract/jobs` names the page-size parameter `pageSize` on the wire; the
+    # public kwarg stays `page_size`. A wrong name here fails silently -- the gateway
+    # ignores the unknown param and answers with the default page size -- so pin both
+    # the presence of `pageSize` and the absence of the snake_case spelling.
+    client = LandingAIADE(apikey=APIKEY)
+    route = respx.get("https://api.ade.landing.ai/v2/extract/jobs").mock(
+        return_value=httpx.Response(200, json={"jobs": [], "has_more": False})
+    )
+    client.v2.extract_jobs.list(page=1, page_size=25)
+    params = route.calls.last.request.url.params
+    assert params["pageSize"] == "25"
+    assert params["page"] == "1"
+    assert "page_size" not in params
+
+
+def test_extract_job_list_page_size_omitted_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Query-dict level (the URL encoder drops `None`, which would mask a regression):
+    # an unset `page_size` must not be sent under either spelling.
+    client = LandingAIADE(apikey=APIKEY)
+    captured: Dict[str, Any] = {}
+
+    def fake_get(path: str, *, cast_to: Any, options: Any = None, **kwargs: Any) -> Any:  # noqa: ARG001
+        captured["params"] = dict(options or {}).get("params", {})
+        return {"jobs": [], "has_more": False}
+
+    monkeypatch.setattr(client.v2.extract_jobs, "_get", fake_get)
+
+    client.v2.extract_jobs.list()
+    assert "pageSize" not in captured["params"] and "page_size" not in captured["params"]
+
+    client.v2.extract_jobs.list(page_size=7)
+    assert captured["params"]["pageSize"] == 7
+
+
+@respx.mock
+def test_extract_job_list_normalizes_cancelled_status() -> None:
+    # `cancelled` joined the `/v2/extract/jobs` list-item status enum in the
+    # 2026-09-10 snapshot. It maps onto the unified `JobStatus.CANCELLED` and counts
+    # as terminal, so `wait()` stops on it instead of polling to the deadline.
+    client = LandingAIADE(apikey=APIKEY)
+    respx.get("https://api.ade.landing.ai/v2/extract/jobs").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "jobs": [
+                    {"job_id": "e1", "status": "cancelled", "failure_reason": "cancelled by user"},
+                    {"job_id": "e2", "status": "completed"},
+                ],
+                "has_more": False,
+            },
+        )
+    )
+    jobs = client.v2.extract_jobs.list()
+    cancelled = jobs[0]
+    assert cancelled.status is JobStatus.CANCELLED
+    assert cancelled.is_terminal is True
+    assert cancelled.error is not None and cancelled.error.message == "cancelled by user"
+    assert jobs[1].status is JobStatus.COMPLETED

--- a/tests/api_resources/v2/test_parse.py
+++ b/tests/api_resources/v2/test_parse.py
@@ -743,6 +743,42 @@ def test_parse_job_list_carries_envelope() -> None:
 
 
 @respx.mock
+def test_parse_job_list_sends_page_size_as_camel_case() -> None:
+    # `GET /v2/parse/jobs` names the page-size parameter `pageSize` on the wire; the
+    # public kwarg stays `page_size`. A wrong name here fails silently -- the gateway
+    # ignores the unknown param and answers with the default page size -- so pin both
+    # the presence of `pageSize` and the absence of the snake_case spelling.
+    client = LandingAIADE(apikey=APIKEY)
+    route = respx.get("https://api.ade.landing.ai/v2/parse/jobs").mock(
+        return_value=httpx.Response(200, json={"jobs": [], "has_more": False})
+    )
+    client.v2.parse_jobs.list(page=2, page_size=5)
+    params = route.calls.last.request.url.params
+    assert params["pageSize"] == "5"
+    assert params["page"] == "2"
+    assert "page_size" not in params
+
+
+def test_parse_job_list_page_size_omitted_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Query-dict level (the URL encoder drops `None`, which would mask a regression):
+    # an unset `page_size` must not be sent under either spelling.
+    client = LandingAIADE(apikey=APIKEY)
+    captured: Dict[str, Any] = {}
+
+    def fake_get(path: str, *, cast_to: Any, options: Any = None, **kwargs: Any) -> Any:  # noqa: ARG001
+        captured["params"] = dict(options or {}).get("params", {})
+        return {"jobs": [], "has_more": False}
+
+    monkeypatch.setattr(client.v2.parse_jobs, "_get", fake_get)
+
+    client.v2.parse_jobs.list()
+    assert "pageSize" not in captured["params"] and "page_size" not in captured["params"]
+
+    client.v2.parse_jobs.list(page_size=7)
+    assert captured["params"]["pageSize"] == 7
+
+
+@respx.mock
 def test_parse_job_wait_polls_until_completed() -> None:
     client = LandingAIADE(apikey=APIKEY)
     responses = [

--- a/tests/contract/test_v2_smoke.py
+++ b/tests/contract/test_v2_smoke.py
@@ -201,3 +201,27 @@ def test_parse_jobs(staging_client: LandingAIADE) -> None:
     # `Job.metadata` receipt (set only for `output_save_url` deliveries) is absent.
     assert done.metadata is None
     assert done.result.metadata is not None
+
+
+@pytest.mark.parametrize("resource", ["parse", "extract"])
+def test_job_list_honors_page_size(staging_client: LandingAIADE, resource: str) -> None:
+    # Both list routes take the page size as `pageSize` on the wire (the SDK kwarg
+    # stays `page_size`). Live, the assertable half is that the gateway honors the
+    # cap: a misspelled param is ignored and the default page of 10 comes back, so a
+    # page of at most 1 is evidence the name landed. Nothing here pins a count --
+    # this key may legitimately have no jobs at all -- and the exact wire spelling is
+    # pinned deterministically in tests/api_resources/v2/.
+    jobs = (
+        staging_client.v2.parse_jobs.list(page=0, page_size=1)
+        if resource == "parse"
+        else staging_client.v2.extract_jobs.list(page=0, page_size=1)
+    )
+    assert len(jobs) <= 1
+    # The *response* envelope still reports snake_case `page_size`, and it is
+    # optional: assert absent-or-valid rather than that it echoes the request.
+    if jobs.page_size is not None:
+        assert 1 <= jobs.page_size <= 100
+    if jobs.page is not None:
+        assert jobs.page == 0
+    for job in jobs:
+        assert job.job_id


### PR DESCRIPTION
Automated V2 spec-sync PR (`client.v2`).

- **Commit 1 (mechanical):** normalized V2 spec snapshot + regenerated reference models.
- **Commit 2 (AI, only if the spec diff needs SDK changes):** client.v2 resources/methods/tests/docs wired from the diff, added after this PR opened. Workflow-only drift is excluded and an AI no-op is skipped, so some drifts produce a **mechanical-only PR with no second commit**.

Gates (surface-lock, V2 contract tests, lint/test/typecheck) must pass. When present, the AI commit is a **draft a human finishes** (the V2 ergonomic layer — unified Job, dual-host, schema coercion — is not in the spec). **Human review required before merge.**

<!-- what-changed:start -->
## What changed
_AI-generated from the PR diff — verify against the actual changes._

This PR updates the V2 job-listing query parameter to match the gateway's wire naming and adds `cancelled` as a recognized terminal status for extract jobs.

**Changes:**
- The `page_size` keyword on `parse_jobs.list`, `extract_jobs.list`, and `build_schema_jobs.list` (sync and async) is now sent on the wire as `pageSize`, with no change to the public kwarg name or the response's `page_size` field.
- `extract_jobs.wait` now treats `cancelled` as a terminal status (in addition to `completed`/`failed`), since the extract list-jobs envelope can report it.
- Documented that `output_save_url` is now shared between the async extract wire contract and `/api/extract`, alongside spec description updates for split-document `filename` behavior on `markdown` file uploads.
<!-- what-changed:end -->
<!-- spec-sync-nudged: 20709 -->
